### PR TITLE
J1 visualize mapped relationships

### DIFF
--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -25,6 +25,7 @@
     "@jupiterone/integration-sdk-runtime": "^2.4.0",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
+    "lodash": "^4.17.19",
     "upath": "^1.2.0",
     "vis": "^4.21.0-EOL"
   },
@@ -33,11 +34,13 @@
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
+    "@types/lodash": "^4.14.158",
     "@types/pollyjs__adapter-node-http": "^2.0.0",
     "@types/pollyjs__core": "^4.0.0",
     "@types/pollyjs__persister": "^2.0.1",
     "@types/vis": "^4.21.20",
     "jsonwebtoken": "^8.5.1",
-    "memfs": "^3.2.0"
+    "memfs": "^3.2.0",
+    "uuid": "^8.2.0"
   }
 }

--- a/packages/integration-sdk-cli/src/visualization/__tests__/__snapshots__/generateVisHTML.test.ts.snap
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/__snapshots__/generateVisHTML.test.ts.snap
@@ -47,7 +47,7 @@ exports[`renders html with default config 1`] = `
           nodes: nodes,
           edges: edges
         };
-        var options = {\\"edges\\":{\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}}};
+        var options = {\\"edges\\":{\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}},\\"physics\\":{\\"barnesHut\\":{\\"springLength\\":300,\\"centralGravity\\":0.03}}};
         var network = new vis.Network(container, data, options);
       </script>
     </body>

--- a/packages/integration-sdk-cli/src/visualization/__tests__/createMappedRelationshipNodesAndEdges.test.ts
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/createMappedRelationshipNodesAndEdges.test.ts
@@ -1,0 +1,329 @@
+import { createMappedRelationshipNodesAndEdges } from "../createMappedRelationshipNodesAndEdges"
+import { RelationshipDirection } from "@jupiterone/integration-sdk-core/src"
+
+const mappedRelationships = [{
+  displayName: 'HAS',
+  _mapping: {
+    relationshipDirection: RelationshipDirection.FORWARD,
+    sourceEntityKey: '123',
+    targetFilterKeys: ['_key'],
+    targetEntity: {
+      _key: '456',
+    }
+  },
+  _key: 'abc',
+  _type: 'src_has_target',
+  _class: 'HAS',
+}];
+
+test('should return relationship between two existing entities', () => {
+  const explicitEntities = [
+    {
+      _key: '123',
+      _type: 'src',
+      _class: ['Account'],
+    },
+    {
+      _key: '456',
+      _type: 'target',
+      _class: ['User'],
+    }
+  ]
+
+  const {
+    mappedRelationshipEdges,
+    mappedRelationshipNodes,
+  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
+
+  expect(mappedRelationshipEdges).toEqual([
+    {
+      from: '123',
+      to: '456',
+      label: 'HAS',
+      dashes: true,
+    }
+  ]);
+
+  expect(mappedRelationshipNodes).toEqual([]);
+});
+
+test('should return MISSING entity when sourceEntityKey is not found in explicitEntities', () => {
+  const explicitEntities = [
+    {
+      _key: '456',
+      _type: 'target',
+      _class: ['User'],
+    }
+  ]
+
+  const {
+    mappedRelationshipEdges,
+    mappedRelationshipNodes,
+  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
+
+  expect(mappedRelationshipEdges).toEqual([
+    {
+      from: '123',
+      to: '456',
+      label: 'HAS',
+      dashes: true,
+    }
+  ]);
+
+  expect(mappedRelationshipNodes).toEqual([
+    {
+      id: '123',
+      color: 'red',
+      font: {
+        multi: 'html'
+      },
+      group: 'missing',
+      label: '<b>[MISSING ENTITY]</b>\n123',
+    }
+  ]);
+});
+
+test('should return PLACEHOLDER entity when targetEntity is not found in entities', () => {
+  const explicitEntities = [
+    {
+      _key: '123',
+      _type: 'source',
+      _class: ['Acccount'],
+    }
+  ]
+
+  const {
+    mappedRelationshipEdges,
+    mappedRelationshipNodes,
+  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
+
+  expect(mappedRelationshipEdges).toEqual([
+    {
+      from: '123',
+      to: '456',
+      label: 'HAS',
+      dashes: true,
+    }
+  ]);
+
+  expect(mappedRelationshipNodes).toEqual([
+    {
+      id: '456',
+      font: {
+        multi: 'html'
+      },
+      group: 'unknown',
+      label: '<b>[PLACEHOLDER ENTITY]</b>\n_key: "456"',
+    }
+  ]);
+});
+
+test('should only return one PLACEHOLDER entity when found in multiple relationships', () => {
+  const mappedRelationships = [
+    {
+      displayName: 'HAS',
+      _mapping: {
+        relationshipDirection: RelationshipDirection.FORWARD,
+        sourceEntityKey: '123',
+        targetFilterKeys: ['_key'],
+        targetEntity: {
+          _key: '789',
+        }
+      },
+      _key: 'abc',
+      _type: 'src_has_target',
+      _class: 'HAS',
+    },
+    {
+      displayName: 'HAS',
+      _mapping: {
+        relationshipDirection: RelationshipDirection.FORWARD,
+        sourceEntityKey: '456',
+        targetFilterKeys: ['_key'],
+        targetEntity: {
+          _key: '789',
+        }
+      },
+      _key: 'def',
+      _type: 'src_has_target',
+      _class: 'HAS',
+    }
+  ];
+  
+  const explicitEntities = [
+    {
+      _key: '123',
+      _type: 'source',
+      _class: ['Acccount'],
+    },
+    {
+      _key: '456',
+      _type: 'target',
+      _class: ['User'],
+    }
+  ]
+
+  const {
+    mappedRelationshipEdges,
+    mappedRelationshipNodes,
+  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
+
+  expect(mappedRelationshipEdges).toEqual([
+    {
+      from: '123',
+      to: '789',
+      label: 'HAS',
+      dashes: true,
+    },
+    {
+      from: '456',
+      to: '789',
+      label: 'HAS',
+      dashes: true,
+    },
+  ]);
+
+  expect(mappedRelationshipNodes).toEqual([
+    {
+      id: '789',
+      font: {
+        multi: 'html'
+      },
+      group: 'unknown',
+      label: '<b>[PLACEHOLDER ENTITY]</b>\n_key: "789"',
+    }
+  ]);
+});
+
+
+test('should return UUID for ID when PLACEHOLDER entity when found in multiple relationships', () => {
+  const mappedRelationships = [
+    {
+      displayName: 'HAS',
+      _mapping: {
+        relationshipDirection: RelationshipDirection.FORWARD,
+        sourceEntityKey: '123',
+        targetFilterKeys: ['_class'],
+        targetEntity: {
+          _class: '789',
+        }
+      },
+      _key: 'abc',
+      _type: 'src_has_target',
+      _class: 'HAS',
+    },
+    {
+      displayName: 'HAS',
+      _mapping: {
+        relationshipDirection: RelationshipDirection.FORWARD,
+        sourceEntityKey: '456',
+        targetFilterKeys: ['_class'],
+        targetEntity: {
+          _class: '789',
+        }
+      },
+      _key: 'def',
+      _type: 'src_has_target',
+      _class: 'HAS',
+    }
+  ];
+  
+  const explicitEntities = [
+    {
+      _key: '123',
+      _type: 'source',
+      _class: ['Acccount'],
+    },
+    {
+      _key: '456',
+      _type: 'target',
+      _class: ['User'],
+    }
+  ]
+
+  const {
+    mappedRelationshipEdges,
+    mappedRelationshipNodes,
+  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
+
+  expect(mappedRelationshipEdges).toEqual([
+    {
+      from: '123',
+      to: expect.any(String),
+      label: 'HAS',
+      dashes: true,
+    },
+    {
+      from: '456',
+      to: expect.any(String),
+      label: 'HAS',
+      dashes: true,
+    },
+  ]);
+  expect(mappedRelationshipEdges[0].to).toEqual(mappedRelationshipEdges[1].to);
+
+  expect(mappedRelationshipNodes).toEqual([
+    {
+      id: mappedRelationshipEdges[0].to,
+      font: {
+        multi: 'html'
+      },
+      group: 'unknown',
+      label: '<b>[PLACEHOLDER ENTITY]</b>\n_class: "789"',
+    }
+  ]);
+});
+
+
+test('should return node with group === _type when "_type" is targetFilterKey', () => {
+  const mappedRelationships = [
+    {
+      displayName: 'HAS',
+      _mapping: {
+        relationshipDirection: RelationshipDirection.FORWARD,
+        sourceEntityKey: '123',
+        targetFilterKeys: ['_type'],
+        targetEntity: {
+          _type: '789',
+        }
+      },
+      _key: 'abc',
+      _type: 'src_has_target',
+      _class: 'HAS',
+    }
+  ];
+  
+  const explicitEntities = [
+    {
+      _key: '123',
+      _type: 'source',
+      _class: ['Acccount'],
+    }
+  ]
+
+  const {
+    mappedRelationshipEdges,
+    mappedRelationshipNodes,
+  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
+
+  expect(mappedRelationshipEdges).toEqual([
+    {
+      from: '123',
+      to: expect.any(String),
+      label: 'HAS',
+      dashes: true,
+    },
+  ]);
+
+  expect(mappedRelationshipNodes).toEqual([
+    {
+      id: expect.any(String),
+      font: {
+        multi: 'html'
+      },
+      group: '789',
+      label: '<b>[PLACEHOLDER ENTITY]</b>\n_type: "789"',
+    }
+  ]);
+});
+

--- a/packages/integration-sdk-cli/src/visualization/__tests__/generateVisHTML.test.ts
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/generateVisHTML.test.ts
@@ -17,7 +17,7 @@ test('renders html with default config', () => {
   const html = generateVisHTML(nodeDataSets, edgeDataSet);
 
   expect(html).toContain(
-    'var options = {"edges":{"arrows":{"to":{"enabled":true}}}}',
+    'var options = {"edges":{"arrows":{"to":{"enabled":true}}},"physics":{"barnesHut":{"springLength":300,"centralGravity":0.03}}}',
   );
   expect(html).toMatchSnapshot();
 });

--- a/packages/integration-sdk-cli/src/visualization/__tests__/generateVisualization.test.ts
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/generateVisualization.test.ts
@@ -41,6 +41,7 @@ const integrationData: IntegrationData = {
     },
   ],
   relationships: [],
+  mappedRelationships: [],
 };
 
 beforeEach(() => {

--- a/packages/integration-sdk-cli/src/visualization/__tests__/retrieveIntegrationData.test.ts
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/retrieveIntegrationData.test.ts
@@ -28,6 +28,7 @@ const integrationData: IntegrationData = {
       toType: 'entity',
     }) as ExplicitRelationship,
   ],
+  mappedRelationships: [],
 };
 
 afterEach(() => {
@@ -53,7 +54,7 @@ test('returns the json objects read from the files', async () => {
   expect(result).toEqual(integrationData);
 });
 
-test('excludes mapped relationships', async () => {
+test('includes mapped relationships', async () => {
   const mappedRelationship = {
     _mapping: 'user_is_user',
     id: '123456',
@@ -69,5 +70,5 @@ test('excludes mapped relationships', async () => {
     `${integrationPath}/graph/entity/relationships/abc.json`,
   ]);
 
-  expect(result).toEqual(integrationData);
+  expect(result).toEqual({...integrationData, mappedRelationships: [{_mapping: 'user_is_user', id: '123456'}]});
 });

--- a/packages/integration-sdk-cli/src/visualization/createMappedRelationshipNodesAndEdges.ts
+++ b/packages/integration-sdk-cli/src/visualization/createMappedRelationshipNodesAndEdges.ts
@@ -1,0 +1,108 @@
+import { Node, Edge } from "vis";
+import { Entity, MappedRelationship, RelationshipDirection } from "@jupiterone/integration-sdk-core";
+import { isMatch } from "lodash";
+import { v4 as uuid } from 'uuid';
+
+interface MappedRelationshipNodesAndEdges {
+  mappedRelationshipNodes: Node[];
+  mappedRelationshipEdges: Edge[];
+}
+
+export function createMappedRelationshipNodesAndEdges(mappedRelationships: MappedRelationship[], explicitEntities: Entity[]): MappedRelationshipNodesAndEdges {
+  const mappedRelationshipNodes: Node[] = [];
+  const mappedRelationshipEdges: Edge[] = [];
+
+  const entities = [...explicitEntities];
+
+  for (const mappedRelationship of mappedRelationships) {
+    let sourceKey = explicitEntities.find((e) => e._key === mappedRelationship._mapping.sourceEntityKey)?._key;
+    if (sourceKey === undefined) {
+      // This should never happen! The "sourceEntity" ought to exist in the integration.
+      const sourceNode = createMissingEntity(mappedRelationship._mapping.sourceEntityKey);
+      mappedRelationshipNodes.push(sourceNode);
+      sourceKey = sourceNode.id as string;
+    }
+
+    let targetKey = entities.find((e) => isMatch(e, mappedRelationship._mapping.targetEntity))?._key;
+
+    if (targetKey === undefined) {
+      const targetNode = createPlaceholderEntity(mappedRelationship._mapping.targetEntity);
+      entities.push({
+        _key: targetNode.id as string,
+        ...(mappedRelationship._mapping.targetEntity),
+      } as Entity);
+      mappedRelationshipNodes.push(targetNode);
+      targetKey = targetNode.id
+    }
+
+    mappedRelationshipEdges.push(createMappedRelationshipEdge(sourceKey, targetKey, mappedRelationship.displayName, mappedRelationship._mapping.relationshipDirection))
+  }
+
+  return {
+    mappedRelationshipNodes,
+    mappedRelationshipEdges,
+  }
+}
+
+const MISSING_GROUP = 'missing';
+
+function createMissingEntity(sourceEntityKey: string): Node {
+  return {
+    id: sourceEntityKey,
+    label: `<b>[MISSING ENTITY]</b>\n${sourceEntityKey}`,
+    color: 'red',
+    group: MISSING_GROUP,
+    font: {
+      // required: enables displaying <b>text</b> in the label as bold text
+      multi: 'html',
+    }
+  };
+}
+
+const UNKNOWN_GROUP = 'unknown';
+
+/**
+ * 
+ * @param JSONableObject 
+ */
+function getWrappedJsonString(JSONableObject: object): string {
+  const keyValueArray: string[] = [];
+  for (const key of Object.keys(JSONableObject)) {
+    keyValueArray.push(`${key}: ${JSON.stringify(JSONableObject[key])}`);
+  }
+  return keyValueArray.join('\n');
+}
+
+function createPlaceholderEntity(targetEntity: Partial<Entity>) {
+  return {
+    id: targetEntity._key || uuid(),
+    label: `<b>[PLACEHOLDER ENTITY]</b>\n${getWrappedJsonString(targetEntity)}`,
+    group: targetEntity._type || UNKNOWN_GROUP,
+    font: {
+      // required: enables displaying <b>text</b> in the label as bold text
+      multi: 'html',
+    }
+  }
+}
+
+export function createMappedRelationshipEdge(sourceKey: string, targetKey: string, label: string | undefined, relationshipDirection: RelationshipDirection): Edge {
+  let fromKey: string;
+  let toKey: string;
+  switch (relationshipDirection) {
+    case RelationshipDirection.FORWARD:
+      fromKey = sourceKey;
+      toKey = targetKey;
+      break;
+    case RelationshipDirection.REVERSE:
+      fromKey = targetKey;
+      toKey = sourceKey;
+      break;
+  }
+
+  return {
+    from: fromKey,
+    to: toKey,
+    label,
+    dashes: true,
+  }
+}

--- a/packages/integration-sdk-cli/src/visualization/generateVisHTML.ts
+++ b/packages/integration-sdk-cli/src/visualization/generateVisHTML.ts
@@ -8,7 +8,7 @@ export const nothingToDisplayMessage = 'There was no data found to visualize.';
 export function generateVisHTML(
   nodeDataSets: Node[],
   edgeDataSets: Edge[],
-  options: Options = { edges: { arrows: { to: { enabled: true } } } },
+  options: Options = { edges: { arrows: { to: { enabled: true } } }, physics: { barnesHut: { springLength: 300, centralGravity: 0.03 } } },
 ) {
   const displayVisualization =
     nodeDataSets.length > 0 || edgeDataSets.length > 0;

--- a/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
+++ b/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
@@ -31,7 +31,8 @@ export async function generateVisualization(
 
   const nodeDataSets = entities.map((entity) => ({
     id: entity._key,
-    label: entity.displayName,
+    label: `${entity.displayName}\n[${entity._type}]`,
+    group: entity._type,
   }));
   const edgeDataSets = relationships.map(
     (relationship): Edge => ({

--- a/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
+++ b/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
@@ -8,6 +8,7 @@ import globby from 'globby';
 import upath from 'upath';
 
 import * as log from '../log';
+import { createMappedRelationshipNodesAndEdges } from './createMappedRelationshipNodesAndEdges';
 
 /**
  * Generates visualization of Vertices and Edges using https://visjs.github.io/vis-network/docs/network/
@@ -25,7 +26,7 @@ export async function generateVisualization(
     log.warn(`Unable to find any files under path: ${resolvedIntegrationPath}`);
   }
 
-  const { entities, relationships } = await retrieveIntegrationData(
+  const { entities, relationships, mappedRelationships } = await retrieveIntegrationData(
     entitiesAndRelationshipPaths,
   );
 
@@ -34,7 +35,7 @@ export async function generateVisualization(
     label: `${entity.displayName}\n[${entity._type}]`,
     group: entity._type,
   }));
-  const edgeDataSets = relationships.map(
+  const explicitEdgeDataSets = relationships.map(
     (relationship): Edge => ({
       from: relationship._fromEntityKey,
       to: relationship._toEntityKey,
@@ -42,11 +43,16 @@ export async function generateVisualization(
     }),
   );
 
+  const {
+    mappedRelationshipEdges, 
+    mappedRelationshipNodes,
+  } = createMappedRelationshipNodesAndEdges(mappedRelationships, entities);
+
   const htmlFileLocation = path.join(resolvedIntegrationPath, 'index.html');
 
   await writeFileToPath({
     path: htmlFileLocation,
-    content: generateVisHTML(nodeDataSets, edgeDataSets),
+    content: generateVisHTML([...nodeDataSets, ...mappedRelationshipNodes], [...explicitEdgeDataSets, ...mappedRelationshipEdges]),
   });
 
   return htmlFileLocation;

--- a/packages/integration-sdk-cli/src/visualization/retrieveIntegrationData.ts
+++ b/packages/integration-sdk-cli/src/visualization/retrieveIntegrationData.ts
@@ -1,4 +1,4 @@
-import { Entity, ExplicitRelationship } from '@jupiterone/integration-sdk-core';
+import { Entity, ExplicitRelationship, MappedRelationship } from '@jupiterone/integration-sdk-core';
 import { readJsonFromPath } from '@jupiterone/integration-sdk-runtime';
 import { IntegrationData } from './types/IntegrationData';
 
@@ -9,7 +9,8 @@ export async function retrieveIntegrationData(
   entitiesAndRelationshipPaths: string[],
 ): Promise<IntegrationData> {
   const entities: Entity[] = [];
-  const relationships: ExplicitRelationship[] = [];
+  const explicitRelationships: ExplicitRelationship[] = [];
+  const mappedRelationships: MappedRelationship[] = [];
 
   const entitiesAndRelationships = await Promise.all(
     entitiesAndRelationshipPaths.map(
@@ -26,18 +27,20 @@ export async function retrieveIntegrationData(
       }
 
       if (item.relationships && Array.isArray(item.relationships)) {
-        relationships.push(
-          ...item.relationships.filter(
-            (relationship) =>
-              typeof relationship === 'object' && !relationship._mapping,
-          ),
-        );
+        for (const relationship of item.relationships) {
+          if (typeof relationship === 'object' && !relationship._mapping) {
+            explicitRelationships.push(relationship);
+          } else {
+            mappedRelationships.push(relationship);
+          }
+        }
       }
     }
   }
 
   return {
     entities,
-    relationships,
+    relationships: explicitRelationships,
+    mappedRelationships,
   };
 }

--- a/packages/integration-sdk-cli/src/visualization/types/IntegrationData.ts
+++ b/packages/integration-sdk-cli/src/visualization/types/IntegrationData.ts
@@ -1,6 +1,7 @@
-import { Entity, ExplicitRelationship } from '@jupiterone/integration-sdk-core';
+import { Entity, ExplicitRelationship, MappedRelationship } from '@jupiterone/integration-sdk-core';
 
 export interface IntegrationData {
   entities: Entity[];
   relationships: ExplicitRelationship[];
+  mappedRelationships: MappedRelationship[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,6 +1638,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
   integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
 
+"@types/lodash@^4.14.158":
+  version "4.14.158"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.158.tgz#b38ea8b6fe799acd076d7a8d7ab71c26ef77f785"
+  integrity sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -5871,6 +5876,11 @@ lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
 log-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
@@ -8847,6 +8857,11 @@ uuid@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
   integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
+
+uuid@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
+  integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
Taking the visualization tool a bit further for mapped relationships. 

As developers create mapped relationships in the integration SDK, visualizing the output of these mapped relationships can help to catch bugs during development.

This PR mainly creates three additional types on the `j1-integration visualize` graph:
1. Mapped relationships are shown on the graph as dashed edges (as opposed to solid edges)
2. The `MappedRelationship._mapping.sourceEntityKey` from a mapped relationship is expected to map back to an entity in the integration. When the `sourceEntityKey` is not found in the list of existing entities, the graph displays a red entity with the header **[MISSING ENTITY]**
3. The `MappedRelationship._mapping.targetRelationship` can exist in the integration, or may exist in another integration. Mapped relationships can point to a discrete entity in the integration (see below, `Owner --TRUSTS--> Nick Dowmon`), but if the entity does not exist, it points to a new entity with the type **[PLACEHOLDER ENTITY]**, along with the expected properties of the placeholder.

Example: 
![Screen Shot 2020-07-24 at 4 54 46 PM](https://user-images.githubusercontent.com/15333061/88437302-2eca6b80-cdd4-11ea-883f-f3823e39aa1b.png)
