### PR TITLE
Pass the source `_type` to mapped relationships.

### DIFF
--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -295,6 +295,14 @@ await iterateEntities({ _type: 'my_integration_user' }, async (userEntity) => {
 });
 ```
 
+Specific entities can be looked up using `_key` and `_type` properties via the `getEntity` function.
+
+Example usage:
+
+```typescript
+const entity = getEntity({_type: 'my_integration_user', _key: 'some_unique_identifier'})
+```
+
 More details about how the framework uses `jobState` is detailed in the [Data
 collection](# Data collection) section below.
 
@@ -671,7 +679,7 @@ automatically flush the data to disk as a certain threshold of entities and
 relationships is met. The data flushed to disk are grouped in folders that based
 on the step that was run. Entities and relationships will also be grouped by the
 `_type` and linked into separate directories to provide faster look ups. These
-directories will be used by the `iterateEntities` and `iterateRelationships`
+directories will be used by the `getEntity`, `iterateEntities`, and `iterateRelationships`
 functions to provide faster lookups.
 
 From our experience, integrations most commonly query collected data from

--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
@@ -7,7 +7,70 @@ import {
 import {
   createIntegrationRelationship,
   generateRelationshipType,
+  createDirectRelationship,
+  createMappedRelationship,
 } from '../createIntegrationRelationship';
+
+describe('createIntegrationRelationship', () => {
+  const entityA: Entity = {
+    _type: 'a_entity',
+    _class: 'A',
+    _key: 'a',
+  };
+
+  const entityB: Entity = {
+    _type: 'b_entity',
+    _class: 'B',
+    _key: 'b',
+  };
+
+  test('creates direct relationships', () => {
+    const expected: Relationship = {
+      _type: 'a_entity_has_b_entity',
+      _class: 'HAS',
+      _key: 'a|has|b',
+      _fromEntityKey: 'a',
+      _toEntityKey: 'b',
+      displayName: 'HAS',
+    };
+
+    expect(
+      createIntegrationRelationship({
+        _class: 'HAS',
+        from: entityA,
+        to: entityB,
+      }),
+    ).toEqual(expected);
+  });
+
+  test('creates mapped relationships', () => {
+    const expected: MappedRelationship = {
+      _key: 'a|has|b',
+      _type: 'a_entity_has_b_entity',
+      _class: 'HAS',
+      _mapping: {
+        relationshipDirection: RelationshipDirection.FORWARD,
+        sourceEntityKey: 'a',
+        sourceEntityType: 'a_entity',
+        targetFilterKeys: [['_type', '_key']],
+        targetEntity: {
+          _key: 'b',
+          _class: 'B',
+          _type: 'b_entity',
+        },
+      },
+      displayName: 'HAS',
+    };
+
+    expect(
+      createMappedRelationship({
+        _class: 'HAS',
+        source: entityA,
+        target: entityB,
+      }),
+    ).toEqual(expected);
+  })
+});
 
 describe('DirectRelationshipOptions', () => {
   const entityA: Entity = {
@@ -33,7 +96,7 @@ describe('DirectRelationshipOptions', () => {
 
   test('defaults', () => {
     expect(
-      createIntegrationRelationship({
+      createDirectRelationship({
         _class: 'HAS',
         from: entityA,
         to: entityB,
@@ -43,7 +106,7 @@ describe('DirectRelationshipOptions', () => {
 
   test('_class is upcased', () => {
     expect(
-      createIntegrationRelationship({
+      createDirectRelationship({
         _class: 'has',
         from: entityA,
         to: entityB,
@@ -53,7 +116,7 @@ describe('DirectRelationshipOptions', () => {
 
   test('transfers additional properties', () => {
     expect(
-      createIntegrationRelationship({
+      createDirectRelationship({
         _class: 'HAS',
         from: entityA,
         to: entityB,
@@ -77,7 +140,7 @@ describe('DirectRelationshipLiteralOptions', () => {
 
   test('defaults', () => {
     expect(
-      createIntegrationRelationship({
+      createDirectRelationship({
         _class: 'HAS',
         fromKey: 'a',
         fromType: 'a_entity',
@@ -89,7 +152,7 @@ describe('DirectRelationshipLiteralOptions', () => {
 
   test('_class is upcased', () => {
     expect(
-      createIntegrationRelationship({
+      createDirectRelationship({
         _class: 'has',
         fromKey: 'a',
         fromType: 'a_entity',
@@ -133,7 +196,7 @@ describe('MappedRelationshipOptions', () => {
 
   test('defaults', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         source: entityA,
         target: entityB,
@@ -143,7 +206,7 @@ describe('MappedRelationshipOptions', () => {
 
   test('_class is upcased', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'has',
         source: entityA,
         target: entityB,
@@ -153,7 +216,7 @@ describe('MappedRelationshipOptions', () => {
 
   test('additional properties', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         source: entityA,
         target: entityB,
@@ -166,7 +229,7 @@ describe('MappedRelationshipOptions', () => {
 
   test('_type provided explicitly', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'has',
         _type: 'use_my_type',
         source: entityA,
@@ -180,7 +243,7 @@ describe('MappedRelationshipOptions', () => {
 
   test('_key provided explicitly', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'has',
         _key: 'use_my_key',
         source: entityA,
@@ -194,7 +257,7 @@ describe('MappedRelationshipOptions', () => {
 
   test('override defaults with properties option', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         source: entityA,
         target: entityB,
@@ -232,7 +295,7 @@ describe('MappedRelationshipLiteralOptions', () => {
 
   test('defaults', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         _mapping: {
           relationshipDirection: RelationshipDirection.REVERSE,
@@ -249,7 +312,7 @@ describe('MappedRelationshipLiteralOptions', () => {
 
   test('missing _type in targetEntity', () => {
     expect(() => {
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         _mapping: {
           relationshipDirection: RelationshipDirection.REVERSE,
@@ -266,7 +329,7 @@ describe('MappedRelationshipLiteralOptions', () => {
 
   test('_key provided explicitly', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         _key: 'my-key-please',
         _mapping: {
@@ -287,7 +350,7 @@ describe('MappedRelationshipLiteralOptions', () => {
 
   test('_type provided explicitly', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         _type: 'my_type_please',
         _mapping: {
@@ -308,7 +371,7 @@ describe('MappedRelationshipLiteralOptions', () => {
 
   test('sourceEntityType provided explicitly', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         _mapping: {
           relationshipDirection: RelationshipDirection.REVERSE,
@@ -333,7 +396,7 @@ describe('MappedRelationshipLiteralOptions', () => {
 
   test('override defaults with properties option', () => {
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         _mapping: {
           relationshipDirection: RelationshipDirection.REVERSE,
@@ -375,7 +438,7 @@ describe('MappedRelationshipLiteralOptions', () => {
     };
 
     expect(
-      createIntegrationRelationship({
+      createMappedRelationship({
         _class: 'HAS',
         _mapping: mapping,
       }),

--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
@@ -115,11 +115,12 @@ describe('MappedRelationshipOptions', () => {
 
   const expected: MappedRelationship = {
     _key: 'a|has|b',
-    _type: 'mapping_source_has_b_entity',
+    _type: 'a_entity_has_b_entity',
     _class: 'HAS',
     _mapping: {
       relationshipDirection: RelationshipDirection.FORWARD,
       sourceEntityKey: 'a',
+      sourceEntityType: 'a_entity',
       targetFilterKeys: [['_type', '_key']],
       targetEntity: {
         _key: 'b',
@@ -305,6 +306,31 @@ describe('MappedRelationshipLiteralOptions', () => {
     });
   });
 
+  test('sourceEntityType provided explicitly', () => {
+    expect(
+      createIntegrationRelationship({
+        _class: 'HAS',
+        _mapping: {
+          relationshipDirection: RelationshipDirection.REVERSE,
+          targetEntity: {
+            _key: 'b',
+            _type: 'b_entity',
+          },
+          targetFilterKeys: [['something']],
+          sourceEntityKey: 'a',
+          sourceEntityType: 'a_entity',
+        },
+      }),
+    ).toEqual({
+      ...expected,
+      _type: 'a_entity_has_b_entity',
+      _mapping: {
+        ...expected._mapping,
+        sourceEntityType: 'a_entity',
+      }
+    });
+  });
+
   test('override defaults with properties option', () => {
     expect(
       createIntegrationRelationship({
@@ -319,13 +345,13 @@ describe('MappedRelationshipLiteralOptions', () => {
         },
         properties: {
           _key: 'a-has-b',
-          _type: 'a_entity_has_b_entity',
+          _type: 'a_special_type',
         },
       }),
     ).toEqual({
       ...expected,
       _key: 'a-has-b',
-      _type: 'a_entity_has_b_entity',
+      _type: 'a_special_type',
       _mapping: {
         ...expected._mapping,
         targetEntity: {

--- a/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
@@ -129,11 +129,9 @@ type TargetEntity = TargetEntityProperties & {
 type AdditionalRelationshipProperties = { [key: string]: any };
 
 /**
- * Create an `IntegrationRelationship`.
- *
- * `DirectRelationshipOptions` and `MappedRelationshipOptions` are recommended
- * over literal forms. Older integrations may need to use the literal forms to
- * control values for some reason or other.
+ * @deprecated
+ * @see createDirectRelationship
+ * @see createMappedRelationship
  */
 export function createIntegrationRelationship(
   options:
@@ -142,10 +140,51 @@ export function createIntegrationRelationship(
     | MappedRelationshipOptions
     | MappedRelationshipLiteralOptions,
 ): Relationship {
-  if ('_mapping' in options) {
+  if ('_mapping' in options || 'target' in options) {
     return createMappedRelationship(options);
-  } else if ('target' in options) {
-    return createMappedRelationship({
+  } else {
+    return createDirectRelationship(options);
+  }
+}
+
+/**
+ * Create a direct `IntegrationRelationship` between two entities
+ *
+ * `DirectRelationshipOptions` is recommended over `DirectRelationshipOptionsLiteral`. Older integrations may need to use the literal forms to control values for some reason or other.
+ */
+export function createDirectRelationship(
+  options: DirectRelationshipOptions | DirectRelationshipLiteralOptions,
+): ExplicitRelationship {
+  //
+  if ('fromType' in options) {
+    return createRelationship(options);
+  //
+  } else {
+    return createRelationship({
+      _class: options._class,
+      fromType: options.from._type,
+      fromKey: options.from._key,
+      toType: options.to._type,
+      toKey: options.to._key,
+      properties: options.properties,
+    });
+  }
+}
+
+/**
+ * Create a mapped `IntegrationRelationship`.
+ *
+ * `MappedRelationshipOptions` is recommended over `MappedRelationshipOptionsLiteral`. Older integrations may need to use the literal forms to control values for some reason or other.
+ */
+export function createMappedRelationship(
+  options: MappedRelationshipOptions | MappedRelationshipLiteralOptions,
+): MappedRelationship {
+  // MappedRelationshipLiteralOptions
+  if ('_mapping' in options) {
+    return createMappedRelationshipLiteral(options);
+  // MappedRelationshipOptions
+  } else {
+    return createMappedRelationshipLiteral({
       _class: options._class,
       _type: options._type,
       _key: options._key,
@@ -160,21 +199,10 @@ export function createIntegrationRelationship(
       },
       properties: options.properties,
     });
-  } else if ('fromType' in options) {
-    return createRelationship(options);
-  } else {
-    return createRelationship({
-      _class: options._class,
-      fromType: options.from._type,
-      fromKey: options.from._key,
-      toType: options.to._type,
-      toKey: options.to._key,
-      properties: options.properties,
-    });
   }
 }
 
-function createMappedRelationship(
+function createMappedRelationshipLiteral(
   options: MappedRelationshipLiteralOptions,
 ): MappedRelationship {
   const mapping = options._mapping;

--- a/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
@@ -153,6 +153,7 @@ export function createIntegrationRelationship(
         relationshipDirection:
           options.relationshipDirection || RelationshipDirection.FORWARD,
         sourceEntityKey: options.source._key,
+        sourceEntityType: options.source._type,
         targetEntity: options.target,
         targetFilterKeys: options.targetFilterKeys || [['_type', '_key']],
         skipTargetCreation: options.skipTargetCreation,
@@ -196,7 +197,7 @@ function createMappedRelationship(
     type(
       options.properties,
       options._class,
-      'mapping_source',
+      mapping.sourceEntityType || 'mapping_source',
       mapping.targetEntity._type,
     );
 

--- a/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
@@ -177,10 +177,8 @@ export function createDirectRelationship(
 export function createMappedRelationship(
   options: MappedRelationshipOptions | MappedRelationshipLiteralOptions,
 ): MappedRelationship {
-  // MappedRelationshipLiteralOptions
   if ('_mapping' in options) {
     return createMappedRelationshipLiteral(options);
-  // MappedRelationshipOptions
   } else {
     return createMappedRelationshipLiteral({
       _class: options._class,

--- a/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
@@ -155,10 +155,8 @@ export function createIntegrationRelationship(
 export function createDirectRelationship(
   options: DirectRelationshipOptions | DirectRelationshipLiteralOptions,
 ): ExplicitRelationship {
-  //
   if ('fromType' in options) {
     return createRelationship(options);
-  //
   } else {
     return createRelationship({
       _class: options._class,

--- a/packages/integration-sdk-core/src/errors.ts
+++ b/packages/integration-sdk-core/src/errors.ts
@@ -153,6 +153,15 @@ export class IntegrationDuplicateKeyError extends IntegrationError {
   }
 }
 
+export class IntegrationMissingKeyError extends IntegrationError {
+  constructor(message: string) {
+    super({
+      code: 'MISSING_KEY_ERROR',
+      message,
+    });
+  }
+}
+
 /**
  * An error that may be thrown by an integration during `validateInvocation`,
  * used to communicate something the user should see that can help them fix a

--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -4,6 +4,10 @@ export interface GraphObjectFilter {
   _type: string;
 }
 
+export interface GraphObjectLookupKey extends GraphObjectFilter {
+  _key: string;
+}
+
 export type GraphObjectIteratee<T> = (obj: T) => void | Promise<void>;
 
 /**
@@ -63,6 +67,12 @@ export interface JobState {
    * to add a single relationship to the collection.
    */
   addRelationships: (relationships: Relationship[]) => Promise<void>;
+
+  /**
+   * Gets an entity by _key and _type
+   * Throws when !== 1 entity
+   */
+  getEntity: (lookupKey: GraphObjectLookupKey) => Promise<Entity>
 
   /**
    * Allows a step to iterate all entities collected into the job state, limited

--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -4,7 +4,8 @@ export interface GraphObjectFilter {
   _type: string;
 }
 
-export interface GraphObjectLookupKey extends GraphObjectFilter {
+export interface GraphObjectLookupKey {
+  _type: string;
   _key: string;
 }
 

--- a/packages/integration-sdk-core/src/types/relationship.ts
+++ b/packages/integration-sdk-core/src/types/relationship.ts
@@ -87,6 +87,11 @@ export interface RelationshipMapping {
   sourceEntityKey: string;
 
   /**
+   * The `_type` value of the entity managed by the integration. This allows generated relationship types to match entity types.
+   */
+  sourceEntityType?: string;
+
+  /**
    * Identifies properties in the `targetEntity` that are used to locate the
    * entites to connect to the `sourceEntityKey`. For example, if you know that
    * you want to build a relationship to user entities with a known email, this

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -96,6 +96,10 @@ export function createStepJobState({
     },
     addRelationships,
 
+    getEntity: (lookupKey) => {
+      return graphObjectStore.getEntity(lookupKey)
+    },
+
     iterateEntities: (filter, iteratee) =>
       graphObjectStore.iterateEntities(filter, iteratee),
 

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -4,10 +4,11 @@ import { Sema } from 'async-sema';
 import {
   Entity,
   Relationship,
-  IntegrationError,
   GraphObjectLookupKey,
   GraphObjectFilter,
   GraphObjectIteratee,
+  IntegrationDuplicateKeyError,
+  IntegrationMissingKeyError,
 } from '@jupiterone/integration-sdk-core';
 
 import { flushDataToDisk } from './flushDataToDisk';
@@ -74,11 +75,14 @@ export class FileSystemGraphObjectStore {
       }
     );
 
-    if (entities.length !== 1) {
-      throw new IntegrationError({
-        code: 'GET_ENTITY_ERROR',
-        message: `Failed to find entity with _type=${_type}, _key=${_key}`,
-      });
+    if (entities.length === 0) {
+      throw new IntegrationMissingKeyError(
+        `Failed to find entity (_type=${_type}, _key=${_key})`,
+      );
+    } else if (entities.length > 1) {
+      throw new IntegrationDuplicateKeyError(
+        `Duplicate _key detected (_type=${_type}, _key=${_key})`,
+      )
     } else {
       return entities[0];
     }

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -279,7 +279,7 @@ describe('getEntity', () => {
       ...nonMatchingEntities,
     ]);
 
-    await expect(store.getEntity({ _type, _key })).rejects.toThrow(`Failed to find entity with _type=${_type}, _key=${_key}`);
+    await expect(store.getEntity({ _type, _key })).rejects.toThrow(`Failed to find entity (_type=${_type}, _key=${_key})`);
   });
 });
 

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -242,6 +242,47 @@ describe('addRelationships', () => {
   });
 });
 
+describe('getEntity', () => {
+  test('should flush buffered entities and get an entity by "_type" and "_key"', async () => {
+    const { storageDirectoryPath, store } = setupFileSystemObjectStore();
+
+    const _type = uuid();
+    const _key = uuid();
+
+    const nonMatchingEntities = times(25, () =>
+      generateEntity({ _type }),
+    );
+    const matchingEntity = generateEntity({ _type, _key })
+
+    await store.addEntities(storageDirectoryPath, [
+      ...nonMatchingEntities,
+      matchingEntity,
+    ]);
+
+    const entity = await store.getEntity({ _type, _key });
+    expect(store.entityStorageMap.totalItemCount).toEqual(0);
+
+    expect(entity).toEqual(matchingEntity);
+  });
+
+  test('should throw if entity is not found by "_type" and "_key"', async () => {
+    const { storageDirectoryPath, store } = setupFileSystemObjectStore();
+
+    const _type = uuid();
+    const _key = uuid();
+
+    const nonMatchingEntities = times(25, () =>
+      generateEntity({ _type }),
+    );
+
+    await store.addEntities(storageDirectoryPath, [
+      ...nonMatchingEntities,
+    ]);
+
+    await expect(store.getEntity({ _type, _key })).rejects.toThrow(`Failed to find entity with _type=${_type}, _key=${_key}`);
+  });
+});
+
 describe('iterateEntities', () => {
   test('should flush buffered entities and iterate the entity "_type" index stored on disk', async () => {
     const { storageDirectoryPath, store } = setupFileSystemObjectStore();

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 ### Added
 
 - Added `getEntity({ _type, _key })` function
+- Added optional `sourceEntityType` property on `RelationshipMapping`
 
 ## 2.5.0 - 2020-07-28
 

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added `getEntity({ _type, _key })` function
+- `j1-integration visualize`:
+  - Nodes (entities) are colored by `_type`.
+  - Mapped relationships are shown as dashed lines (edges)
+
 ## 2.4.0 - 2020-07-22
 
 ### Added

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 - Added `getEntity({ _type, _key })` function
 - Added optional `sourceEntityType` property on `RelationshipMapping`
 
+### Changed
+
+- Deprecated `createIntegrationRelationship`. Developers should use the exported `createDirectRelationship` or `createMappedRelationship` functions.
+
 ## 2.5.0 - 2020-07-28
 
 ### Added

--- a/packages/integration-sdk/README.md
+++ b/packages/integration-sdk/README.md
@@ -11,3 +11,15 @@ This is now a shell package used to store historical information about the older
 
 If you are developing an integration, use the `@jupiterone/integration-sdk-core`
 and `@jupiterone/integration-sdk-cli` packages.
+
+## Versioning this project
+
+To version all packages in this project and tag the repo with a new version number, run the following (where `major.minor.patch` is the version you expect to move to):
+
+```shell
+git checkout -b release-<major>.<minor>.<patch>
+git push -u origin release-<major>.<minor>.<patch>
+yarn lerna version {major, minor, patch}
+```
+
+Note the `git checkout`/`git push` is required because Lerna will expect that you've already created a remote branch before bumping, tagging, and pushing the local changes to remote.


### PR DESCRIPTION
Allow mapped relationships to receive the source `_type`, either from the `source` property on `MappedRelationshipOptions`, or the optional `_mapping.sourceEntityType` property on `MappedRelationshipOptionsLiteral`.

Since this was related to #62 as well, I deprecated `createIntegrationRelationship` and exported `createDirectRelationship` and `createMappedRelationship`. These changes are in a separate commit from the primary functionality above.