### PR TITLE
Expose silent version of runtime IntegrationLogger for createMockIntegrationLogger

### DIFF
--- a/packages/integration-sdk-testing/src/logger.ts
+++ b/packages/integration-sdk-testing/src/logger.ts
@@ -1,29 +1,25 @@
-import { IntegrationLogger } from '@jupiterone/integration-sdk-core';
-import noop from 'lodash/noop';
+import { IntegrationLogger } from '@jupiterone/integration-sdk-runtime';
+
+import Logger, { RingBuffer } from 'bunyan';
+
 export const noopAsync = () => Promise.resolve();
 
 export function createMockIntegrationLogger(): IntegrationLogger {
-  const logger: IntegrationLogger = {
-    trace: noop,
-    debug: noop,
-    info: noop,
-    warn: noop,
-    error: noop,
-    fatal: noop,
-    isHandledError: () => false,
-    stepStart: noop,
-    stepSuccess: noop,
-    stepFailure: noop,
-    synchronizationUploadStart: noop,
-    synchronizationUploadEnd: noop,
-    validationFailure: noop,
-    publishMetric: noop,
-    publishEvent: noop,
-    publishErrorEvent: noop,
-    child() {
-      return this;
-    },
-  };
+  const ringbuffer = new RingBuffer({ limit: 100 });
 
-  return logger;
+  const quietLogger = new Logger({
+    name: 'test',
+    streams: [
+      {
+        level: 'trace',
+        type: 'raw',
+        stream: ringbuffer,
+      },
+    ],
+  });
+
+  return new IntegrationLogger({
+    logger: quietLogger,
+    errorSet: new Set(),
+  });
 }

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Replace `createMockIntegrationLogger` implementation with a silent version of
+  the logger exposed by `@jupiterone/integration-sdk-runtime`.
+
 ## 2.0.0 - 2020-06-17
 
 ### Changed


### PR DESCRIPTION
This makes the mock test logger a little easier to maintain (no need to add noop for every new function added) and also makes testing the logger's publishing behavior in the managed runtime a lot easier.