### PR TITLE
Add shouldReportErrorToOperator to avoid alerts

### DIFF
--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -9,7 +9,6 @@ import {
   IntegrationProviderAuthorizationError,
   IntegrationStep,
   IntegrationValidationError,
-  PROVIDER_AUTH_ERROR_DESCRIPTION,
   SynchronizationJob,
   UNEXPECTED_ERROR_CODE,
   UNEXPECTED_ERROR_REASON,
@@ -19,6 +18,7 @@ import {
   createErrorEventDescription,
   createIntegrationLogger,
   IntegrationLogger,
+  PROVIDER_AUTH_ERROR_HELP,
 } from '../../logger';
 
 const invocationConfig = {} as IntegrationInvocationConfig;
@@ -394,7 +394,7 @@ describe('provider auth error details', () => {
         description: expect.stringMatching(
           new RegExp(
             '^Step "Mochi" failed to complete due to error.' +
-              PROVIDER_AUTH_ERROR_DESCRIPTION +
+              PROVIDER_AUTH_ERROR_HELP +
               ` \\(errorCode="${error.code}", errorId="[^"]*", reason="${expectedReason}"\\)$`,
           ),
         ),
@@ -409,7 +409,7 @@ describe('provider auth error details', () => {
         description: expect.stringMatching(
           new RegExp(
             '^Error occurred while validating integration configuration.' +
-              PROVIDER_AUTH_ERROR_DESCRIPTION +
+              PROVIDER_AUTH_ERROR_HELP +
               ` \\(errorCode="${error.code}", errorId="[^"]*", reason="${expectedReason}"\\)$`,
           ),
         ),

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Introduced `shouldReportErrorToOperator` function for integration runtime
+  environments to check whether an `Error` is of a type that need not be alerted
+  to deployment operators. All `Error`s other than those only an end user can
+  resolve should be reported.
+
 ## 3.2.0 - 2020-09-01
 
 ### Changed


### PR DESCRIPTION
We're getting Sentry alerts for a few errors that are considered to be a kind that may only be resolved by the user changing something in their configuration. These are handled in the sdk runtime code in some special way, avoiding a `logger.error` call, and then re-thrown. The managed runtime sends them to Sentry, which we don't want to do. This adds a function to allow the managed runtime to see if it should not report these.

The places where these error types are handled in the SDK:

* [`IntegrationProviderAuthorizationError`](https://github.com/search?q=org%3AJupiterOne+IntegrationProviderAuthorizationError&type=Code)
* [`IntegrationProviderAuthenticationError`](https://github.com/search?q=org%3AJupiterOne+IntegrationProviderAuthenticationError&type=Code)
* [`IntegrationValidationError`](https://github.com/search?q=org%3AJupiterOne+IntegrationValidationError&type=Code)

I'd like to consider a change that makes the SDK not throw these kinds of errors, but I think it will take a bit more care because the managed runtime may need more changes to live without the error being thrown.