### PR TITLE
Fix git describe matching in publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Fetch tags
         run: |
           git fetch --tags
-          if git describe --exact-match --match "v*.*.*" HEAD^2
+          if git describe --exact-match --match "@*.*.*" HEAD^2
           then
             echo "Found version commit tag. Publishing."
             echo "::set-env name=publish::true"

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^1.0.0",
+    "@jupiterone/integration-sdk-runtime": "^1.0.1",
     "@types/vis": "^4.21.20",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
@@ -30,7 +30,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^1.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^1.0.1",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "node": "10.x || 12.x || 14.x"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^1.0.0",
+    "@jupiterone/integration-sdk-core": "^1.0.1",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -20,7 +20,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^1.0.0",
+    "@jupiterone/integration-sdk-core": "^1.0.1",
     "@lifeomic/alpha": "^1.1.3",
     "async-sema": "^3.1.0",
     "axios": "^0.19.2",
@@ -38,7 +38,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^1.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^1.0.1",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -20,8 +20,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^1.0.0",
-    "@jupiterone/integration-sdk-runtime": "^1.0.0",
+    "@jupiterone/integration-sdk-core": "^1.0.1",
+    "@jupiterone/integration-sdk-runtime": "^1.0.1",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^1.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^1.0.1",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"

--- a/packages/integration-sdk/README.md
+++ b/packages/integration-sdk/README.md
@@ -6,7 +6,7 @@ The functionality provided by this package has been broken up into multiple
 smaller packages.
 
 This is now a shell package used to store historical information about the older
-`@jupiterone/integration-sdk` and also track changes made to the the
+`@jupiterone/integration-sdk` and also track changes made to the
 `@jupiterone/integration-sdk-*` family of packages.
 
 If you are developing an integration, use the `@jupiterone/integration-sdk-core`


### PR DESCRIPTION
Looks like independent versioning creates different tags and the publish workflow wasn't updated to handle that. I tested the `git describe` change locally and it properly resolves the commit to a tag now.