### PR TITLE
Append additional message details for events related to provider auth error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- When an `IntegrationProviderAuthenticationError` or
+  `IntegrationProviderAuthorizationError` is thrown, additional information will
+  be added to the published event's description to notify the end user that
+  action needs to be taken.
+
 ## 3.0.1 - 2020-05-26
 
 `3.0.0` is a major release because a number of types have changed to clarify the

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,7 +5,7 @@ export const UNEXPECTED_ERROR_REASON =
 export const PROVIDER_AUTH_ERROR_DESCRIPTION =
   ' Failed to access provider resource.' +
   ' This integration is likely misconfigured or has insufficient permissions required to access the resource.' +
-  " Please ensure your integration's configuration settings are setup correctly.";
+  " Please ensure your integration's configuration settings are set up correctly.";
 
 export interface IntegrationErrorOptions {
   message: string;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,11 @@ export const UNEXPECTED_ERROR_CODE = 'UNEXPECTED_ERROR';
 export const UNEXPECTED_ERROR_REASON =
   'Unexpected error occurred executing integration! Please contact us in Slack or at https://support.jupiterone.io if the problem continues to occur.';
 
+export const PROVIDER_AUTH_ERROR_DESCRIPTION =
+  ' Failed to access provider resource.' +
+  ' This integration is likely misconfigured or has insufficient permissions required to access the resource.' +
+  " Please ensure your integration's configuration settings are setup correctly.";
+
 export interface IntegrationErrorOptions {
   message: string;
 
@@ -14,6 +19,7 @@ export interface IntegrationErrorOptions {
 
   /**
    * An optional flag used to mark the error as fatal. A fatal error will stop
+   *
    * execution of the entire integration.
    */
   fatal?: boolean;

--- a/src/framework/execution/logger.ts
+++ b/src/framework/execution/logger.ts
@@ -6,6 +6,7 @@ import {
   IntegrationError,
   UNEXPECTED_ERROR_CODE,
   UNEXPECTED_ERROR_REASON,
+  PROVIDER_AUTH_ERROR_DESCRIPTION,
 } from '../../errors';
 import { SynchronizationJob } from '../synchronization';
 import {
@@ -22,6 +23,10 @@ import {
   IntegrationStepExecutionContext,
   IntegrationInvocationConfig,
 } from './types';
+import {
+  IntegrationProviderAuthorizationError,
+  IntegrationProviderAuthenticationError,
+} from './error';
 
 // eslint-disable-next-line
 const bunyanFormat = require('bunyan-format');
@@ -399,6 +404,12 @@ export function createErrorEventDescription(
     errorReason = UNEXPECTED_ERROR_REASON;
   }
 
+  if (isProviderAuthError(err)) {
+    // add additional instructions to the displayed message
+    // if we know that this is an auth error
+    message += PROVIDER_AUTH_ERROR_DESCRIPTION;
+  }
+
   const nameValuePairs: NameValuePair[] = [
     ['errorCode', errorCode],
     ['errorId', errorId],
@@ -421,4 +432,15 @@ export function createErrorEventDescription(
     errorId,
     description: `${message} (${errorDetails})`,
   };
+}
+
+type ProviderAuthError =
+  | IntegrationProviderAuthorizationError
+  | IntegrationProviderAuthenticationError;
+
+export function isProviderAuthError(err: Error): err is ProviderAuthError {
+  return (
+    err instanceof IntegrationProviderAuthorizationError ||
+    err instanceof IntegrationProviderAuthenticationError
+  );
 }


### PR DESCRIPTION
Closes #136 . I decided to not add a `logger.authError` function and opted to instead just enhance the existing messages with more information if we happen to come across an `IntegrationProviderAuth*` error. 