### PR TITLE
J1-4227: Match array/string _class in visualize

### DIFF
--- a/packages/integration-sdk-cli/src/visualization/__tests__/createMappedRelationshipNodesAndEdges.test.ts
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/createMappedRelationshipNodesAndEdges.test.ts
@@ -1,329 +1,440 @@
-import { createMappedRelationshipNodesAndEdges } from "../createMappedRelationshipNodesAndEdges"
+import { createMappedRelationshipNodesAndEdges, isClassMatch, findTargetEntity } from "../createMappedRelationshipNodesAndEdges"
 import { RelationshipDirection } from "@jupiterone/integration-sdk-core/src"
 
-const mappedRelationships = [{
-  displayName: 'HAS',
-  _mapping: {
-    relationshipDirection: RelationshipDirection.FORWARD,
-    sourceEntityKey: '123',
-    targetFilterKeys: ['_key'],
-    targetEntity: {
-      _key: '456',
-    }
-  },
-  _key: 'abc',
-  _type: 'src_has_target',
-  _class: 'HAS',
-}];
-
-test('should return relationship between two existing entities', () => {
-  const explicitEntities = [
-    {
-      _key: '123',
-      _type: 'src',
-      _class: ['Account'],
+describe('#createMappedRelationshipNodesAndEdges', () => {
+  const mappedRelationships = [{
+    displayName: 'HAS',
+    _mapping: {
+      relationshipDirection: RelationshipDirection.FORWARD,
+      sourceEntityKey: '123',
+      targetFilterKeys: ['_key'],
+      targetEntity: {
+        _key: '456',
+      }
     },
-    {
-      _key: '456',
-      _type: 'target',
-      _class: ['User'],
-    }
-  ]
+    _key: 'abc',
+    _type: 'src_has_target',
+    _class: 'HAS',
+  }];
 
-  const {
-    mappedRelationshipEdges,
-    mappedRelationshipNodes,
-  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
+  test('should return relationship between two existing entities', () => {
+    const explicitEntities = [
+      {
+        _key: '123',
+        _type: 'src',
+        _class: ['Account'],
+      },
+      {
+        _key: '456',
+        _type: 'target',
+        _class: ['User'],
+      }
+    ]
 
-  expect(mappedRelationshipEdges).toEqual([
-    {
-      from: '123',
-      to: '456',
-      label: 'HAS',
-      dashes: true,
-    }
-  ]);
+    const {
+      mappedRelationshipEdges,
+      mappedRelationshipNodes,
+    } = createMappedRelationshipNodesAndEdges({mappedRelationships, explicitEntities});
 
-  expect(mappedRelationshipNodes).toEqual([]);
+    expect(mappedRelationshipEdges).toEqual([
+      {
+        from: '123',
+        to: '456',
+        label: 'HAS',
+        dashes: true,
+      }
+    ]);
+
+    expect(mappedRelationshipNodes).toEqual([]);
+  });
+
+  test('should return MISSING entity when sourceEntityKey is not found in explicitEntities', () => {
+    const explicitEntities = [
+      {
+        _key: '456',
+        _type: 'target',
+        _class: ['User'],
+      }
+    ]
+
+    const {
+      mappedRelationshipEdges,
+      mappedRelationshipNodes,
+    } = createMappedRelationshipNodesAndEdges({mappedRelationships, explicitEntities});
+
+    expect(mappedRelationshipEdges).toEqual([
+      {
+        from: '123',
+        to: '456',
+        label: 'HAS',
+        dashes: true,
+      }
+    ]);
+
+    expect(mappedRelationshipNodes).toEqual([
+      {
+        id: '123',
+        color: 'red',
+        font: {
+          multi: 'html'
+        },
+        group: 'missing',
+        label: '<b>[MISSING ENTITY]</b>\n123',
+      }
+    ]);
+  });
+
+  test('should return PLACEHOLDER entity when targetEntity is not found in entities', () => {
+    const explicitEntities = [
+      {
+        _key: '123',
+        _type: 'source',
+        _class: ['Acccount'],
+      }
+    ]
+
+    const {
+      mappedRelationshipEdges,
+      mappedRelationshipNodes,
+    } = createMappedRelationshipNodesAndEdges({mappedRelationships, explicitEntities});
+
+    expect(mappedRelationshipEdges).toEqual([
+      {
+        from: '123',
+        to: '456',
+        label: 'HAS',
+        dashes: true,
+      }
+    ]);
+
+    expect(mappedRelationshipNodes).toEqual([
+      {
+        id: '456',
+        font: {
+          multi: 'html'
+        },
+        group: 'unknown',
+        label: '<b>[PLACEHOLDER ENTITY]</b>\n_key: "456"',
+      }
+    ]);
+  });
+
+  test('should only return one PLACEHOLDER entity when found in multiple relationships', () => {
+    const mappedRelationships = [
+      {
+        displayName: 'HAS',
+        _mapping: {
+          relationshipDirection: RelationshipDirection.FORWARD,
+          sourceEntityKey: '123',
+          targetFilterKeys: ['_key'],
+          targetEntity: {
+            _key: '789',
+          }
+        },
+        _key: 'abc',
+        _type: 'src_has_target',
+        _class: 'HAS',
+      },
+      {
+        displayName: 'HAS',
+        _mapping: {
+          relationshipDirection: RelationshipDirection.FORWARD,
+          sourceEntityKey: '456',
+          targetFilterKeys: ['_key'],
+          targetEntity: {
+            _key: '789',
+          }
+        },
+        _key: 'def',
+        _type: 'src_has_target',
+        _class: 'HAS',
+      }
+    ];
+    
+    const explicitEntities = [
+      {
+        _key: '123',
+        _type: 'source',
+        _class: ['Acccount'],
+      },
+      {
+        _key: '456',
+        _type: 'target',
+        _class: ['User'],
+      }
+    ]
+
+    const {
+      mappedRelationshipEdges,
+      mappedRelationshipNodes,
+    } = createMappedRelationshipNodesAndEdges({mappedRelationships, explicitEntities});
+
+    expect(mappedRelationshipEdges).toEqual([
+      {
+        from: '123',
+        to: '789',
+        label: 'HAS',
+        dashes: true,
+      },
+      {
+        from: '456',
+        to: '789',
+        label: 'HAS',
+        dashes: true,
+      },
+    ]);
+
+    expect(mappedRelationshipNodes).toEqual([
+      {
+        id: '789',
+        font: {
+          multi: 'html'
+        },
+        group: 'unknown',
+        label: '<b>[PLACEHOLDER ENTITY]</b>\n_key: "789"',
+      }
+    ]);
+  });
+
+  test('should return UUID for ID when PLACEHOLDER entity when found in multiple relationships', () => {
+    const mappedRelationships = [
+      {
+        displayName: 'HAS',
+        _mapping: {
+          relationshipDirection: RelationshipDirection.FORWARD,
+          sourceEntityKey: '123',
+          targetFilterKeys: ['_class'],
+          targetEntity: {
+            _class: '789',
+          }
+        },
+        _key: 'abc',
+        _type: 'src_has_target',
+        _class: 'HAS',
+      },
+      {
+        displayName: 'HAS',
+        _mapping: {
+          relationshipDirection: RelationshipDirection.FORWARD,
+          sourceEntityKey: '456',
+          targetFilterKeys: ['_class'],
+          targetEntity: {
+            _class: '789',
+          }
+        },
+        _key: 'def',
+        _type: 'src_has_target',
+        _class: 'HAS',
+      }
+    ];
+    
+    const explicitEntities = [
+      {
+        _key: '123',
+        _type: 'source',
+        _class: ['Acccount'],
+      },
+      {
+        _key: '456',
+        _type: 'target',
+        _class: ['User'],
+      }
+    ]
+
+    const {
+      mappedRelationshipEdges,
+      mappedRelationshipNodes,
+    } = createMappedRelationshipNodesAndEdges({mappedRelationships, explicitEntities});
+
+    expect(mappedRelationshipEdges).toEqual([
+      {
+        from: '123',
+        to: expect.any(String),
+        label: 'HAS',
+        dashes: true,
+      },
+      {
+        from: '456',
+        to: expect.any(String),
+        label: 'HAS',
+        dashes: true,
+      },
+    ]);
+    expect(mappedRelationshipEdges[0].to).toEqual(mappedRelationshipEdges[1].to);
+
+    expect(mappedRelationshipNodes).toEqual([
+      {
+        id: mappedRelationshipEdges[0].to,
+        font: {
+          multi: 'html'
+        },
+        group: 'unknown',
+        label: '<b>[PLACEHOLDER ENTITY]</b>\n_class: "789"',
+      }
+    ]);
+  });
+
+  test('should return node with group === _type when "_type" is targetFilterKey', () => {
+    const mappedRelationships = [
+      {
+        displayName: 'HAS',
+        _mapping: {
+          relationshipDirection: RelationshipDirection.FORWARD,
+          sourceEntityKey: '123',
+          targetFilterKeys: ['_type'],
+          targetEntity: {
+            _type: '789',
+          }
+        },
+        _key: 'abc',
+        _type: 'src_has_target',
+        _class: 'HAS',
+      }
+    ];
+    
+    const explicitEntities = [
+      {
+        _key: '123',
+        _type: 'source',
+        _class: ['Acccount'],
+      }
+    ]
+
+    const {
+      mappedRelationshipEdges,
+      mappedRelationshipNodes,
+    } = createMappedRelationshipNodesAndEdges({mappedRelationships, explicitEntities});
+
+    expect(mappedRelationshipEdges).toEqual([
+      {
+        from: '123',
+        to: expect.any(String),
+        label: 'HAS',
+        dashes: true,
+      },
+    ]);
+
+    expect(mappedRelationshipNodes).toEqual([
+      {
+        id: expect.any(String),
+        font: {
+          multi: 'html'
+        },
+        group: '789',
+        label: '<b>[PLACEHOLDER ENTITY]</b>\n_type: "789"',
+      }
+    ]);
+  });
+
+  test('should return DUPLICATE KEY when duplicate non-matching entity found', () => {
+    const mappedRelationships = [
+      {
+        displayName: 'HAS',
+        _mapping: {
+          relationshipDirection: RelationshipDirection.FORWARD,
+          sourceEntityKey: '123',
+          targetFilterKeys: [['_key', '_type']],
+          targetEntity: {
+            _key: '456',
+            _type: 'non-matching-target',
+          }
+        },
+        _key: 'abc',
+        _type: 'src_has_target',
+        _class: 'HAS',
+      },
+    ];
+    
+    const explicitEntities = [
+      {
+        _key: '123',
+        _type: 'source',
+        _class: ['Acccount'],
+      },
+      {
+        _key: '456',
+        _type: 'target',
+        _class: ['User'],
+      }
+    ]
+
+    const {
+      mappedRelationshipEdges,
+      mappedRelationshipNodes,
+    } = createMappedRelationshipNodesAndEdges({mappedRelationships, explicitEntities});
+
+    expect(mappedRelationshipEdges).toEqual([
+      {
+        from: '123',
+        to: expect.not.stringMatching('456'),
+        label: 'HAS',
+        dashes: true,
+      },
+    ]);
+
+    expect(mappedRelationshipNodes).toEqual([
+      {
+        id: mappedRelationshipEdges[0].to,
+        color: 'red',
+        font: {
+          multi: 'html'
+        },
+        group: 'non-matching-target',
+        label: '<b>[DUPLICATE _KEY][PLACEHOLDER ENTITY]</b>\n_key: "456"\n_type: "non-matching-target"',
+      }
+    ]);
+  });
 });
 
-test('should return MISSING entity when sourceEntityKey is not found in explicitEntities', () => {
-  const explicitEntities = [
-    {
-      _key: '456',
-      _type: 'target',
-      _class: ['User'],
-    }
-  ]
-
-  const {
-    mappedRelationshipEdges,
-    mappedRelationshipNodes,
-  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
-
-  expect(mappedRelationshipEdges).toEqual([
-    {
-      from: '123',
-      to: '456',
-      label: 'HAS',
-      dashes: true,
-    }
-  ]);
-
-  expect(mappedRelationshipNodes).toEqual([
-    {
-      id: '123',
-      color: 'red',
-      font: {
-        multi: 'html'
+describe('#findTargetEntity', () => {
+  test('should not match entity with same key but different other props', () => {
+    const _mapping = {
+      relationshipDirection: RelationshipDirection.FORWARD,
+      sourceEntityKey: '123',
+      targetFilterKeys: [['_key', '_type']],
+      targetEntity: {
+        _key: '456',
+        _type: 'non-matching-target',
+      }
+    };
+    
+    const nodeEntities = [
+      {
+        _key: '456',
+        _type: 'target',
+        _class: ['User'],
+        nodeId: '456',
       },
-      group: 'missing',
-      label: '<b>[MISSING ENTITY]</b>\n123',
-    }
-  ]);
+    ];
+    
+    const response = findTargetEntity(nodeEntities, _mapping);
+
+    expect(response).toBeUndefined();
+  })
 });
 
-test('should return PLACEHOLDER entity when targetEntity is not found in entities', () => {
-  const explicitEntities = [
-    {
-      _key: '123',
-      _type: 'source',
-      _class: ['Acccount'],
-    }
-  ]
+describe('#isClassMatch', () => {
+  test('should match when matching array', () => {
+    expect(isClassMatch(['User'], ['User'])).toEqual(true);
+  });
 
-  const {
-    mappedRelationshipEdges,
-    mappedRelationshipNodes,
-  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
+  test('should match when matching string', () => {
+    expect(isClassMatch('User', 'User')).toEqual(true);
+  });
 
-  expect(mappedRelationshipEdges).toEqual([
-    {
-      from: '123',
-      to: '456',
-      label: 'HAS',
-      dashes: true,
-    }
-  ]);
+  test('should match when target string is only element in array', () => {
+    expect(isClassMatch(['User'], 'User')).toEqual(true);
+  });
 
-  expect(mappedRelationshipNodes).toEqual([
-    {
-      id: '456',
-      font: {
-        multi: 'html'
-      },
-      group: 'unknown',
-      label: '<b>[PLACEHOLDER ENTITY]</b>\n_key: "456"',
-    }
-  ]);
+  test('should match when target string in array', () => {
+    expect(isClassMatch(['User', 'Group'], 'User')).toEqual(true);
+  });
+
+  test('should match when target array in array', () => {
+    expect(isClassMatch(['User', 'Group', 'Account'], ['User', 'Group'])).toEqual(true);
+  });
+
+  test('should not match when classes differ', () => {
+    expect(isClassMatch('User', 'Group')).toEqual(false);
+  });
 });
-
-test('should only return one PLACEHOLDER entity when found in multiple relationships', () => {
-  const mappedRelationships = [
-    {
-      displayName: 'HAS',
-      _mapping: {
-        relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: '123',
-        targetFilterKeys: ['_key'],
-        targetEntity: {
-          _key: '789',
-        }
-      },
-      _key: 'abc',
-      _type: 'src_has_target',
-      _class: 'HAS',
-    },
-    {
-      displayName: 'HAS',
-      _mapping: {
-        relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: '456',
-        targetFilterKeys: ['_key'],
-        targetEntity: {
-          _key: '789',
-        }
-      },
-      _key: 'def',
-      _type: 'src_has_target',
-      _class: 'HAS',
-    }
-  ];
-  
-  const explicitEntities = [
-    {
-      _key: '123',
-      _type: 'source',
-      _class: ['Acccount'],
-    },
-    {
-      _key: '456',
-      _type: 'target',
-      _class: ['User'],
-    }
-  ]
-
-  const {
-    mappedRelationshipEdges,
-    mappedRelationshipNodes,
-  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
-
-  expect(mappedRelationshipEdges).toEqual([
-    {
-      from: '123',
-      to: '789',
-      label: 'HAS',
-      dashes: true,
-    },
-    {
-      from: '456',
-      to: '789',
-      label: 'HAS',
-      dashes: true,
-    },
-  ]);
-
-  expect(mappedRelationshipNodes).toEqual([
-    {
-      id: '789',
-      font: {
-        multi: 'html'
-      },
-      group: 'unknown',
-      label: '<b>[PLACEHOLDER ENTITY]</b>\n_key: "789"',
-    }
-  ]);
-});
-
-
-test('should return UUID for ID when PLACEHOLDER entity when found in multiple relationships', () => {
-  const mappedRelationships = [
-    {
-      displayName: 'HAS',
-      _mapping: {
-        relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: '123',
-        targetFilterKeys: ['_class'],
-        targetEntity: {
-          _class: '789',
-        }
-      },
-      _key: 'abc',
-      _type: 'src_has_target',
-      _class: 'HAS',
-    },
-    {
-      displayName: 'HAS',
-      _mapping: {
-        relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: '456',
-        targetFilterKeys: ['_class'],
-        targetEntity: {
-          _class: '789',
-        }
-      },
-      _key: 'def',
-      _type: 'src_has_target',
-      _class: 'HAS',
-    }
-  ];
-  
-  const explicitEntities = [
-    {
-      _key: '123',
-      _type: 'source',
-      _class: ['Acccount'],
-    },
-    {
-      _key: '456',
-      _type: 'target',
-      _class: ['User'],
-    }
-  ]
-
-  const {
-    mappedRelationshipEdges,
-    mappedRelationshipNodes,
-  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
-
-  expect(mappedRelationshipEdges).toEqual([
-    {
-      from: '123',
-      to: expect.any(String),
-      label: 'HAS',
-      dashes: true,
-    },
-    {
-      from: '456',
-      to: expect.any(String),
-      label: 'HAS',
-      dashes: true,
-    },
-  ]);
-  expect(mappedRelationshipEdges[0].to).toEqual(mappedRelationshipEdges[1].to);
-
-  expect(mappedRelationshipNodes).toEqual([
-    {
-      id: mappedRelationshipEdges[0].to,
-      font: {
-        multi: 'html'
-      },
-      group: 'unknown',
-      label: '<b>[PLACEHOLDER ENTITY]</b>\n_class: "789"',
-    }
-  ]);
-});
-
-
-test('should return node with group === _type when "_type" is targetFilterKey', () => {
-  const mappedRelationships = [
-    {
-      displayName: 'HAS',
-      _mapping: {
-        relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: '123',
-        targetFilterKeys: ['_type'],
-        targetEntity: {
-          _type: '789',
-        }
-      },
-      _key: 'abc',
-      _type: 'src_has_target',
-      _class: 'HAS',
-    }
-  ];
-  
-  const explicitEntities = [
-    {
-      _key: '123',
-      _type: 'source',
-      _class: ['Acccount'],
-    }
-  ]
-
-  const {
-    mappedRelationshipEdges,
-    mappedRelationshipNodes,
-  } = createMappedRelationshipNodesAndEdges(mappedRelationships, explicitEntities);
-
-  expect(mappedRelationshipEdges).toEqual([
-    {
-      from: '123',
-      to: expect.any(String),
-      label: 'HAS',
-      dashes: true,
-    },
-  ]);
-
-  expect(mappedRelationshipNodes).toEqual([
-    {
-      id: expect.any(String),
-      font: {
-        multi: 'html'
-      },
-      group: '789',
-      label: '<b>[PLACEHOLDER ENTITY]</b>\n_type: "789"',
-    }
-  ]);
-});
-

--- a/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
+++ b/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
@@ -9,6 +9,7 @@ import upath from 'upath';
 
 import * as log from '../log';
 import { createMappedRelationshipNodesAndEdges } from './createMappedRelationshipNodesAndEdges';
+import { getNodeIdFromEntity } from './utils';
 
 /**
  * Generates visualization of Vertices and Edges using https://visjs.github.io/vis-network/docs/network/
@@ -31,7 +32,7 @@ export async function generateVisualization(
   );
 
   const nodeDataSets = entities.map((entity) => ({
-    id: entity._key,
+    id: getNodeIdFromEntity(entity, []),
     label: `${entity.displayName}\n[${entity._type}]`,
     group: entity._type,
   }));
@@ -46,7 +47,10 @@ export async function generateVisualization(
   const {
     mappedRelationshipEdges, 
     mappedRelationshipNodes,
-  } = createMappedRelationshipNodesAndEdges(mappedRelationships, entities);
+  } = createMappedRelationshipNodesAndEdges({
+    mappedRelationships, 
+    explicitEntities: entities,
+  });
 
   const htmlFileLocation = path.join(resolvedIntegrationPath, 'index.html');
 

--- a/packages/integration-sdk-cli/src/visualization/utils.ts
+++ b/packages/integration-sdk-cli/src/visualization/utils.ts
@@ -1,0 +1,33 @@
+import { v4 as uuid } from 'uuid';
+import { Entity } from "@jupiterone/integration-sdk-core";
+
+export type NodeEntity = Partial<Entity> & { nodeId: string };
+
+/**
+ * The nodeId should map back to _key, which ought to be globally unique.
+ * Entities set their node ID once, and return if available.
+ * 
+ * If nodeId is not set, first check that the _key isn't already a nodeId for another entity.
+ * Duplicates will break vis.js, so we will set nodeId to a UUID (this makes isNodeDuplicate(nodeEntity) === true)
+ * 
+ * If node is not a duplicate, return either the entity _key, or, if unavailable, return a new UUID.
+ */
+export function getNodeIdFromEntity(entity: Partial<NodeEntity>, existingEntities: NodeEntity[]): string {
+  if (entity.nodeId !== undefined) {
+    return entity.nodeId;
+  }
+
+  if (entity._key !== undefined) {
+    if (existingEntities.map((e) => e.nodeId).includes(entity._key)) {
+      // duplicate key - generate UUID & continue
+      // will cause isNodeIdDuplicate to return true
+      return uuid();
+    }
+    return entity._key;
+  }
+  return uuid();
+}
+
+export function isNodeIdDuplicate(entity: NodeEntity): boolean {
+  return entity._key !== undefined && entity._key !== entity.nodeId;
+}

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `visualize` cmd where mapped relationships did not consider `targetFilterKey` when matching entities
+- Fixed `visualize` cmd where multiple nodes with the same nodeId could be created, which causes rendering to fail
+
 ## 2.6.0 - 2020-07-28
 
 ### Added


### PR DESCRIPTION
See https://airtable.com/tblq5xeQXHTFS1YnX/viw8UgryHmlyw1g27/recHxh0xfVGqefgk7?blocks=hide

The `visualize` command will NOT match the following targetEntity. The local matcher needs to be updated to make sure the `j1-integration visualize` command works properly:

```
const entity = {
  _key: 'some-key',
  _class: ['User'],
  _type: 'user-type'
}

const targetEntity = {
  _key: 'some-key',
  _class: 'User',
  _type: 'user-type'
}
```

In addition, `RelationshipMapping` interfaces use the `targetFilterKeys` property to declare which properties should be used to match target entities. This PR adds logic to match objects on sets of `targetFilterKey`s.