### PR TITLE
Remove deprecated convention based invocationConfig loading

### DIFF
--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -30,6 +30,13 @@
   },
   "devDependencies": {
     "@jupiterone/integration-sdk-private-test-utils": "^0.1.0",
+    "@pollyjs/adapter-node-http": "^4.0.4",
+    "@pollyjs/core": "^4.0.4",
+    "@pollyjs/persister-fs": "^4.0.4",
+    "@types/pollyjs__adapter-node-http": "^2.0.0",
+    "@types/pollyjs__core": "^4.0.0",
+    "@types/pollyjs__persister": "^2.0.1",
+    "jsonwebtoken": "^8.5.1",
     "memfs": "^3.2.0"
   }
 }

--- a/packages/integration-sdk-cli/src/config.ts
+++ b/packages/integration-sdk-cli/src/config.ts
@@ -1,15 +1,9 @@
-import { promises as fs } from 'fs';
 import globby from 'globby';
 import path from 'path';
 
 import {
   IntegrationError,
-  ExecutionContext,
-  GetStepStartStatesFunction,
-  IntegrationInstanceConfigFieldMap,
   IntegrationInvocationConfig,
-  IntegrationStep,
-  IntegrationInvocationValidationFunction,
 } from '@jupiterone/integration-sdk-core';
 
 import * as log from './log';
@@ -34,28 +28,7 @@ export async function loadConfig(
     registerTypescript();
   }
 
