### PR TITLE
Update tsconfig in integration-dev-tools readme to include outDir

### DIFF
--- a/packages/integration-sdk-dev-tools/README.md
+++ b/packages/integration-sdk-dev-tools/README.md
@@ -55,13 +55,17 @@ Create `tsconfig.json` at root of your project that contains:
 
 ```json
 {
-  "extends": "./node_modules/@jupiterone/integration-sdk-dev-tools/config/typescript"
+  "extends": "./node_modules/@jupiterone/integration-sdk-dev-tools/config/typescript",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "exclude": ["dist"]
 }
 ```
 
 Create a `.eslintrc` at the root of your project that contains:
 
-```
+```json
 {
   "root": true,
   "extends": [


### PR DESCRIPTION
Just a small change to the example tsconfig to make it match what we are actually doing in the integrations.