### PR TITLE
Only publish dist from published packages

### DIFF
--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -7,6 +7,9 @@
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
+  "files": [
+    "dist"
+  ],
   "engines": {
     "node": "10.x || 12.x || 14.x"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -7,6 +7,9 @@
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
+  "files": [
+    "dist"
+  ],
   "engines": {
     "node": "10.x || 12.x || 14.x"
   },

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -7,6 +7,9 @@
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
+  "files": [
+    "dist"
+  ],
   "engines": {
     "node": "10.x || 12.x || 14.x"
   },

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -7,7 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.0 - 2020-06-03
+### Fixed
+
+- Make published packages leaner by only including `dist` files.
+
+## 1.0.1 - 2020-06-03
 
 ### Fixed
 


### PR DESCRIPTION
I saw that the publish result displayed a bunch of `src` files and realized that I forgot to do this.