### PR TITLE
Visualize entities by type

### DIFF
--- a/packages/integration-sdk-cli/src/visualization/__tests__/__snapshots__/generateVisHTML.test.ts.snap
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/__snapshots__/generateVisHTML.test.ts.snap
@@ -47,7 +47,7 @@ exports[`renders html with default config 1`] = `
           nodes: nodes,
           edges: edges
         };
-        var options = {\\"edges\\":{\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}}};
+        var options = {\\"edges\\":{\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}},\\"physics\\":{\\"barnesHut\\":{\\"springLength\\":300,\\"centralGravity\\":0.03}}};
         var network = new vis.Network(container, data, options);
       </script>
     </body>

--- a/packages/integration-sdk-cli/src/visualization/__tests__/generateVisHTML.test.ts
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/generateVisHTML.test.ts
@@ -17,7 +17,7 @@ test('renders html with default config', () => {
   const html = generateVisHTML(nodeDataSets, edgeDataSet);
 
   expect(html).toContain(
-    'var options = {"edges":{"arrows":{"to":{"enabled":true}}}}',
+    'var options = {"edges":{"arrows":{"to":{"enabled":true}}},"physics":{"barnesHut":{"springLength":300,"centralGravity":0.03}}}',
   );
   expect(html).toMatchSnapshot();
 });

--- a/packages/integration-sdk-cli/src/visualization/generateVisHTML.ts
+++ b/packages/integration-sdk-cli/src/visualization/generateVisHTML.ts
@@ -8,7 +8,7 @@ export const nothingToDisplayMessage = 'There was no data found to visualize.';
 export function generateVisHTML(
   nodeDataSets: Node[],
   edgeDataSets: Edge[],
-  options: Options = { edges: { arrows: { to: { enabled: true } } } },
+  options: Options = { edges: { arrows: { to: { enabled: true } } }, physics: { barnesHut: { springLength: 300, centralGravity: 0.03 } } },
 ) {
   const displayVisualization =
     nodeDataSets.length > 0 || edgeDataSets.length > 0;

--- a/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
+++ b/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
@@ -31,7 +31,8 @@ export async function generateVisualization(
 
   const nodeDataSets = entities.map((entity) => ({
     id: entity._key,
-    label: entity.displayName,
+    label: `${entity.displayName}\n[${entity._type}]`,
+    group: entity._type,
   }));
   const edgeDataSets = relationships.map(
     (relationship): Edge => ({


### PR DESCRIPTION
Update the `j1-integration visualize` command to plot entities colored by type, as well as display the J1 type. 

I also changed the physics to bump entities away from eachother.

Formerly:
![Screen Shot 2020-07-24 at 4 52 00 PM](https://user-images.githubusercontent.com/15333061/88434386-0b9cbd80-cdce-11ea-9005-a7141498c03e.png)

Now: 
![Screen Shot 2020-07-24 at 4 50 59 PM](https://user-images.githubusercontent.com/15333061/88434394-11929e80-cdce-11ea-801f-115571fd8863.png)

