### PR TITLE
Add interface for emitting metrics to be published

### DIFF
--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -103,7 +103,7 @@ export function run() {
         log.displaySynchronizationResults(abortResult);
       } finally {
         logger.publishMetric({
-          name: 'total-duration',
+          name: 'duration-total',
           value: Date.now() - startTime,
           unit: 'Milliseconds',
         });

--- a/packages/integration-sdk-cli/src/log.ts
+++ b/packages/integration-sdk-cli/src/log.ts
@@ -5,6 +5,7 @@ import {
   IntegrationStepResult,
   StepResultStatus,
   SynchronizationJob,
+  Metric,
 } from '@jupiterone/integration-sdk-core';
 
 export function debug(msg: string) {
@@ -72,6 +73,16 @@ collected by a step are declared in the step's "types" field.`,
     warn('\nThe following datasets were marked as partial:');
     info(partialDatasets.types.map((type) => `  - ${type}`).join('\n'));
   }
+}
+
+export function displayMetrics(metrics: Metric[]) {
+  metrics.forEach((metric) => {
+    switch (metric.unit) {
+      case 'Milliseconds':
+        info(`Metric "${metric.name}" = ${metric.value}ms`);
+        break;
+    }
+  });
 }
 
 function logStepStatus(stepResult: IntegrationStepResult) {

--- a/packages/integration-sdk-core/src/types/index.ts
+++ b/packages/integration-sdk-core/src/types/index.ts
@@ -7,6 +7,7 @@ export * from './partialDatasets';
 export * from './step';
 export * from './validation';
 export * from './synchronization';
+export * from './metric';
 
 export * from './persistedObject';
 export * from './entity';

--- a/packages/integration-sdk-core/src/types/logger.ts
+++ b/packages/integration-sdk-core/src/types/logger.ts
@@ -1,5 +1,6 @@
 import { StepMetadata } from './';
 import { SynchronizationJob } from './synchronization';
+import { Metric } from './metric';
 
 export interface IntegrationEvent {
   name: string;
@@ -24,6 +25,8 @@ type PublishEventInput = {
   name: string;
   description: string;
 };
+
+type PublishMetricFunction = (metric: Omit<Metric, 'timestamp'>) => void;
 
 type PublishEventFunction = (options: PublishEventInput) => void;
 
@@ -75,6 +78,8 @@ export interface IntegrationLoggerFunctions {
   synchronizationUploadStart: SynchronizationLogFunction;
   synchronizationUploadEnd: SynchronizationLogFunction;
   validationFailure: ValidationLogFunction;
+
+  publishMetric: PublishMetricFunction;
 
   /**
    * @deprecated

--- a/packages/integration-sdk-core/src/types/metric.ts
+++ b/packages/integration-sdk-core/src/types/metric.ts
@@ -1,0 +1,19 @@
+export interface Metric {
+  name: string;
+  value: number;
+
+  /*
+   * The unit that the metric value is associated with
+   */
+  unit: 'Milliseconds';
+
+  /**
+   * Additional dimensions to add to a metric
+   */
+  dimensions?: Record<string, string>;
+
+  /**
+   * The time that the metric was collected.
+   */
+  timestamp: number;
+}

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -221,7 +221,10 @@ export function executeStepDependencyGraph<
           promiseQueue.add(() =>
             timeOperation({
               logger: executionContext.logger,
-              metricName: `${stepId}-duration`,
+              metricName: `duration-step`,
+              dimensions: {
+                stepId,
+              },
               operation: () => executeStep(step),
             }).catch(handleUnexpectedError),
           );

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -16,6 +16,7 @@ import {
   ExecutionContext,
   StepExecutionContext,
 } from '@jupiterone/integration-sdk-core';
+import { timeOperation } from '../metrics';
 
 /**
  * This function accepts a list of steps and constructs a dependency graph
@@ -218,7 +219,11 @@ export function executeStepDependencyGraph<
         if (isStepEnabled(stepId) && stepDependenciesAreComplete(stepId)) {
           removeStepFromWorkingGraph(stepId);
           promiseQueue.add(() =>
-            executeStep(step).catch(handleUnexpectedError),
+            timeOperation({
+              logger: executionContext.logger,
+              metricName: `${stepId}-duration`,
+              operation: () => executeStep(step),
+            }).catch(handleUnexpectedError),
           );
         }
       });

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -63,7 +63,7 @@ export async function executeIntegrationInstance(
 
   return timeOperation({
     logger,
-    metricName: 'collection-duration',
+    metricName: 'duration-collect',
     operation: () =>
       executeWithContext(
         {

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -18,6 +18,7 @@ import {
   getDefaultStepStartStates,
 } from './step';
 import { validateStepStartStates } from './validation';
+import { timeOperation } from '../metrics';
 
 export interface ExecuteIntegrationResult {
   integrationStepResults: IntegrationStepResult[];
@@ -60,15 +61,18 @@ export async function executeIntegrationInstance(
     process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION = 'true';
   }
 
-  const result = await executeWithContext(
-    {
-      instance,
-      logger,
-    },
-    config,
-  );
-
-  return result;
+  return timeOperation({
+    logger,
+    metricName: 'collection-duration',
+    operation: () =>
+      executeWithContext(
+        {
+          instance,
+          logger,
+        },
+        config,
+      ),
+  });
 }
 
 /**

--- a/packages/integration-sdk-runtime/src/index.ts
+++ b/packages/integration-sdk-runtime/src/index.ts
@@ -3,3 +3,4 @@ export * from './execution';
 export * from './synchronization';
 export * from './fileSystem';
 export * from './logger';
+export * from './metrics';

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -469,6 +469,56 @@ describe('createErrorEventDescription', () => {
   });
 });
 
+describe('publishMetric', () => {
+  test('emits a "metric" event when called', () => {
+    const onEmitMetric = jest.fn();
+
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    logger.on('metric', onEmitMetric);
+
+    logger.publishMetric({
+      name: 'metric',
+      value: 1000,
+      unit: 'Milliseconds',
+    });
+
+    expect(onEmitMetric).toHaveBeenCalledWith({
+      name: 'metric',
+      value: 1000,
+      unit: 'Milliseconds',
+      timestamp: expect.any(Number),
+    });
+  });
+
+  test('emits a "metric" event when called with child logger', () => {
+    const onEmitMetric = jest.fn();
+
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    logger.on('metric', onEmitMetric);
+
+    logger.child({}).publishMetric({
+      name: 'metric',
+      value: 1000,
+      unit: 'Milliseconds',
+    });
+
+    expect(onEmitMetric).toHaveBeenCalledWith({
+      name: 'metric',
+      value: 1000,
+      unit: 'Milliseconds',
+      timestamp: expect.any(Number),
+    });
+  });
+});
+
 describe('#publishEvent', () => {
   test('should support publishEvent(...) function', async () => {
     const onEmitEvent = jest.fn();

--- a/packages/integration-sdk-runtime/src/metrics/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/metrics/__tests__/index.test.ts
@@ -1,0 +1,56 @@
+import { timeOperation } from '../index';
+import { createIntegrationLogger } from '../../logger';
+
+test('calls logger.publishMetric with the duration it takes the input operation to execute', async () => {
+  const logger = createIntegrationLogger({
+    name: 'timeOperation',
+  });
+
+  const publishSpy = jest.spyOn(logger, 'publishMetric');
+
+  // Fake 2 seconds elapsing
+  jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(2000);
+
+  await timeOperation({
+    logger,
+    metricName: 'test',
+    operation: () => Promise.resolve(),
+  });
+
+  expect(publishSpy).toHaveBeenCalledTimes(1);
+  expect(publishSpy).toHaveBeenCalledWith({
+    name: 'test',
+    unit: 'Milliseconds',
+    value: 2000,
+  });
+});
+
+test('accepts dimensions to publish with metric', async () => {
+  const logger = createIntegrationLogger({
+    name: 'timeOperation',
+  });
+
+  const publishSpy = jest.spyOn(logger, 'publishMetric');
+
+  // Fake 2 seconds elapsing
+  jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(2000);
+
+  await timeOperation({
+    logger,
+    metricName: 'test',
+    operation: () => Promise.resolve(),
+    dimensions: {
+      test: 'someDimension',
+    },
+  });
+
+  expect(publishSpy).toHaveBeenCalledTimes(1);
+  expect(publishSpy).toHaveBeenCalledWith({
+    name: 'test',
+    unit: 'Milliseconds',
+    value: 2000,
+    dimensions: {
+      test: 'someDimension',
+    },
+  });
+});

--- a/packages/integration-sdk-runtime/src/metrics/index.ts
+++ b/packages/integration-sdk-runtime/src/metrics/index.ts
@@ -1,13 +1,15 @@
-import { IntegrationLogger } from '@jupiterone/integration-sdk-core';
+import { IntegrationLogger, Metric } from '@jupiterone/integration-sdk-core';
 
 interface TimeOperationInput<T extends () => any> {
   logger: IntegrationLogger;
   metricName: string;
   operation: T;
+  dimensions?: Metric['dimensions'];
 }
 export async function timeOperation<T extends () => any>({
   logger,
   metricName,
+  dimensions,
   operation,
 }: TimeOperationInput<T>): Promise<ReturnType<T>> {
   const startTime = Date.now();
@@ -17,6 +19,7 @@ export async function timeOperation<T extends () => any>({
     logger.publishMetric({
       name: metricName,
       unit: 'Milliseconds',
+      dimensions,
       value: duration,
     });
   });

--- a/packages/integration-sdk-runtime/src/metrics/index.ts
+++ b/packages/integration-sdk-runtime/src/metrics/index.ts
@@ -1,0 +1,23 @@
+import { IntegrationLogger } from '@jupiterone/integration-sdk-core';
+
+interface TimeOperationInput<T extends () => any> {
+  logger: IntegrationLogger;
+  metricName: string;
+  operation: T;
+}
+export async function timeOperation<T extends () => any>({
+  logger,
+  metricName,
+  operation,
+}: TimeOperationInput<T>): Promise<ReturnType<T>> {
+  const startTime = Date.now();
+  return await Promise.resolve(operation()).finally(() => {
+    const duration = Date.now() - startTime;
+
+    logger.publishMetric({
+      name: metricName,
+      unit: 'Milliseconds',
+      value: duration,
+    });
+  });
+}

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -174,7 +174,7 @@ export async function uploadCollectedData(context: SynchronizationJobContext) {
 
   await timeOperation({
     logger: context.logger,
-    metricName: 'synchronization-upload-duration',
+    metricName: 'duration-sync-upload',
     operation: () =>
       walkDirectory({
         path: 'graph',

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -20,6 +20,7 @@ import {
 } from '../fileSystem';
 import { synchronizationApiError } from './error';
 import { ApiClient } from '../api';
+import { timeOperation } from '../metrics';
 
 export { synchronizationApiError };
 import { createEventPublishingQueue } from './events';
@@ -162,23 +163,35 @@ async function getPartialDatasets() {
 export async function uploadCollectedData(context: SynchronizationJobContext) {
   context.logger.synchronizationUploadStart(context.job);
 
-  await walkDirectory({
-    path: 'graph',
-    async iteratee({ filePath, data }) {
-      const parsedData = JSON.parse(data);
+  await timeOperation({
+    logger: context.logger,
+    metricName: 'synchronization-upload-duration',
+    operation: () =>
+      walkDirectory({
+        path: 'graph',
+        async iteratee({ data }) {
+          const parsedData = JSON.parse(data);
 
-      try {
-        if (Array.isArray(parsedData.entities)) {
-          await uploadData(context, 'entities', parsedData.entities);
-        }
+          try {
+            if (Array.isArray(parsedData.entities)) {
+              await uploadData(context, 'entities', parsedData.entities);
+            }
 
-        if (Array.isArray(parsedData.relationships)) {
-          await uploadData(context, 'relationships', parsedData.relationships);
-        }
-      } catch (err) {
-        throw synchronizationApiError(err, 'Error uploading collected data');
-      }
-    },
+            if (Array.isArray(parsedData.relationships)) {
+              await uploadData(
+                context,
+                'relationships',
+                parsedData.relationships,
+              );
+            }
+          } catch (err) {
+            throw synchronizationApiError(
+              err,
+              'Error uploading collected data',
+            );
+          }
+        },
+      }),
   });
 
   context.logger.synchronizationUploadEnd(context.job);

--- a/packages/integration-sdk-testing/src/logger.ts
+++ b/packages/integration-sdk-testing/src/logger.ts
@@ -17,6 +17,7 @@ export function createMockIntegrationLogger(): IntegrationLogger {
     synchronizationUploadStart: noop,
     synchronizationUploadEnd: noop,
     validationFailure: noop,
+    publishMetric: noop,
     publishEvent: noop,
     publishErrorEvent: noop,
     child() {


### PR DESCRIPTION
This builds on top of #231 and allows for `metric` events to be listened for. Our managed environment will handle collecting the `metric` events (pr for that coming soon).