### PR TITLE
Log handled config validation errors at level:40

### DIFF
--- a/packages/integration-sdk-cli/src/__tests__/cli-run-failure.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-run-failure.test.ts
@@ -88,7 +88,7 @@ test('does not log errors that have been previously logged', async () => {
 
   const isHandledErrorSpy = jest.spyOn(logger, 'isHandledError');
   const validationFailureSpy = jest.spyOn(logger, 'validationFailure');
-  const errorSpy = jest.spyOn(logger, 'error');
+  const warnSpy = jest.spyOn(logger, 'warn');
 
   jest.spyOn(logger, 'child').mockReturnValue(logger);
 
@@ -110,5 +110,5 @@ test('does not log errors that have been previously logged', async () => {
   expect(isHandledErrorSpy).toHaveBeenCalledWith(loggedError);
   expect(isHandledErrorSpy).toHaveReturnedWith(true);
 
-  expect(errorSpy).toHaveBeenCalledTimes(1);
+  expect(warnSpy).toHaveBeenCalledTimes(1);
 });

--- a/packages/integration-sdk-core/src/types/logger.ts
+++ b/packages/integration-sdk-core/src/types/logger.ts
@@ -69,14 +69,34 @@ interface BaseLogger {
 }
 
 export interface IntegrationLoggerFunctions {
+  /**
+   * Answers true when an error has already by handled by this logger instance
+   * (in `warn` or `error`).
+   *
+   * There are some errors which are handled in the context where they occur.
+   * Once they have been logged, they may be re-thrown to break out of that
+   * context, but they should not be logged again. This mechanism allows higher
+   * catch blocks to discover whether the logger has already handled an error
+   * and if so, to avoid double logging.
+   */
   isHandledError: IsHandledErrorFunction;
 
   // Special log functions used to publish events to j1
+
   stepStart: StepLogFunction;
   stepSuccess: StepLogFunction;
   stepFailure: StepLogFunctionWithError;
   synchronizationUploadStart: SynchronizationLogFunction;
   synchronizationUploadEnd: SynchronizationLogFunction;
+
+  /**
+   * Handles logging of errors that are raised in `validateInvocation`.
+   *
+   * `IntegrationValidationError` and `IntegrationProviderAuthenticationError`
+   * are logged at `level: 40`, expecting these to be user errors that should
+   * not alert in runtime environments. Other error types will be logged at
+   * `level: 50`.
+   */
   validationFailure: ValidationLogFunction;
 
   publishMetric: PublishMetricFunction;

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- The `validateInvocation` function will have certain types of errors it throws
+  (`IntegrationValidationError`, `IntegrationProviderAuthenticationError`)
+  logged at `level: 40` (warn) instead of `level: 50` (error). These are types
+  that are considered handled user errors and are expected to be communicated to
+  the user in a way that allows them to address the problem. All other error
+  types thrown from the function will continue to be logged at `level: 50`.
+
 ## 2.1.0 - 2020-06-19
 
 ### Changed


### PR DESCRIPTION
This aims to help runtime incident response. These user-addressable errors do not need to be level:50. I need this for the Azure integration. We have some Hacker-created junk integrations that are generating alerts.