### PR TITLE
Add convertProperties parseTime option

### DIFF
--- a/packages/integration-sdk-core/src/data/__tests__/converters.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/converters.test.ts
@@ -1,4 +1,4 @@
-import { convertProperties, convertNameValuePairs } from '../converters';
+import { convertNameValuePairs, convertProperties } from '../converters';
 
 describe('convertProperties', () => {
   const original: any = {
@@ -8,6 +8,14 @@ describe('convertProperties', () => {
     // eslint-disable-next-line
     snake_case: 'snake',
     TitleCase: 'title',
+    aGoodTime: '2019-04-23T18:06:05Z',
+    another_time: '2019-04-23T18:06:05Z',
+    someDate: '2019-04-23T18:06:05Z',
+    occurredOn: '2019-04-23T18:06:05Z',
+    updatedAt: '2019-04-23T18:06:05Z',
+    aBadTime: 'do I look like time to you?',
+    anUndefinedTime: undefined,
+    aNullTime: null,
     object: {
       name: 'me',
     },
@@ -20,31 +28,48 @@ describe('convertProperties', () => {
     arrayOfUndefined: [undefined],
   };
 
-  const flattened: any = {
+  const converted: any = {
     string: 'a',
     array: ['a', 'b', 'c'],
     number: 123,
     snakeCase: 'snake',
     titleCase: 'title',
+    aGoodTime: '2019-04-23T18:06:05Z',
+    anotherTime: '2019-04-23T18:06:05Z',
+    someDate: '2019-04-23T18:06:05Z',
+    occurredOn: '2019-04-23T18:06:05Z',
+    updatedAt: '2019-04-23T18:06:05Z',
+    aBadTime: 'do I look like time to you?',
   };
 
-  test('flatten object without options', () => {
-    expect(convertProperties(original, {})).toEqual(flattened);
+  test('default options', () => {
+    expect(convertProperties(original, {})).toEqual(converted);
   });
 
-  test('flatten object stringify object', () => {
+  test('stringify object', () => {
     expect(convertProperties(original, { stringifyObject: true })).toEqual({
-      ...flattened,
+      ...converted,
       object: JSON.stringify(original.object),
       objectArray: [JSON.stringify(original.objectArray[0])],
     });
   });
 
-  test('flatten object stringify array', () => {
+  test('stringify array', () => {
     expect(convertProperties(original, { stringifyArray: true })).toEqual({
-      ...flattened,
+      ...converted,
       array: JSON.stringify(original.array),
       objectArray: JSON.stringify(original.objectArray),
+    });
+  });
+
+  test('parseTime', () => {
+    expect(convertProperties(original, { parseTime: true })).toEqual({
+      ...converted,
+      aGoodTime: 1556042765000,
+      anotherTime: 1556042765000,
+      someDate: 1556042765000,
+      occurredOn: 1556042765000,
+      updatedAt: 1556042765000,
     });
   });
 });

--- a/packages/integration-sdk-core/src/data/converters.ts
+++ b/packages/integration-sdk-core/src/data/converters.ts
@@ -157,7 +157,7 @@ export function convertNameValuePairs(
  * @see parseTimePropertyValue
  */
 export function getTime(
-  time: Date | string | number | undefined,
+  time: Date | string | number | undefined | null,
 ): number | undefined {
   return parseTimePropertyValue(time);
 }
@@ -169,7 +169,7 @@ export function getTime(
  * @param time a time value
  */
 export function parseTimePropertyValue(
-  time: Date | string | number | undefined,
+  time: Date | string | number | undefined | null,
 ): number | undefined {
   if (time) {
     const parsed = new Date(time).getTime();

--- a/packages/integration-sdk-core/src/data/converters.ts
+++ b/packages/integration-sdk-core/src/data/converters.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'crypto';
-
 import camelCase from 'lodash/camelCase';
 
 const TRUE_REGEX = /^true$/i;
@@ -7,9 +6,11 @@ const FALSE_REGEX = /^false$/i;
 const BASE10_NUMBER_REGEX = /^\d+$/;
 const FLOAT_NUMBER_REGEX = /^\d+\.\d+$/;
 
-export function convertPropertyValue(value: string | undefined) {
+export function parseStringPropertyValue(
+  value: string,
+): string | boolean | number | undefined {
   if (!value) {
-    return value;
+    return undefined;
   }
   if (TRUE_REGEX.test(value)) {
     return true;
@@ -26,30 +27,71 @@ export function convertPropertyValue(value: string | undefined) {
   return value;
 }
 
+const TIME_PROPERTY_NAMES = /^\w+((T|_t)ime|(O|_o)n|(A|_a)t|(D|_d)ate)$/;
+function isTimeProperty(property: string): boolean {
+  return TIME_PROPERTY_NAMES.test(property);
+}
+
+type ConvertPropertiesOptions = {
+  /**
+   * Convert `Object` properties using `JSON.stringify(value)`. Without this
+   * option, `Object` properties are not transferred.
+   */
+  stringifyObject?: boolean;
+
+  /**
+   * Convert `Array` properties using `JSON.stringify(value)`. Without this
+   * option, `Array` properties are not transferred.
+   */
+  stringifyArray?: boolean;
+
+  /**
+   * Parse primitive properties (string, boolean, number). Without this
+   * option, values are transferred as-is.
+   */
+  parseString?: boolean;
+
+  /**
+   * Parse properties that are named with date/time-like suffixes into number of
+   * milliseconds since epoch (UNIX timestamp).
+   */
+  parseTime?: boolean;
+
+  /**
+   * Prefix property names as `<prefix>.<property>` when transferring to the
+   * converted object.
+   */
+  prefix?: string;
+};
+
 export function convertProperties(
   object: any = {},
-  options: {
-    stringifyObject?: boolean;
-    stringifyArray?: boolean;
-    parseString?: boolean;
-    prefix?: string;
-  } = {},
+  options: ConvertPropertiesOptions = {},
 ) {
   const supportedTypes = ['string', 'boolean', 'number'];
-  const flattenedObject: any = {};
+  const converted: any = {};
 
   for (const [key, value] of Object.entries(object)) {
+    if (value == null) {
+      continue;
+    }
+
     const newKey =
       options.prefix && options.prefix.length > 0
         ? `${options.prefix}.${camelCase(key)}`
         : camelCase(key);
 
     if (typeof value === 'boolean' || typeof value === 'number') {
-      flattenedObject[newKey] = value;
+      converted[newKey] = value;
     } else if (typeof value === 'string') {
-      flattenedObject[newKey] = options.parseString
-        ? convertPropertyValue(value)
-        : value;
+      if (options.parseString) {
+        converted[newKey] = parseStringPropertyValue(value);
+      } else if (options.parseTime && isTimeProperty(key)) {
+        const time = parseTimePropertyValue(value);
+        converted[newKey] = time ? time : value;
+      } else {
+        converted[newKey] = value;
+      }
     } else if (Array.isArray(value)) {
       const firstEntry = value.length > 0 ? value[0] : undefined;
       if (firstEntry == undefined) {
@@ -57,7 +99,7 @@ export function convertProperties(
       }
 
       if (options.stringifyArray) {
-        flattenedObject[newKey] = JSON.stringify(value);
+        converted[newKey] = JSON.stringify(value);
       } else {
         if (typeof firstEntry !== 'object' || options.stringifyObject) {
           const items: string[] | boolean[] | number[] = value.map((v) => {
@@ -68,16 +110,16 @@ export function convertProperties(
             }
           });
           if (items.length > 0) {
-            flattenedObject[newKey] = items;
+            converted[newKey] = items;
           }
         }
       }
     } else if (options.stringifyObject) {
-      flattenedObject[newKey] = JSON.stringify(value);
+      converted[newKey] = JSON.stringify(value);
     }
   }
 
-  return flattenedObject;
+  return converted;
 }
 
 interface NameValuePair {
@@ -103,22 +145,42 @@ export function convertNameValuePairs(
         options.prefix && options.prefix.length > 0
           ? `${options.prefix}.${camelCase(n)}`
           : camelCase(n);
-      const value = options.parseString ? convertPropertyValue(v) : v;
+      const value = options.parseString ? parseStringPropertyValue(v) : v;
       obj[key] = value;
     }
   }
   return obj;
 }
 
+/**
+ * @deprecated
+ * @see parseTimePropertyValue
+ */
 export function getTime(
   time: Date | string | number | undefined,
 ): number | undefined {
-  return time ? new Date(time).getTime() : undefined;
+  return parseTimePropertyValue(time);
 }
 
 /**
- * @description calculates the base64 sha256 hash of the
- * stringified object
+ * Produces a time value in milliseconds since epoch (UNIX timestamp) using `new
+ * Date(time).getTime()`.
+ *
+ * @param time a time value
+ */
+export function parseTimePropertyValue(
+  time: Date | string | number | undefined,
+): number | undefined {
+  if (time) {
+    const parsed = new Date(time).getTime();
+    if (!isNaN(parsed)) {
+      return parsed;
+    }
+  }
+}
+
+/**
+ * @description calculates the base64 sha256 hash of the stringified object
  * @param object object to hash stringified version of
  */
 export function sha256(object: object | string): string {

--- a/packages/integration-sdk-core/src/data/tagging.ts
+++ b/packages/integration-sdk-core/src/data/tagging.ts
@@ -1,4 +1,4 @@
-import { convertPropertyValue } from './converters';
+import { parseStringPropertyValue } from './converters';
 
 /**
  * A key/value tag associated with a resource in the provider. Some providers
@@ -119,7 +119,7 @@ function assignTagMap(
         tags.push(key);
       }
 
-      entity[`tag.${key}`] = convertPropertyValue(value);
+      entity[`tag.${key}`] = parseStringPropertyValue(value);
 
       const lowerKey = key.toLowerCase();
       if (lowerKey === 'name' && value) {

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- `convertProperties` supports an option `parseTime`, directing the function to
+  convert properties that are named with common suffixes (on, at, time, date) to
+  a UNIX timestamp (number).
+
 ## 1.1.1 - 2020-06-08
 
 ### Added


### PR DESCRIPTION
There's a form of this at https://github.com/JupiterOne/graph-cbdefense/blob/master/src/converters.ts#L105, it seemed good to bring it into this `convertProperties` function that is being used in a number of places.

I'd still like to make `createIntegrationEntity` do this work, but that will take more time to work through, and this will at least move closer to having the code in the converters of the sdk for re-used.