### PR TITLE
Fixes #283 - Change jobState.getEntity to only take a _key

### DIFF
--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -4,11 +4,6 @@ export interface GraphObjectFilter {
   _type: string;
 }
 
-export interface GraphObjectLookupKey {
-  _type: string;
-  _key: string;
-}
-
 export type GraphObjectIteratee<T> = (obj: T) => void | Promise<void>;
 
 /**
@@ -70,10 +65,10 @@ export interface JobState {
   addRelationships: (relationships: Relationship[]) => Promise<void>;
 
   /**
-   * Gets an entity by _key and _type
+   * Gets an entity by _key
    * Throws when !== 1 entity
    */
-  getEntity: (lookupKey: GraphObjectLookupKey) => Promise<Entity>;
+  getEntity: (_key: string) => Promise<Entity>;
 
   /**
    * Allows a step to iterate all entities collected into the job state, limited

--- a/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
@@ -13,10 +13,12 @@ import { Entity } from '@jupiterone/integration-sdk-core';
 jest.mock('fs');
 
 function getMockCreateStepJobStateParams(): CreateStepJobStateParams {
+  const duplicateKeyTracker = new DuplicateKeyTracker();
+
   return {
     stepId: uuid(),
-    graphObjectStore: new FileSystemGraphObjectStore(),
-    duplicateKeyTracker: new DuplicateKeyTracker(),
+    graphObjectStore: new FileSystemGraphObjectStore({ duplicateKeyTracker }),
+    duplicateKeyTracker,
     typeTracker: new TypeTracker(),
     dataStore: new MemoryDataStore(),
   };

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -79,10 +79,12 @@ export function executeStepDependencyGraph<
   // create a queue for managing promises to be executed
   const promiseQueue = new PromiseQueue();
 
-  const graphObjectStore = new FileSystemGraphObjectStore();
+  const duplicateKeyTracker = new DuplicateKeyTracker();
+  const graphObjectStore = new FileSystemGraphObjectStore({
+    duplicateKeyTracker,
+  });
 
   const stepResultsMap = buildStepResultsMap(inputGraph, stepStartStates);
-  const duplicateKeyTracker = new DuplicateKeyTracker();
   const dataStore = new MemoryDataStore();
 
   function isStepEnabled(stepId: string) {

--- a/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
@@ -63,22 +63,17 @@ describe('entities', () => {
     expect(jobState.collectedEntities).toEqual([]);
   });
 
-  test('getEntity returns entity from jobState when _type and _key match', async () => {
+  test.only('getEntity returns entity from jobState when _key matches', async () => {
     const jobState = createMockJobState();
     await jobState.addEntities(inputEntities);
-
-    const result = await jobState.getEntity({ _type: 'test_a', _key: 'a' });
-
+    const result = await jobState.getEntity('a');
     expect(result).toEqual(inputEntities[0]);
   });
 
   test('getEntity throws Error when entity cannot be found in jobState', async () => {
     const jobState = createMockJobState();
     await jobState.addEntities(inputEntities);
-
-    await expect(
-      jobState.getEntity({ _type: 'test_a', _key: 'does-not-exist' }),
-    ).rejects.toThrow();
+    await expect(jobState.getEntity('does-not-exist')).rejects.toThrow();
   });
 
   async function assertEntityFilteringCapabilities(jobState: MockJobState) {

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- [BREAKING] Fixed [#283](https://github.com/JupiterOne/sdk/issues/283) - Change
+  `jobState.getEntity` to only to a `_key`.
+
 ### 2.10.0 - 2020-08-06
 
 ### Changed


### PR DESCRIPTION
See #283 for info

Old API:

```ts
jobState.getEntity({
  _key: 'abc123',
  _type: 'my_type'
});
```

New API:

```ts
jobState.getEntity('abc123');
```