### PR TITLE
[J1-4221] Add getEntity() to the jobState

### DIFF
--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -295,6 +295,14 @@ await iterateEntities({ _type: 'my_integration_user' }, async (userEntity) => {
 });
 ```
 
+Specific entities can be looked up using `_key` and `_type` properties via the `getEntity` function.
+
+Example usage:
+
+```typescript
+const entity = getEntity({_type: 'my_integration_user', _key: 'some_unique_identifier'})
+```
+
 More details about how the framework uses `jobState` is detailed in the [Data
 collection](# Data collection) section below.
 
@@ -671,7 +679,7 @@ automatically flush the data to disk as a certain threshold of entities and
 relationships is met. The data flushed to disk are grouped in folders that based
 on the step that was run. Entities and relationships will also be grouped by the
 `_type` and linked into separate directories to provide faster look ups. These
-directories will be used by the `iterateEntities` and `iterateRelationships`
+directories will be used by the `getEntity`, `iterateEntities`, and `iterateRelationships`
 functions to provide faster lookups.
 
 From our experience, integrations most commonly query collected data from

--- a/packages/integration-sdk-core/src/errors.ts
+++ b/packages/integration-sdk-core/src/errors.ts
@@ -153,6 +153,15 @@ export class IntegrationDuplicateKeyError extends IntegrationError {
   }
 }
 
+export class IntegrationMissingKeyError extends IntegrationError {
+  constructor(message: string) {
+    super({
+      code: 'MISSING_KEY_ERROR',
+      message,
+    });
+  }
+}
+
 /**
  * An error that may be thrown by an integration during `validateInvocation`,
  * used to communicate something the user should see that can help them fix a

--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -4,6 +4,10 @@ export interface GraphObjectFilter {
   _type: string;
 }
 
+export interface GraphObjectLookupKey extends GraphObjectFilter {
+  _key: string;
+}
+
 export type GraphObjectIteratee<T> = (obj: T) => void | Promise<void>;
 
 /**
@@ -63,6 +67,12 @@ export interface JobState {
    * to add a single relationship to the collection.
    */
   addRelationships: (relationships: Relationship[]) => Promise<void>;
+
+  /**
+   * Gets an entity by _key and _type
+   * Throws when !== 1 entity
+   */
+  getEntity: (lookupKey: GraphObjectLookupKey) => Promise<Entity>
 
   /**
    * Allows a step to iterate all entities collected into the job state, limited

--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -4,7 +4,8 @@ export interface GraphObjectFilter {
   _type: string;
 }
 
-export interface GraphObjectLookupKey extends GraphObjectFilter {
+export interface GraphObjectLookupKey {
+  _type: string;
   _key: string;
 }
 

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -96,6 +96,10 @@ export function createStepJobState({
     },
     addRelationships,
 
+    getEntity: (lookupKey) => {
+      return graphObjectStore.getEntity(lookupKey)
+    },
+
     iterateEntities: (filter, iteratee) =>
       graphObjectStore.iterateEntities(filter, iteratee),
 

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -4,10 +4,11 @@ import { Sema } from 'async-sema';
 import {
   Entity,
   Relationship,
-  IntegrationError,
   GraphObjectLookupKey,
   GraphObjectFilter,
   GraphObjectIteratee,
+  IntegrationDuplicateKeyError,
+  IntegrationMissingKeyError,
 } from '@jupiterone/integration-sdk-core';
 
 import { flushDataToDisk } from './flushDataToDisk';
@@ -74,11 +75,14 @@ export class FileSystemGraphObjectStore {
       }
     );
 
-    if (entities.length !== 1) {
-      throw new IntegrationError({
-        code: 'GET_ENTITY_ERROR',
-        message: `Failed to find entity with _type=${_type}, _key=${_key}`,
-      });
+    if (entities.length === 0) {
+      throw new IntegrationMissingKeyError(
+        `Failed to find entity (_type=${_type}, _key=${_key})`,
+      );
+    } else if (entities.length > 1) {
+      throw new IntegrationDuplicateKeyError(
+        `Duplicate _key detected (_type=${_type}, _key=${_key})`,
+      )
     } else {
       return entities[0];
     }

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -279,7 +279,7 @@ describe('getEntity', () => {
       ...nonMatchingEntities,
     ]);
 
-    await expect(store.getEntity({ _type, _key })).rejects.toThrow(`Failed to find entity with _type=${_type}, _key=${_key}`);
+    await expect(store.getEntity({ _type, _key })).rejects.toThrow(`Failed to find entity (_type=${_type}, _key=${_key})`);
   });
 });
 

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -242,6 +242,47 @@ describe('addRelationships', () => {
   });
 });
 
+describe('getEntity', () => {
+  test('should flush buffered entities and get an entity by "_type" and "_key"', async () => {
+    const { storageDirectoryPath, store } = setupFileSystemObjectStore();
+
+    const _type = uuid();
+    const _key = uuid();
+
+    const nonMatchingEntities = times(25, () =>
+      generateEntity({ _type }),
+    );
+    const matchingEntity = generateEntity({ _type, _key })
+
+    await store.addEntities(storageDirectoryPath, [
+      ...nonMatchingEntities,
+      matchingEntity,
+    ]);
+
+    const entity = await store.getEntity({ _type, _key });
+    expect(store.entityStorageMap.totalItemCount).toEqual(0);
+
+    expect(entity).toEqual(matchingEntity);
+  });
+
+  test('should throw if entity is not found by "_type" and "_key"', async () => {
+    const { storageDirectoryPath, store } = setupFileSystemObjectStore();
+
+    const _type = uuid();
+    const _key = uuid();
+
+    const nonMatchingEntities = times(25, () =>
+      generateEntity({ _type }),
+    );
+
+    await store.addEntities(storageDirectoryPath, [
+      ...nonMatchingEntities,
+    ]);
+
+    await expect(store.getEntity({ _type, _key })).rejects.toThrow(`Failed to find entity with _type=${_type}, _key=${_key}`);
+  });
+});
+
 describe('iterateEntities', () => {
   test('should flush buffered entities and iterate the entity "_type" index stored on disk', async () => {
     const { storageDirectoryPath, store } = setupFileSystemObjectStore();

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added `getEntity({ _type, _key })` function
+- `j1-integration visualize`:
+  - Nodes (entities) are colored by `_type`.
+  - Mapped relationships are shown as dashed lines (edges)
+
 ## 2.4.0 - 2020-07-22
 
 ### Added

--- a/packages/integration-sdk/README.md
+++ b/packages/integration-sdk/README.md
@@ -11,3 +11,15 @@ This is now a shell package used to store historical information about the older
 
 If you are developing an integration, use the `@jupiterone/integration-sdk-core`
 and `@jupiterone/integration-sdk-cli` packages.
+
+## Versioning this project
+
+To version all packages in this project and tag the repo with a new version number, run the following (where `major.minor.patch` is the version you expect to move to):
+
+```shell
+git checkout -b release-<major>.<minor>.<patch>
+git push -u origin release-<major>.<minor>.<patch>
+yarn lerna version {major, minor, patch}
+```
+
+Note the `git checkout`/`git push` is required because Lerna will expect that you've already created a remote branch before bumping, tagging, and pushing the local changes to remote.


### PR DESCRIPTION
Gets an existing entity in the job state by `{ _key, _type }`. Throws if there is not *exactly* one match.