### PR TITLE
Fixes #279 - Introduce eslint rules that will help catch async errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,9 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": 2020
+    "ecmaVersion": 2020,
+    "project": "./tsconfig.base.json",
+    "tsconfigRootDir": "."
   },
   "extends": ["eslint:recommended", "prettier"],
   "ignorePatterns": ["node_modules/", "dist/", "work/", "coverage/"],
@@ -25,7 +27,10 @@
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/ban-types": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off"
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/await-thenable": "error",
+        "@typescript-eslint/require-await": "error",
+        "@typescript-eslint/no-floating-promises": "error"
       }
     },
     {

--- a/packages/cli/src/__tests__/cli-export.test.ts
+++ b/packages/cli/src/__tests__/cli-export.test.ts
@@ -17,7 +17,7 @@ jest.mock('../log');
 const mockedAxios = mocked(axios, true);
 const mockedCreateApiClient = mocked(runtime.createApiClientWithApiKey, true);
 
-beforeEach(async () => {
+beforeEach(() => {
   mockedCreateApiClient.mockReturnValue(axios);
   mockedAxios.get.mockReset();
   delete process.env.JUPITERONE_API_KEY;
@@ -62,7 +62,7 @@ test('should export assets', async () => {
       `--api-key=${TEST_API_KEY}`,
     ]),
   ).resolves.toEqual(expect.anything());
-  await expect(Object.values(vol.toJSON())).toMatchInlineSnapshot(`
+  expect(Object.values(vol.toJSON())).toMatchInlineSnapshot(`
           Array [
             "[{\\"id\\":\\"entity-1\\",\\"name\\":\\"Entity 1\\",\\"displayName\\":\\"Entity 1\\",\\"createdOn\\":1591831808891,\\"_class\\":\\"Entity\\",\\"_type\\":\\"entity_type_1\\",\\"_key\\":\\"entity-1\\",\\"tag.Production\\":\\"{\\\\\\"object\\\\\\":{\\\\\\"innerProp\\\\\\":\\\\\\"foobar\\\\\\"}}\\"}]",
             "[{\\"id\\":\\"entity-2\\",\\"name\\":\\"Entity 2\\",\\"displayName\\":\\"Entity 2\\",\\"createdOn\\":1591831808892,\\"_class\\":\\"Entity\\",\\"_type\\":\\"entity_type_2\\",\\"_key\\":\\"entity-2\\"}]",
@@ -114,7 +114,7 @@ test('should only export relationships when specified', async () => {
       `--no-include-entities`,
     ]),
   ).resolves.toEqual(expect.anything());
-  await expect(Object.values(vol.toJSON())).toMatchInlineSnapshot(`
+  expect(Object.values(vol.toJSON())).toMatchInlineSnapshot(`
           Array [
             "[{\\"_key\\":\\"entity-1|has|entity-2\\",\\"_type\\":\\"entity_type_1_has_2\\",\\"_class\\":\\"HAS\\",\\"_fromEntityKey\\":\\"entity-1\\",\\"_toEntityKey\\":\\"entity-2\\",\\"displayName\\":\\"HAS\\"}]",
             "_key,_type,_class,_fromEntityKey,_toEntityKey,displayName
@@ -160,7 +160,7 @@ test('should only export entities when specified', async () => {
       `--no-include-entities`,
     ]),
   ).resolves.toEqual(expect.anything());
-  await expect(Object.values(vol.toJSON())).toMatchInlineSnapshot(`
+  expect(Object.values(vol.toJSON())).toMatchInlineSnapshot(`
           Array [
             "[{\\"id\\":\\"entity-1\\",\\"name\\":\\"Entity 1\\",\\"displayName\\":\\"Entity 1\\",\\"createdOn\\":1591831808891,\\"_class\\":\\"Entity\\",\\"_type\\":\\"entity_type_1\\",\\"_key\\":\\"entity-1\\",\\"tag.Production\\":\\"{\\\\\\"object\\\\\\":{\\\\\\"innerProp\\\\\\":\\\\\\"foobar\\\\\\"}}\\"}]",
             "[{\\"id\\":\\"entity-2\\",\\"name\\":\\"Entity 2\\",\\"displayName\\":\\"Entity 2\\",\\"createdOn\\":1591831808892,\\"_class\\":\\"Entity\\",\\"_type\\":\\"entity_type_2\\",\\"_key\\":\\"entity-2\\"}]",
@@ -171,8 +171,6 @@ test('should only export entities when specified', async () => {
           ]
         `);
 });
-
-
 
 test('should log error when export fails', async () => {
   const error = new Error();

--- a/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
@@ -44,10 +44,10 @@ beforeEach(() => {
   });
 });
 
-afterEach(async () => {
+afterEach(() => {
   delete process.env.JUPITERONE_API_KEY;
   delete process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION;
-  await polly.disconnect();
+  polly.disconnect();
 });
 
 test('enables graph object schema validation', async () => {

--- a/packages/integration-sdk-cli/src/__tests__/cli-sync.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-sync.test.ts
@@ -41,10 +41,10 @@ beforeEach(() => {
   });
 });
 
-afterEach(async () => {
+afterEach(() => {
   delete process.env.JUPITERONE_API_KEY;
   delete process.env.JUPITERONE_DEV;
-  await polly.disconnect();
+  polly.disconnect();
 });
 
 test('uploads data to the synchronization api and displays the results', async () => {

--- a/packages/integration-sdk-dev-tools/config/eslint.json
+++ b/packages/integration-sdk-dev-tools/config/eslint.json
@@ -25,7 +25,10 @@
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/ban-types": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off"
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/await-thenable": "error",
+        "@typescript-eslint/require-await": "error",
+        "@typescript-eslint/no-floating-promises": "error"
       }
     },
     {

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -199,7 +199,10 @@ describe('executeStepDependencyGraph', () => {
     ];
 
     const graph = buildStepDependencyGraph(steps);
-    executeStepDependencyGraph(
+
+    // NOTE: This is intentionally not awaiting because the `spyB` function
+    // never resolves.
+    void executeStepDependencyGraph(
       executionContext,
       graph,
       getDefaultStepStartStates(steps),

--- a/packages/integration-sdk-runtime/src/execution/__tests__/instance.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/instance.test.ts
@@ -14,8 +14,8 @@ describe('createIntegrationInstanceForLocalExecution', () => {
     delete process.env.MY_FIELD;
   });
 
-  test('creates local integration instance with config loaded from env if no instance id is provided', async () => {
-    const instance = await createIntegrationInstanceForLocalExecution({
+  test('creates local integration instance with config loaded from env if no instance id is provided', () => {
+    const instance = createIntegrationInstanceForLocalExecution({
       validateInvocation: jest.fn(),
       integrationSteps: [],
     });
@@ -23,10 +23,10 @@ describe('createIntegrationInstanceForLocalExecution', () => {
     expect(instance).toEqual(LOCAL_INTEGRATION_INSTANCE);
   });
 
-  test('should allow specifying local JupiterOne account id through environment variable', async () => {
+  test('should allow specifying local JupiterOne account id through environment variable', () => {
     const accountId = (process.env.JUPITERONE_LOCAL_INTEGRATION_INSTANCE_ACCOUNT_ID = uuid());
 
-    const instance = await createIntegrationInstanceForLocalExecution({
+    const instance = createIntegrationInstanceForLocalExecution({
       validateInvocation: jest.fn(),
       integrationSteps: [],
     });
@@ -37,8 +37,8 @@ describe('createIntegrationInstanceForLocalExecution', () => {
     });
   });
 
-  test('should load config from env onto instance', async () => {
-    const instance = await createIntegrationInstanceForLocalExecution({
+  test('should load config from env onto instance', () => {
+    const instance = createIntegrationInstanceForLocalExecution({
       validateInvocation: jest.fn(),
       integrationSteps: [],
       instanceConfigFields: {

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -218,7 +218,7 @@ export function executeStepDependencyGraph<
          */
         if (isStepEnabled(stepId) && stepDependenciesAreComplete(stepId)) {
           removeStepFromWorkingGraph(stepId);
-          promiseQueue.add(() =>
+          void promiseQueue.add(() =>
             timeOperation({
               logger: executionContext.logger,
               metricName: `duration-step`,
@@ -286,7 +286,10 @@ export function executeStepDependencyGraph<
     // kick off work for all leaf nodes
     enqueueLeafSteps();
 
-    promiseQueue.onIdle().then(() => resolve([...stepResultsMap.values()]));
+    void promiseQueue
+      .onIdle()
+      .then(() => resolve([...stepResultsMap.values()]))
+      .catch(reject);
   });
 }
 

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -83,10 +83,11 @@ export function createStepJobState({
   return {
     setData: async <T>(key: string, data: T): Promise<void> => {
       dataStore.set(key, data);
+      return Promise.resolve();
     },
 
     getData: async <T>(key: string): Promise<T> => {
-      return dataStore.get(key) as T;
+      return Promise.resolve(dataStore.get(key) as T);
     },
 
     addEntity: async (entity: Entity): Promise<Entity> => {

--- a/packages/integration-sdk-runtime/src/execution/step.ts
+++ b/packages/integration-sdk-runtime/src/execution/step.ts
@@ -115,7 +115,7 @@ export function prepareLocalStepCollection<
         return enabledRecord;
       }
     : originalGetStepStartStates &&
-      (async (ctx) => originalGetStepStartStates(ctx));
+      (async (ctx) => Promise.resolve(originalGetStepStartStates(ctx)));
 
   return config;
 }

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -135,7 +135,7 @@ describe('createIntegrationLogger', () => {
     } as unknown) as Logger);
   });
 
-  test('installs expected properties', async () => {
+  test('installs expected properties', () => {
     createIntegrationLogger({ name, invocationConfig });
 
     expect(Logger.createLogger).toHaveBeenCalledWith({
@@ -299,7 +299,7 @@ describe('step event publishing', () => {
     );
   });
 
-  test('posts events via api client if synchronizationContext is registered', async () => {
+  test('posts events via api client if synchronizationContext is registered', () => {
     const onEmitEvent = jest.fn();
 
     const logger = createIntegrationLogger({
@@ -383,7 +383,7 @@ describe('provider auth error details', () => {
         'Provider authorization failed at https://cute.af: 403 Forbidden',
     },
   ].forEach(({ error, expectedReason }) => {
-    test(`stepFailure adds additional information to the log message if an ${error.code} error is provided`, async () => {
+    test(`stepFailure adds additional information to the log message if an ${error.code} error is provided`, () => {
       logger.stepFailure(step, error);
 
       expect(onEmitEvent).toHaveBeenCalledWith({
@@ -398,7 +398,7 @@ describe('provider auth error details', () => {
       });
     });
 
-    test(`validationFailure adds additional information to the log message if an ${error.code} error is provided`, async () => {
+    test(`validationFailure adds additional information to the log message if an ${error.code} error is provided`, () => {
       logger.validationFailure(error);
 
       expect(onEmitEvent).toHaveBeenCalledWith({
@@ -416,7 +416,7 @@ describe('provider auth error details', () => {
 });
 
 describe('sync upload logging', () => {
-  test('posts events to api client', async () => {
+  test('posts events to api client', () => {
     const onEmitEvent = jest.fn();
 
     const logger = createIntegrationLogger({
@@ -443,7 +443,7 @@ describe('sync upload logging', () => {
 });
 
 describe('validation failure logging', () => {
-  test('unexpected error', async () => {
+  test('unexpected error', () => {
     const logger = createIntegrationLogger({
       name,
       invocationConfig,
@@ -474,7 +474,7 @@ describe('validation failure logging', () => {
     );
   });
 
-  test('expected user error', async () => {
+  test('expected user error', () => {
     const logger = createIntegrationLogger({
       name,
       invocationConfig,
@@ -611,7 +611,7 @@ describe('publishMetric', () => {
 });
 
 describe('#publishEvent', () => {
-  test('should support publishEvent(...) function', async () => {
+  test('should support publishEvent(...) function', () => {
     const onEmitEvent = jest.fn();
 
     const logger = createIntegrationLogger({
@@ -635,7 +635,7 @@ describe('#publishEvent', () => {
 });
 
 describe('#publishErrorEvent', () => {
-  test('should support publishErrorEvent(...) function', async () => {
+  test('should support publishErrorEvent(...) function', () => {
     const onEmitEvent = jest.fn();
 
     const logger = createIntegrationLogger({

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -59,21 +59,18 @@ export class FileSystemGraphObjectStore {
     }
   }
 
-  async getEntity(
-    getEntityOptions: GraphObjectLookupKey,
-  ): Promise<Entity> {
+  async getEntity(getEntityOptions: GraphObjectLookupKey): Promise<Entity> {
     const { _type, _key } = getEntityOptions;
     await this.flushEntitiesToDisk();
 
     const entities: Entity[] = [];
-    await this.iterateEntities(
-      { _type, },
-      async (e) => {
-        if (e._key === _key) {
-          entities.push(e);
-        }
+    await this.iterateEntities({ _type }, async (e) => {
+      if (e._key === _key) {
+        entities.push(e);
       }
-    );
+
+      return Promise.resolve();
+    });
 
     if (entities.length === 0) {
       throw new IntegrationMissingKeyError(
@@ -82,7 +79,7 @@ export class FileSystemGraphObjectStore {
     } else if (entities.length > 1) {
       throw new IntegrationDuplicateKeyError(
         `Duplicate _key detected (_type=${_type}, _key=${_key})`,
-      )
+      );
     } else {
       return entities[0];
     }

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
@@ -20,8 +20,8 @@ test('publishes events added to the queue in the order they were enqueued', asyn
 
   const postSpy = jest.spyOn(apiClient, 'post').mockImplementation(noop as any);
 
-  queue.enqueue(eventA);
-  queue.enqueue(eventB);
+  await queue.enqueue(eventA);
+  await queue.enqueue(eventB);
 
   await queue.onIdle();
 
@@ -52,7 +52,7 @@ test('logs an error if publish fails', async () => {
 
   const logErrorSpy = jest.spyOn(logger, 'error');
 
-  queue.enqueue(event);
+  await queue.enqueue(event);
 
   await queue.onIdle();
 

--- a/packages/integration-sdk-testing/src/__tests__/context.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/context.test.ts
@@ -167,14 +167,14 @@ describe('createMockStepExecutionContext', () => {
       instanceConfigFields,
     });
 
-    jobState.addEntities(entities);
-    jobState.addRelationships(relationships);
+    await jobState.addEntities(entities);
+    await jobState.addRelationships(relationships);
 
     expect(jobState.collectedEntities).toEqual(entities);
     expect(jobState.collectedRelationships).toEqual(relationships);
   });
 
-  test('throws error if duplicate key is added', () => {
+  test('throws error if duplicate key is added', async () => {
     const entities: Entity[] = [
       {
         _key: 'test',
@@ -191,7 +191,7 @@ describe('createMockStepExecutionContext', () => {
       instanceConfigFields,
     });
 
-    expect(jobState.addEntities(entities)).rejects.toThrow(
+    await expect(jobState.addEntities(entities)).rejects.toThrow(
       /Duplicate _key detected \(_key=test\)/,
     );
   });
@@ -212,18 +212,18 @@ describe('createMockStepExecutionContext', () => {
     await step.executionHandler(context);
   });
 
-  test('tracks encounteredTypes', () => {
+  test('tracks encounteredTypes', async () => {
     const { jobState } = createMockStepExecutionContext({
       instanceConfigFields,
     });
 
-    jobState.addEntity({
+    await jobState.addEntity({
       _key: 'entity:0',
       _type: 'test_entity',
       _class: 'Resource',
     });
 
-    jobState.addRelationship({
+    await jobState.addRelationship({
       _key: 'relationship:0',
       _type: 'test_relationship',
       _class: 'Resource',

--- a/packages/integration-sdk-testing/src/__tests__/recording.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/recording.test.ts
@@ -22,7 +22,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await server.close();
-  recording.stop();
+  await recording.stop();
   vol.reset();
 });
 

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -49,7 +49,7 @@ export function createMockJobState({
       typeTracker.registerType(e._type);
     });
     collectedEntities = collectedEntities.concat(newEntities);
-    return newEntities;
+    return Promise.resolve(newEntities);
   };
 
   const addRelationships = async (newRelationships) => {
@@ -58,6 +58,7 @@ export function createMockJobState({
       typeTracker.registerType(r._type as string);
     });
     collectedRelationships = collectedRelationships.concat(newRelationships);
+    return Promise.resolve();
   };
 
   const iterateEntities = async <T extends Entity = Entity>(
@@ -87,10 +88,11 @@ export function createMockJobState({
 
     setData: async <T>(key: string, data: T): Promise<void> => {
       dataStore.set(key, data);
+      return Promise.resolve();
     },
 
     getData: async <T>(key: string): Promise<T> => {
-      return dataStore.get(key) as T;
+      return Promise.resolve(dataStore.get(key) as T);
     },
 
     addEntity: async (entity: Entity): Promise<Entity> => {
@@ -100,7 +102,7 @@ export function createMockJobState({
     addEntities,
 
     addRelationship: async (relationship: Relationship) => {
-      addRelationships([relationship]);
+      await addRelationships([relationship]);
     },
     addRelationships,
 
@@ -112,6 +114,8 @@ export function createMockJobState({
         if (e._key === _key) {
           entities.push(e);
         }
+
+        return Promise.resolve();
       });
 
       if (entities.length !== 1) {

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- #279 - Update `.eslintrc` to include eslint rules that will help catch async
+  errors
+
+### Fixed
+
+- `jobState.addRelationships` floating promise in
+  `@jupiterone/integration-sdk-testing`
+- Various async fixes in test suites
+
 ## 2.9.2 - 2020-08-06
 
 ### Fixed


### PR DESCRIPTION
#279 

- `jobState.addRelationships` floating promise in `@jupiterone/integration-sdk-testing`
- Various async fixes in test suites

I've noticed that sometimes tests are flaky in the CI. I think this PR should help. There were places in the tests that had floating promises.

We should ultimately switch to using `plugin:@typescript-eslint/recommended-requiring-type-checking`, but that will produce a lot of noise.