### PR TITLE
Publish source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Source maps are included in the `@jupiterone/integration-sdk` package to allow
+  for source stack traces. Using Node 12.12+, these can be enabled with
+  `--enable-source-maps`. For integration developers, this means
+  `NODE_OPTIONS=--enable-source-maps yarn j1-integration collect`, for example.
+
 ## 3.0.1 - 2020-05-26
 
 `3.0.0` is a major release because a number of types have changed to clarify the

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true
+  },
   "exclude": [
     "**/*.test.ts",
     "**/*/__tests__/**/*.ts",


### PR DESCRIPTION
I'm running into this stack trace:
```
Configuration loaded! Running integration...

TypeError: Cannot read property 'disabled' of undefined
    at /Users/aiwilliams/Workspaces/jupiterone-io/graph-azure/node_modules/@jupiterone/integration-sdk/src/framework/execution/dependencyGraph.js:247:46
    at Array.map (<anonymous>)
    at buildStepResultsMap (/Users/aiwilliams/Workspaces/jupiterone-io/graph-azure/node_modules/@jupiterone/integration-sdk/src/framework/execution/dependencyGraph.js:236:10)
    at Object.executeStepDependencyGraph (/Users/aiwilliams/Workspaces/jupiterone-io/graph-azure/node_modules/@jupiterone/integration-sdk/src/framework/execution/dependencyGraph.js:59:28)
    at Object.executeSteps (/Users/aiwilliams/Workspaces/jupiterone-io/graph-azure/node_modules/@jupiterone/integration-sdk/src/framework/execution/step.js:11:30)
    at executeWithContext (/Users/aiwilliams/Workspaces/jupiterone-io/graph-azure/node_modules/@jupiterone/integration-sdk/src/framework/execution/executeIntegration.js:48:49)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at executeIntegrationInstance (/Users/aiwilliams/Workspaces/jupiterone-io/graph-azure/node_modules/@jupiterone/integration-sdk/src/framework/execution/executeIntegration.js:26:20)
    at Command.<anonymous> (/Users/aiwilliams/Workspaces/jupiterone-io/graph-azure/node_modules/@jupiterone/integration-sdk/src/cli/commands/collect.js:68:25)
    at async Promise.all (index 0)
```

I'd like to have a quicker path to the source code, so we need source maps. After talking with @charlieduong94, `.map` files seems best, since we don't need it to be inline, and Node now has native support for these `.map` files. With these changes, I now get the following:

```
12:45 $ NODE_OPTIONS=--enable-source-maps yarn j1-integration collect
yarn run v1.22.4
$ /Users/aiwilliams/Workspaces/jupiterone-io/graph-azure/node_modules/.bin/j1-integration collect
TypeScript files detected. Registering ts-node.

Configuration loaded! Running integration...

TypeError: Cannot read property 'disabled' of undefined
    at /Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/dist/src/framework/execution/dependencyGraph.js:247:46
        -> /Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/src/framework/execution/dependencyGraph.ts:339:38
    at Array.map (<anonymous>)
    at buildStepResultsMap (/Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/dist/src/framework/execution/dependencyGraph.js:236:10)
        -> /Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/src/framework/execution/dependencyGraph.ts:323:6
    at Object.executeStepDependencyGraph (/Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/dist/src/framework/execution/dependencyGraph.js:59:28)
        -> /Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/src/framework/execution/dependencyGraph.ts:83:26
    at Object.executeSteps (/Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/dist/src/framework/execution/step.js:11:30)
        -> /Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/src/framework/execution/step.ts:26:10
    at executeWithContext (/Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/dist/src/framework/execution/executeIntegration.js:48:49)
        -> /Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/src/framework/execution/executeIntegration.ts:96:40
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async executeIntegrationInstance (/Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/dist/src/framework/execution/executeIntegration.js:26:20)
        -> /Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/src/framework/execution/executeIntegration.ts:61:18
    at async Command.<anonymous> (/Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/dist/src/cli/commands/collect.js:68:25)
        -> /Users/aiwilliams/Workspaces/jupiterone-io/integration-sdk/src/cli/commands/collect.ts:91:23
    at async Promise.all (index 0)
```

Reference material:

* https://github.com/googleapis/google-cloud-node/issues/2867
* https://medium.com/@nodejs/source-maps-in-node-js-482872b56116