### PR TITLE
Log out metrics that were collected via logger.publishMetric

### DIFF
--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -580,6 +580,34 @@ describe('publishMetric', () => {
       timestamp: expect.any(Number),
     });
   });
+
+  test('logs the metric', () => {
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    const infoSpy = jest.spyOn(logger, 'info');
+
+    logger.publishMetric({
+      name: 'metric',
+      value: 1000,
+      unit: 'Milliseconds',
+    });
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      {
+        metric: {
+          name: 'metric',
+          value: 1000,
+          unit: 'Milliseconds',
+          timestamp: expect.any(Number),
+        },
+      },
+      'Collected metric.',
+    );
+  });
 });
 
 describe('#publishEvent', () => {

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -289,10 +289,16 @@ export class IntegrationLogger extends EventEmitter
   }
 
   publishMetric(metric: Omit<Metric, 'timestamp'>) {
-    return this.emit('metric', {
+    const metricWithTimestamp = {
       ...metric,
       timestamp: Date.now(),
-    });
+    };
+
+    this.info({ metric: metricWithTimestamp }, 'Collected metric.');
+
+    // emit the metric so that consumers can collect the metric
+    // and publish it if needed
+    return this.emit('metric', metricWithTimestamp);
   }
 
   publishEvent(event: IntegrationEvent) {

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- `publishMetric` now logs the metric that is published.
+
 ### Changed
 
 - The `validateInvocation` function will have certain types of errors it throws


### PR DESCRIPTION
Since we are going to relying on log filtering for a bit, we might as well log the metric here. It's helpful for integration developers to see as well.