### PR TITLE
Decouple logger and api client

### DIFF
--- a/packages/integration-sdk-cli/src/__tests__/cli-run-failure.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-run-failure.test.ts
@@ -91,9 +91,6 @@ test('does not log errors that have been previously logged', async () => {
   const errorSpy = jest.spyOn(logger, 'error');
 
   jest.spyOn(logger, 'child').mockReturnValue(logger);
-  jest
-    .spyOn(logger, 'registerSynchronizationJobContext')
-    .mockReturnValue(logger);
 
   mocked(mockCreateIntegrationLogger).mockReturnValue(logger);
 

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.6.4",
-    "axios": "^0.19.2",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-core/src/types/apiClient.ts
+++ b/packages/integration-sdk-core/src/types/apiClient.ts
@@ -1,2 +1,0 @@
-import { AxiosInstance } from 'axios';
-export type ApiClient = AxiosInstance;

--- a/packages/integration-sdk-core/src/types/index.ts
+++ b/packages/integration-sdk-core/src/types/index.ts
@@ -1,4 +1,3 @@
-export * from './apiClient';
 export * from './config';
 export * from './context';
 export * from './instance';

--- a/packages/integration-sdk-core/src/types/logger.ts
+++ b/packages/integration-sdk-core/src/types/logger.ts
@@ -1,6 +1,10 @@
 import { StepMetadata } from './';
 import { SynchronizationJob } from './synchronization';
-import { ApiClient } from './apiClient';
+
+export interface IntegrationEvent {
+  name: string;
+  description: string;
+}
 
 interface LogFunction {
   (...args: any[]): boolean | void;
@@ -61,16 +65,7 @@ interface BaseLogger {
   child: ChildLogFunction;
 }
 
-export interface LoggerSynchronizationJobContext {
-  apiClient: ApiClient;
-  job: SynchronizationJob;
-}
-
 export interface IntegrationLoggerFunctions {
-  registerSynchronizationJobContext: (
-    context: LoggerSynchronizationJobContext,
-  ) => IntegrationLogger;
-
   isHandledError: IsHandledErrorFunction;
 
   // Special log functions used to publish events to j1
@@ -90,10 +85,6 @@ export interface IntegrationLoggerFunctions {
    * @deprecated
    */
   publishErrorEvent: PublishErrorEventFunction;
-
-  // flushes the queue of work to ensure that
-  // all events have been published
-  flush: () => Promise<void>;
 }
 
 export type IntegrationLogger = BaseLogger & IntegrationLoggerFunctions;

--- a/packages/integration-sdk-runtime/src/api/index.ts
+++ b/packages/integration-sdk-runtime/src/api/index.ts
@@ -1,11 +1,11 @@
-import { ApiClient } from '@jupiterone/integration-sdk-core';
+import { AxiosInstance } from 'axios';
 import Alpha from '@lifeomic/alpha';
 import { malformedApiKeyError, apiKeyRequiredError } from './error';
 
 import dotenv from 'dotenv';
 import dotenvExpand from 'dotenv-expand';
 
-export { ApiClient };
+export type ApiClient = AxiosInstance;
 
 const jwt = require('jsonwebtoken');
 

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -10,9 +10,9 @@ import {
   IntegrationError,
   IntegrationExecutionContext,
   IntegrationInstance,
-  IntegrationLogger,
   IntegrationStep,
   IntegrationStepExecutionContext,
+  IntegrationLogger,
   StepResultStatus,
   JobState,
 } from '@jupiterone/integration-sdk-core';
@@ -21,7 +21,10 @@ import {
   executeStepDependencyGraph,
 } from '../dependencyGraph';
 import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
-import { createIntegrationLogger } from '../../logger';
+import {
+  createIntegrationLogger,
+  IntegrationLogger as IntegrationLoggerImpl,
+} from '../../logger';
 import { getDefaultStepStartStates } from '../step';
 
 jest.mock('fs');
@@ -142,7 +145,7 @@ describe('executeStepDependencyGraph', () => {
 
     expect(executionHandlerSpy).toHaveBeenCalledTimes(1);
 
-    expect(logger!).toBeInstanceOf(jest.requireActual('bunyan'));
+    expect(logger!).toBeInstanceOf(IntegrationLoggerImpl);
     expect(instance!).toEqual(LOCAL_INTEGRATION_INSTANCE);
 
     // ensure job state has expected functions

--- a/packages/integration-sdk-runtime/src/execution/__tests__/executeIntegration.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/executeIntegration.test.ts
@@ -9,7 +9,10 @@ import {
   ExecuteIntegrationResult,
 } from '../executeIntegration';
 import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
-import { createIntegrationLogger } from '../../logger';
+import {
+  createIntegrationLogger,
+  IntegrationLogger as IntegrationLoggerImpl,
+} from '../../logger';
 import {
   IntegrationLogger,
   IntegrationExecutionContext,
@@ -455,7 +458,7 @@ describe('executeIntegrationLocally', () => {
 
     const expectedContext: IntegrationExecutionContext = {
       instance: LOCAL_INTEGRATION_INSTANCE,
-      logger: expect.any(jest.requireActual('bunyan')),
+      logger: expect.any(IntegrationLoggerImpl),
     };
 
     expect(validateInvocation).toHaveBeenCalledWith(expectedContext);

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -126,7 +126,5 @@ export async function executeWithContext<
     'Integration data collection has completed.',
   );
 
-  await logger.flush();
-
   return summary;
 }

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -1,8 +1,8 @@
 import Logger from 'bunyan';
-import PromiseQueue from 'p-queue';
 import { v4 as uuid } from 'uuid';
 
 import {
+  IntegrationLogger as IntegrationLoggerType,
   IntegrationError,
   UNEXPECTED_ERROR_CODE,
   UNEXPECTED_ERROR_REASON,
@@ -18,11 +18,11 @@ import {
   IntegrationInvocationConfig,
   IntegrationProviderAuthorizationError,
   IntegrationProviderAuthenticationError,
-  IntegrationLogger,
-  LoggerSynchronizationJobContext,
-  IntegrationLoggerFunctions,
   SynchronizationJob,
+  IntegrationEvent,
 } from '@jupiterone/integration-sdk-core';
+
+import { EventEmitter } from 'events';
 
 // eslint-disable-next-line
 const bunyanFormat = require('bunyan-format');
@@ -74,23 +74,12 @@ export function createLogger<
     logger.addSerializers(serializers);
   }
 
-  // NOTE: concurrency is set to one to allow for logs to be published in
-  // the order that they are added to the queue.
-  //
-  // Optimizations can come later once the synchronization api supports
-  // accepting a timestamp.
-  const eventPublishingQueue = new PromiseQueue({ concurrency: 1 });
   const errorSet = new Set<Error>();
 
-  const verboseTraceLogger = instrumentVerboseTrace(logger);
-
-  return instrumentEventLogging(
-    instrumentErrorTracking(verboseTraceLogger, errorSet),
-    {
-      eventPublishingQueue,
-      errorSet,
-    },
-  );
+  return new IntegrationLogger({
+    logger,
+    errorSet,
+  });
 }
 
 /**
@@ -147,232 +136,183 @@ function createInstanceConfigSerializer(
   };
 }
 
-function instrumentVerboseTrace(logger: Logger): Logger {
-  const trace = logger.trace;
-  const child = logger.child;
-
-  Object.assign(logger, {
-    trace: (...params: any[]) => {
-      if (params.length === 0) {
-        return trace.apply(logger);
-      }
-
-      let additionalFields: Record<string, any> = {};
-      let remainingArgs: any[] = params;
-      if (params[0] instanceof Error) {
-        additionalFields = { err: params[0] };
-        remainingArgs = params.slice(1);
-      } else if (typeof params[0] === 'object') {
-        additionalFields = params[0];
-        remainingArgs = params.slice(1);
-      }
-
-      trace.apply(logger, [
-        { verbose: true, ...additionalFields },
-        ...remainingArgs,
-      ]);
-    },
-
-    child: (options: object = {}, simple?: boolean) => {
-      const c = child.apply(logger, [options, simple]);
-      return instrumentVerboseTrace(c);
-    },
-  });
-
-  return logger;
+interface EventLookup {
+  event: IntegrationEvent;
 }
 
-function instrumentErrorTracking(logger: Logger, errorSet: Set<Error>): Logger {
-  const error = logger.error;
-  const child = logger.child;
-
-  Object.assign(logger, {
-    error: (...params: any[]) => {
-      if (params.length === 0) {
-        return error.apply(logger);
-      }
-
-      if (params[0] instanceof Error) {
-        errorSet.add(params[0]);
-      } else if (params[0]?.err instanceof Error) {
-        errorSet.add(params[0].err);
-      }
-
-      error.apply(logger, [...params]);
-    },
-
-    child: (options: object = {}, simple?: boolean) => {
-      const c = child.apply(logger, [options, simple]);
-      return instrumentErrorTracking(c, errorSet);
-    },
-  });
-
-  return logger;
-}
-
-interface LogContext {
-  eventPublishingQueue: PromiseQueue;
+interface IntegrationLoggerInput {
+  logger: Logger;
   errorSet: Set<Error>;
-  synchronizationJobContext?: LoggerSynchronizationJobContext;
 }
 
-function instrumentEventLogging(
-  logger: Logger,
-  context: LogContext,
-): IntegrationLogger {
-  const { eventPublishingQueue, errorSet } = context;
-  const child = logger.child;
+export class IntegrationLogger extends EventEmitter
+  implements IntegrationLoggerType {
+  private _logger: Logger;
+  private _errorSet: Set<Error>;
 
-  const publishEvent = (name: string, description: string) => {
-    if (process.env.JUPITERONE_DISABLE_EVENT_LOGGING === 'true') {
+  constructor(input: IntegrationLoggerInput) {
+    super();
+    this._logger = input.logger;
+    this._errorSet = input.errorSet;
+  }
+
+  isHandledError(err: Error) {
+    return this._errorSet.has(err);
+  }
+
+  debug(...params: any[]) {
+    return this._logger.debug(...params);
+  }
+  info(...params: any[]) {
+    return this._logger.info(...params);
+  }
+  warn(...params: any[]) {
+    return this._logger.warn(...params);
+  }
+  fatal(...params: any[]) {
+    return this._logger.fatal(...params);
+  }
+
+  trace(...params: any[]) {
+    if (params.length === 0) {
       return;
     }
 
-    if (context.synchronizationJobContext) {
-      const { job, apiClient } = context.synchronizationJobContext;
+    let additionalFields: Record<string, any> = {};
+    let remainingArgs: any[] = params;
 
-      const event = { name, description };
-
-      eventPublishingQueue.add(async () => {
-        try {
-          await apiClient.post(
-            `/persister/synchronization/jobs/${job.id}/events`,
-            {
-              events: [event],
-            },
-          );
-        } catch (err) {
-          // It's not the end of the world if we fail to publish
-          // an event
-          logger.error(
-            {
-              err,
-              event,
-            },
-            'Failed to publish integration event.',
-          );
-        }
-      });
+    if (params[0] instanceof Error) {
+      additionalFields = { err: params[0] };
+      remainingArgs = params.slice(1);
+    } else if (typeof params[0] === 'object') {
+      additionalFields = params[0];
+      remainingArgs = params.slice(1);
     }
-  };
 
-  const createChildLogger = (options: object = {}, simple?: boolean) => {
-    const childLogger = child.apply(logger, [options, simple]);
-    return instrumentEventLogging(childLogger, context);
-  };
+    return this._logger.trace(
+      { verbose: true, ...additionalFields },
+      ...remainingArgs,
+    );
+  }
 
-  const integrationLoggerFunctions: IntegrationLoggerFunctions = {
-    flush: async () => {
-      await eventPublishingQueue.onIdle();
-    },
+  error(...params: any[]) {
+    if (params[0] instanceof Error) {
+      this._errorSet.add(params[0]);
+    } else if (params[0]?.err instanceof Error) {
+      this._errorSet.add(params[0].err);
+    }
 
-    registerSynchronizationJobContext: (
-      synchronizationJobContext: LoggerSynchronizationJobContext,
-    ) => {
-      context.synchronizationJobContext = synchronizationJobContext;
-      const { job } = synchronizationJobContext;
+    this._logger.error(...params);
+  }
 
-      return createChildLogger({
+  child(options: object = {}, simple?: boolean) {
+    const childLogger = new IntegrationLogger({
+      errorSet: this._errorSet,
+      logger: this._logger.child(options, simple),
+    });
+
+    // pass events to parent
+    childLogger.on('event', (data) => {
+      this.emit('event', data);
+    });
+
+    return childLogger;
+  }
+
+  emit<T extends EventLookup, K extends keyof EventLookup>(
+    name: K,
+    data: T[K],
+  ) {
+    return super.emit(name, data);
+  }
+
+  stepStart(step: StepMetadata) {
+    const name = 'step_start';
+    const description = `Starting step "${step.name}"...`;
+    this.info({ step: step.id }, description);
+    this.publishEvent({ name, description });
+  }
+
+  stepSuccess(step: StepMetadata) {
+    const name = 'step_end';
+    const description = `Completed step "${step.name}".`;
+    this.info({ step: step.id }, description);
+    this.publishEvent({ name, description });
+  }
+
+  stepFailure(step: StepMetadata, err: Error) {
+    const name = 'step_failure';
+    const { errorId, description } = createErrorEventDescription(
+      err,
+      `Step "${step.name}" failed to complete due to error.`,
+    );
+
+    this.error({ errorId, err, step: step.id }, description);
+    this.publishEvent({ name, description });
+  }
+
+  synchronizationUploadStart(job: SynchronizationJob) {
+    const name = 'sync_upload_start';
+    const description = 'Uploading collected data for synchronization...';
+    this.info(
+      {
         synchronizationJobId: job.id,
-        integrationJobId: job.integrationJobId,
-        integrationInstanceId: job.integrationInstanceId,
-      });
-    },
+      },
+      description,
+    );
+    this.publishEvent({ name, description });
+  }
 
-    isHandledError: (err: Error) => errorSet.has(err),
+  synchronizationUploadEnd(job: SynchronizationJob) {
+    const name = 'sync_upload_end';
+    const description = 'Upload complete.';
+    this.info(
+      {
+        synchronizationJobId: job.id,
+      },
+      description,
+    );
+    this.publishEvent({ name, description });
+  }
 
-    stepStart: (step: StepMetadata) => {
-      const name = 'step_start';
-      const description = `Starting step "${step.name}"...`;
-      logger.info({ step: step.id }, description);
+  validationFailure(err: Error) {
+    const name = 'validation_failure';
+    const { errorId, description } = createErrorEventDescription(
+      err,
+      `Error occurred while validating integration configuration.`,
+    );
 
-      publishEvent(name, description);
-    },
-    stepSuccess: (step: StepMetadata) => {
-      const name = 'step_end';
-      const description = `Completed step "${step.name}".`;
-      logger.info({ step: step.id }, description);
+    this.error({ errorId, err }, description);
+    this.publishEvent({ name, description });
+  }
 
-      publishEvent(name, description);
-    },
-    stepFailure: (step: StepMetadata, err: Error) => {
-      const name = 'step_failure';
-      const { errorId, description } = createErrorEventDescription(
-        err,
-        `Step "${step.name}" failed to complete due to error.`,
-      );
+  publishEvent(event: IntegrationEvent) {
+    return this.emit('event', event);
+  }
 
-      logger.error({ errorId, err, step: step.id }, description);
+  publishErrorEvent(options) {
+    const {
+      name,
+      message,
+      err,
 
-      publishEvent(name, description);
-    },
-    synchronizationUploadStart: (job: SynchronizationJob) => {
-      const name = 'sync_upload_start';
-      const description = 'Uploading collected data for synchronization...';
-      logger.info(
-        {
-          synchronizationJobId: job.id,
-        },
-        description,
-      );
+      // `logData` is only logged (it is used to log data that should
+      // not be shown to customer but might be helpful for troubleshooting)
+      logData,
 
-      publishEvent(name, description);
-    },
-    synchronizationUploadEnd: (job: SynchronizationJob) => {
-      const name = 'sync_upload_end';
-      const description = 'Upload complete.';
-      logger.info(
-        {
-          synchronizationJobId: job.id,
-        },
-        description,
-      );
+      // `eventData` is added to error description but not logged
+      eventData,
+    } = options;
 
-      publishEvent(name, description);
-    },
-    validationFailure: (err: Error) => {
-      const name = 'validation_failure';
-      const { errorId, description } = createErrorEventDescription(
-        err,
-        `Error occurred while validating integration configuration.`,
-      );
+    const { errorId, description } = createErrorEventDescription(
+      err,
+      message,
+      eventData,
+    );
 
-      logger.error({ errorId, err }, description);
-      publishEvent(name, description);
-    },
-
-    publishEvent(options) {
-      return publishEvent(options.name, options.description);
-    },
-
-    publishErrorEvent(options) {
-      const {
-        name,
-        message,
-        err,
-
-        // `logData` is only logged (it is used to log data that should
-        // not be shown to customer but might be helpful for troubleshooting)
-        logData,
-
-        // `eventData` is added to error description but not logged
-        eventData,
-      } = options;
-      const { errorId, description } = createErrorEventDescription(
-        err,
-        message,
-        eventData,
-      );
-
-      logger.error({ ...logData, errorId, err }, description);
-      publishEvent(name, description);
-    },
-  };
-
-  return Object.assign(logger, {
-    ...integrationLoggerFunctions,
-    child: createChildLogger,
-  });
+    this._logger.error({ ...logData, errorId, err }, description);
+    this.publishEvent({ name, description });
+  }
 }
 
 type NameValuePair = [string, any];

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
@@ -1,0 +1,86 @@
+import { SynchronizationJob } from '@jupiterone/integration-sdk-core';
+import { createIntegrationLogger } from '../../logger';
+import { createApiClient } from '../../api';
+
+import { createEventPublishingQueue } from '../index';
+import noop from 'lodash/noop';
+
+test('publishes events added to the queue in the order they were enqueued', async () => {
+  const eventA = {
+    name: 'a',
+    description: 'Event A',
+  };
+
+  const eventB = {
+    name: 'b',
+    description: 'Event B',
+  };
+
+  const { apiClient, job, queue } = createContext();
+
+  const postSpy = jest.spyOn(apiClient, 'post').mockImplementation(noop as any);
+
+  queue.enqueue(eventA);
+  queue.enqueue(eventB);
+
+  await queue.onIdle();
+
+  expect(postSpy).toHaveBeenCalledTimes(2);
+  expect(postSpy).toHaveBeenNthCalledWith(
+    1,
+    `/persister/synchronization/jobs/${job.id}/events`,
+    { events: [eventA] },
+  );
+
+  expect(postSpy).toHaveBeenNthCalledWith(
+    2,
+    `/persister/synchronization/jobs/${job.id}/events`,
+    { events: [eventB] },
+  );
+});
+
+test('logs an error if publish fails', async () => {
+  const event = {
+    name: 'a',
+    description: 'Event A',
+  };
+
+  const { apiClient, logger, queue } = createContext();
+
+  const error = new Error('Failed to post event');
+  jest.spyOn(apiClient, 'post').mockRejectedValue(error);
+
+  const logErrorSpy = jest.spyOn(logger, 'error');
+
+  queue.enqueue(event);
+
+  await queue.onIdle();
+
+  expect(logErrorSpy).toHaveBeenCalledTimes(1);
+  expect(logErrorSpy).toHaveBeenCalledWith(
+    {
+      err: error,
+    },
+    'Failed to publish integration event',
+  );
+});
+
+function createContext() {
+  const apiClient = createApiClient({
+    apiBaseUrl: 'https://mochi:8080',
+    account: 'mochi',
+  });
+
+  const logger = createIntegrationLogger({
+    name: 'test',
+  });
+
+  const job = { id: 'test' } as SynchronizationJob;
+
+  return {
+    apiClient,
+    logger,
+    job,
+    queue: createEventPublishingQueue({ apiClient, logger, job }),
+  };
+}

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/index.test.ts
@@ -53,35 +53,6 @@ describe('initiateSynchronization', () => {
     });
   });
 
-  test('registers synchronization job and apiClient with logger', async () => {
-    const job = generateSynchronizationJob();
-
-    const context = createTestContext();
-
-    const { apiClient, logger } = context;
-    jest.spyOn(apiClient, 'post').mockResolvedValue({
-      data: {
-        job,
-      },
-    });
-    const registerSynchronizationJobContextSpy = jest.spyOn(
-      logger,
-      'registerSynchronizationJobContext',
-    );
-
-    const synchronizationContext = await initiateSynchronization(context);
-
-    expect(registerSynchronizationJobContextSpy).toHaveBeenCalledTimes(1);
-    expect(registerSynchronizationJobContextSpy).toHaveBeenCalledWith({
-      apiClient,
-      job,
-    });
-
-    expect(registerSynchronizationJobContextSpy).toHaveReturnedWith(
-      synchronizationContext.logger,
-    );
-  });
-
   test('throws error if integration instance cannot be found', async () => {
     const context = createTestContext();
     const { apiClient } = context;

--- a/packages/integration-sdk-runtime/src/synchronization/events.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/events.ts
@@ -1,0 +1,30 @@
+import { IntegrationEvent } from '@jupiterone/integration-sdk-core';
+import PromiseQueue from 'p-queue';
+
+import { SynchronizationJobContext } from '../synchronization';
+
+export const createEventPublishingQueue = ({
+  apiClient,
+  logger,
+  job,
+}: SynchronizationJobContext) => {
+  const queue = new PromiseQueue({ concurrency: 1 });
+
+  return {
+    enqueue(event: IntegrationEvent) {
+      return queue.add(async () => {
+        try {
+          await apiClient.post(
+            `/persister/synchronization/jobs/${job.id}/events`,
+            {
+              events: [event],
+            },
+          );
+        } catch (err) {
+          logger.error({ err }, 'Failed to publish integration event');
+        }
+      });
+    },
+    onIdle: () => queue.onIdle(),
+  };
+};

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -7,8 +7,9 @@ import {
   Entity,
   Relationship,
   SynchronizationJob,
-  IntegrationLogger,
 } from '@jupiterone/integration-sdk-core';
+
+import { IntegrationLogger } from '../logger';
 
 import { ExecuteIntegrationResult } from '../execution';
 
@@ -21,6 +22,8 @@ import { synchronizationApiError } from './error';
 import { ApiClient } from '../api';
 
 export { synchronizationApiError };
+import { createEventPublishingQueue } from './events';
+export { createEventPublishingQueue } from './events';
 
 const UPLOAD_BATCH_SIZE = 250;
 const UPLOAD_CONCURRENCY = 2;
@@ -39,6 +42,9 @@ export async function synchronizeCollectedData(
 ): Promise<SynchronizationJob> {
   const jobContext = await initiateSynchronization(input);
 
+  const eventPublishingQueue = createEventPublishingQueue(jobContext);
+  jobContext.logger.on('event', (event) => eventPublishingQueue.enqueue(event));
+
   try {
     await uploadCollectedData(jobContext);
 
@@ -54,6 +60,8 @@ export async function synchronizeCollectedData(
 
     await abortSynchronization({ ...jobContext, reason: err.message });
     throw err;
+  } finally {
+    await eventPublishingQueue.onIdle();
   }
 }
 
@@ -91,9 +99,10 @@ export async function initiateSynchronization({
   return {
     apiClient,
     job,
-    logger: logger.registerSynchronizationJobContext({
-      apiClient,
-      job,
+    logger: logger.child({
+      synchronizationJobId: job.id,
+      integrationJobId: job.integrationJobId,
+      integrationInstanceId: job.integrationInstanceId,
     }),
   };
 }

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -55,10 +55,19 @@ export async function synchronizeCollectedData(
   } catch (err) {
     jobContext.logger.error(
       err,
-      'Error occured while synchronizing collected data',
+      'Error occurred while synchronizing collected data',
     );
 
-    await abortSynchronization({ ...jobContext, reason: err.message });
+    try {
+      await abortSynchronization({ ...jobContext, reason: err.message });
+    } catch (abortError) {
+      jobContext.logger.error(
+        abortError,
+        'Error occurred while aborting synchronization job.',
+      );
+      throw abortError;
+    }
+
     throw err;
   } finally {
     await eventPublishingQueue.onIdle();

--- a/packages/integration-sdk-testing/src/__tests__/context.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/context.test.ts
@@ -61,23 +61,12 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
         const { logger } = createContext({ instanceConfigFields });
 
         Object.keys(logger).forEach((key) => {
-          if (
-            key !== 'child' &&
-            key !== 'registerSynchronizationJobContext' &&
-            key !== 'flush' &&
-            key !== 'isHandledError'
-          ) {
+          if (key !== 'child' && key !== 'flush' && key !== 'isHandledError') {
             expect(logger[key]).toEqual(noop);
           }
         });
 
-        expect(
-          logger.registerSynchronizationJobContext(
-            {} as SynchronizationJobContext,
-          ),
-        ).toEqual(logger);
         expect(logger.child({})).toEqual(logger);
-        expect(logger.flush).toEqual(noopAsync);
       });
 
       test('generates an execution context with the integration instance used for local development', () => {

--- a/packages/integration-sdk-testing/src/logger.ts
+++ b/packages/integration-sdk-testing/src/logger.ts
@@ -10,9 +10,6 @@ export function createMockIntegrationLogger(): IntegrationLogger {
     warn: noop,
     error: noop,
     fatal: noop,
-    registerSynchronizationJobContext() {
-      return this;
-    },
     isHandledError: () => false,
     stepStart: noop,
     stepSuccess: noop,
@@ -20,7 +17,6 @@ export function createMockIntegrationLogger(): IntegrationLogger {
     synchronizationUploadStart: noop,
     synchronizationUploadEnd: noop,
     validationFailure: noop,
-    flush: noopAsync,
     publishEvent: noop,
     publishErrorEvent: noop,
     child() {

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Decoupled synchronization event publishing from the `IntegrationLogger`.
+  Events publishing can now be performed by listening to events that the logger
+  publishes.
+
+### Removed
+
+- Remove the need for the `JUPITERONE_DISABLE_EVENT_LOGGING` environment
+  variable.
+- Removed `ApiClient` type from the `@jupiterone/integration-sdk-core` package.
+  Also removed the dependency on `axios` from the package as well.
+
 ## 1.1.1 - 2020-06-08
 
 ### Added


### PR DESCRIPTION
Converted the IntegrationLogger implementation into an event emitter that can now be observed for events to publish. Part of the reason why I did this was because some interface needs to be exposed for publishing metrics and the logger felt like a good place to expose that since a metric really just a different type of event to log. Having to register the logger with a sync context started to feel dirty to me after implementing it, so this allows for us to remove that and allow the logger to mostly just function as a regular logger but now with hooks.

A small side benefit of this is that it removes the need for the `JUPITERONE_DISABLE_EVENT_LOGGING` environment variable hack that the j1-j1-integration needed. This also allows for us to remove the `axios` dependency from the `integration-sdk-core` module (something that also felt dirty to me as I was pulling the sdk a part).