### PR TITLE
Move @types/vis from dependencies to devDependencies

### DIFF
--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@jupiterone/integration-sdk-runtime": "^1.0.1",
-    "@types/vis": "^4.21.20",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "upath": "^1.2.0",
@@ -37,6 +36,7 @@
     "@types/pollyjs__adapter-node-http": "^2.0.0",
     "@types/pollyjs__core": "^4.0.0",
     "@types/pollyjs__persister": "^2.0.1",
+    "@types/vis": "^4.21.20",
     "jsonwebtoken": "^8.5.1",
     "memfs": "^3.2.0"
   }

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 - Regression: `createIntegrationRelationship()` lost a change to accept optional
   `_type` for relationship mappings, overriding the generated value or values
   provided in `properties` option.
+- Removed `@types/vis` from dependencies to devDependencies because having the
+  type forces typescript consumers to have `DOM` in the their `lib` compiler
+  option.
 
 ## 1.0.1 - 2020-06-03
 


### PR DESCRIPTION
We don't expose any types from the cli that require `@types/vis` to be installed for consumers to use it.