-  let config = loadInvocationConfig(projectSourceDirectory);
-
-  if (!config) {
-    log.warn(
-      'WARNING: Automatically loading configurations from a directory structure is deprecated and will be removed in a future release when the SDK is broken up into multiple packages.\n' +
-        'Please migrate your integration to export the integration configuration at "src/index".\n' +
-        'For more information, see https://github.com/JupiterOne/integration-sdk/issues/125',
-    );
-
-    config = {
-      instanceConfigFields: loadInstanceConfigFields(projectSourceDirectory),
-      validateInvocation: loadValidateInvocationFunction(
-        projectSourceDirectory,
-      ),
-      getStepStartStates: loadGetStepStartStatesFunction(
-        projectSourceDirectory,
-      ),
-      integrationSteps: await loadIntegrationSteps(projectSourceDirectory),
-    };
-  }
-
-  return config;
+  return loadInvocationConfig(projectSourceDirectory);
 }
 
 /**
@@ -63,101 +36,18 @@ export async function loadConfig(
  */
 export function loadInvocationConfig(
   projectSourceDirectory: string = path.join(process.cwd(), 'src'),
-): IntegrationInvocationConfig | undefined {
+): IntegrationInvocationConfig {
   let integrationModule: any;
 
   try {
     integrationModule = require(path.resolve(projectSourceDirectory, 'index'));
   } catch (err) {
-    // module not found
-    //
-    // Once the deprecated integration config path is handled,
-    // this will throw an error
-    return undefined;
-  }
-
-  const invocationConfig = integrationModule?.invocationConfig;
-
-  if (!invocationConfig) {
     throw new IntegrationInvocationConfigNotFoundError(
       'Integration invocation configuration not found. Configuration should be exported as "invocationConfig" from "src/index".',
     );
   }
 
-  return invocationConfig;
-}
-
-/**
- * Loads instanceConfigFields from ./src/instanceConfigFields
- */
-export function loadInstanceConfigFields(
-  projectSourceDirectory: string = path.join(process.cwd(), 'src'),
-) {
-  return loadModuleContent<IntegrationInstanceConfigFieldMap>(
-    path.resolve(projectSourceDirectory, 'instanceConfigFields'),
-  );
-}
-
-/**
- * Loads getStepStartStates function from ./src/getStepStartStates.(t|j)s
- */
-export function loadValidateInvocationFunction(
-  projectSourceDirectory: string = path.join(process.cwd(), 'src'),
-): IntegrationInvocationValidationFunction | undefined {
-  return loadModuleContent(
-    path.resolve(projectSourceDirectory, 'validateInvocation'),
-  );
-}
-
-/**
- * Loads getStepStartStates function from ./src/getStepStartStates.(t|j)s
- */
-export function loadGetStepStartStatesFunction<T extends ExecutionContext>(
-  projectSourceDirectory: string = path.join(process.cwd(), 'src'),
-) {
-  return loadModuleContent<GetStepStartStatesFunction<T>>(
-    path.resolve(projectSourceDirectory, 'getStepStartStates'),
-  );
-}
-
-export async function loadIntegrationSteps(
-  projectSourceDirectory: string = path.join(process.cwd(), 'src'),
-): Promise<IntegrationStep[]> {
-  let files: string[];
-
-  const stepsDir = path.resolve(projectSourceDirectory, 'steps');
-
-  try {
-    files = await fs.readdir(stepsDir);
-  } catch (err) {
-    console.error(err);
-    return [];
-  }
-
-  const steps: IntegrationStep[] = [];
-  for (const file of files) {
-    const step = loadModuleContent<IntegrationStep>(
-      path.resolve(stepsDir, file),
-    );
-    if (step !== undefined) {
-      steps.push(step);
-    }
-  }
-
-  return steps;
-}
-
-export function loadModuleContent<T>(modulePath: string): T | undefined {
-  let integrationModule: any;
-
-  try {
-    integrationModule = require(modulePath);
-  } catch (err) {
-    // module not found
-    return undefined;
-  }
-
-  return integrationModule?.default ?? integrationModule;
+  return integrationModule.invocationConfig as IntegrationInvocationConfig;
 }
 
 async function isTypescriptPresent(

--- a/packages/integration-sdk-private-test-utils/__fixtures__/instanceConfigWithoutEnv/src/index.ts
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/instanceConfigWithoutEnv/src/index.ts
@@ -1,0 +1,8 @@
+import noop from 'lodash/noop';
+
+// this fixture helps ensure that the
+// invocation config is read correctly
+export default {
+  instanceConfigFields: require('./instanceConfigFields'),
+  validateInvocation: noop,
+};

--- a/packages/integration-sdk-private-test-utils/__fixtures__/instanceWithDependentSteps/src/index.ts
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/instanceWithDependentSteps/src/index.ts
@@ -1,0 +1,18 @@
+import fetchAccounts from './steps/fetchAccounts';
+import fetchGroups from './steps/fetchGroups';
+import fetchUsers from './steps/fetchUsers';
+
+import validateInvocation from './validateInvocation';
+import getStepStartStates from './getStepStartStates';
+
+export const invocationConfig = {
+  instanceConfigFields: {
+    myConfig: {
+      mask: true,
+      type: 'boolean',
+    },
+  },
+  integrationSteps: [fetchAccounts, fetchGroups, fetchUsers],
+  validateInvocation,
+  getStepStartStates,
+};

--- a/packages/integration-sdk-private-test-utils/__fixtures__/javaScriptProject/src/index.js
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/javaScriptProject/src/index.js
@@ -1,0 +1,17 @@
+const fetchGroups = require('./steps/fetchGroups');
+const fetchUsers = require('./steps/fetchUsers');
+
+const validateInvocation = require('./validateInvocation');
+const getStepStartStates = require('./getStepStartStates');
+
+exports.invocationConfig = {
+  instanceConfigFields: {
+    myConfig: {
+      mask: true,
+      type: 'boolean',
+    },
+  },
+  integrationSteps: [fetchUsers, fetchGroups],
+  validateInvocation,
+  getStepStartStates,
+};

--- a/packages/integration-sdk-private-test-utils/__fixtures__/typeScriptIntegrationProject/src/index.ts
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/typeScriptIntegrationProject/src/index.ts
@@ -1,0 +1,17 @@
+import fetchAccounts from './steps/fetchAccounts';
+import fetchUsers from './steps/fetchUsers';
+
+import validateInvocation from './validateInvocation';
+import getStepStartStates from './getStepStartStates';
+
+export const invocationConfig = {
+  instanceConfigFields: {
+    myConfig: {
+      mask: true,
+      type: 'boolean',
+    },
+  },
+  integrationSteps: [fetchAccounts, fetchUsers],
+  validateInvocation,
+  getStepStartStates,
+};

--- a/packages/integration-sdk-private-test-utils/__fixtures__/typeScriptProject/src/index.ts
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/typeScriptProject/src/index.ts
@@ -1,0 +1,17 @@
+import fetchAccounts from './steps/fetchAccounts';
+import fetchUsers from './steps/fetchUsers';
+
+import validateInvocation from './validateInvocation';
+import getStepStartStates from './getStepStartStates';
+
+export const invocationConfig = {
+  instanceConfigFields: {
+    myConfig: {
+      mask: true,
+      type: 'boolean',
+    },
+  },
+  integrationSteps: [fetchAccounts, fetchUsers],
+  validateInvocation,
+  getStepStartStates,
+};

--- a/packages/integration-sdk-private-test-utils/__fixtures__/typeScriptVisualizeProject/src/index.ts
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/typeScriptVisualizeProject/src/index.ts
@@ -1,0 +1,15 @@
+import fetchAccounts from './steps/fetchAccounts';
+import fetchUsers from './steps/fetchUsers';
+
+import validateInvocation from './validateInvocation';
+
+export const invocationConfig = {
+  instanceConfigFields: {
+    myConfig: {
+      mask: true,
+      type: 'boolean',
+    },
+  },
+  integrationSteps: [fetchAccounts, fetchUsers],
+  validateInvocation,
+};

--- a/packages/integration-sdk-private-test-utils/__fixtures__/validationFailure/src/index.ts
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/validationFailure/src/index.ts
@@ -1,0 +1,7 @@
+import fetchUsers from './steps/fetchUsers';
+import validateInvocation from './validateInvocation';
+
+export const invocationConfig = {
+  integrationSteps: [fetchUsers],
+  validateInvocation,
+};

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -23,7 +23,7 @@
     "@jupiterone/integration-sdk-runtime": "^0.1.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
-    "@pollyjs/persister-fs": "4.0.4",
+    "@pollyjs/persister-fs": "^4.0.4",
     "@types/har-format": "^1.2.4",
     "@types/pollyjs__adapter-node-http": "^2.0.0",
     "@types/pollyjs__core": "^4.0.0",

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to
   directive to the mapper to produce one or more relationships, each of which
   would not have the provided/generated `_key`.
 
+### Removed
+
+- Removed the deprecated convention based invocation config loading.
+
+### Changed
+
+- Related to the removal of convention based configuration loading, the
+  `createMockExecutionContext` and `createMockStepExecutionContext` utilities
+  exposed by `@jupiterone/integration-sdk-testing` now require
+  `instanceConfigFields` to be passed in for config value generation to work.
+
 ## 3.1.0 - 2020-06-01
 
 ### Added

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,7 +1446,7 @@
     route-recognizer "^0.3.4"
     slugify "^1.3.4"
 
-"@pollyjs/node-server@^4.0.2":
+"@pollyjs/node-server@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@pollyjs/node-server/-/node-server-4.3.0.tgz#f822e66110e71eb25fbe476951fdc764d2417395"
   integrity sha512-pGrX889RkJXleW7p1cMKJqEtuasABbosneU9VrHOUYOMlYnObIOTt5y/n3m0NMAh9SyyusgqC7yQ18/PnMCgfg==
@@ -1460,15 +1460,15 @@
     morgan "^1.9.1"
     nocache "^2.1.0"
 
-"@pollyjs/persister-fs@4.0.4":
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@pollyjs/persister-fs/-/persister-fs-4.0.4.tgz#6975be09b5d1dd9942f5138da4faca26c856be88"
-  integrity sha512-mzPtgcYtWLlz2WOmInjTRnzX7W8C3IKWQ8Bt/cFzKxT0Qb822sXcvlCywjAkBqshzKXE/GyeVZszD+eIypEnUg==
+"@pollyjs/persister-fs@^4.0.4":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@pollyjs/persister-fs/-/persister-fs-4.3.0.tgz#d6eb718a6b3e027c7071b59f4300b26961b36a07"
+  integrity sha512-2DUIyl/3mr5F1Orq6bnpW6Witz2I8ulMGsqCFrlh4LaA4DlSg2SwOv88bbjzMCfqGP1CN3U5Zu8o7tZlFxkd8w==
   dependencies:
-    "@pollyjs/node-server" "^4.0.2"
-    "@pollyjs/persister" "^4.0.4"
+    "@pollyjs/node-server" "^4.3.0"
+    "@pollyjs/persister" "^4.3.0"
 
-"@pollyjs/persister@^4.0.4":
+"@pollyjs/persister@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@pollyjs/persister/-/persister-4.3.0.tgz#cd62b6d3c7deae5f6eabdfb107bb76ed4389b8e6"
   integrity sha512-oKTl++rZdT/5tMoeHMsgUAHjnRf/4qLNv7kc7u8ddldjgZ4eDAIWlG6BwFkhDxjhV+ofVlnLxFnRjmK4qrrmqA==


### PR DESCRIPTION
Updated all test fixtures to have a `src/index` file that exposes the `invocationConfig`.

Added an entry to the CHANGELOG to reflect a change that was made to the `integration-sdk-testing` package around changes to convention based loading as well.

Added missing devDependencies to the `integration-sdk-cli` package.