### PR TITLE
Disallow Array/Object in AdditionalRelationshipProperties index sig

### DIFF
--- a/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationRelationship.ts
@@ -125,8 +125,14 @@ type TargetEntity = TargetEntityProperties & {
 /**
  * Allows assignment of any additional properties without being forced to use
  * specific types where that isn't helpful.
+ *
+ * The persister does not allow Object or Array properties.
  */
-type AdditionalRelationshipProperties = { [key: string]: any };
+type AdditionalRelationshipProperties = {
+  _type?: string;
+  _key?: string;
+  [key: string]: string | boolean | number | null | undefined;
+};
 
 function createInvalidateRelationshipClassError(_class: string) {
   return new IntegrationError({

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   resolve should be reported.
 - [#333](https://github.com/JupiterOne/sdk/issues/333) - Made
   `ToMatchGraphObjectSchemaParams.schema` property optional in jest matcher.
+- Changed index signature of `AdditionalRelationshipProperties` to not allow
+  Array or Object types.
 
 ## 3.2.0 - 2020-09-01
 


### PR DESCRIPTION
There is no relationship property validation during the developer experience that would indicate to a developer that relationship properties cannot be `Object` or `Array` types, so devs are not notified until a failure in the integration run:

```
(6:16:26 PM) - [job_abort] - Aborting integration job. (reason=Error uploading collected data (API response: code=RELATIONSHIP_UPLOAD_FAILED_VALIDATION, message="2 validation error(s): - Error in relationships[0].repositoryPermissions (reason=OBJECTS_NOT_ALLOWED) - Error in relationships[0].buildPermissions (reason=OBJECTS_NOT_ALLOWED) (code=RELATIONSHIP_UPLOAD_FAILED_VALIDATION, statusCode=400, correlationId=91597af1-6ac5-49bf-853c-9b7f472104c4)").)
```

```
(6:19:08 PM) - [job_abort] - Aborting integration job. (reason=Error uploading collected data (API response: code=RELATIONSHIP_UPLOAD_FAILED_VALIDATION, message="1 validation error(s): - Error in relationships[0].permissions (reason=ARRAYS_NOT_ALLOWED) (code=RELATIONSHIP_UPLOAD_FAILED_VALIDATION, statusCode=400, correlationId=a97fc218-b204-49b1-b97f-5b61f4375eff)").)
```

I thought about doing some JSON schema validation for relationships by adding a **Relationship.json** schema and setting `additionalProperties` with `"type": ["string", "null", "number", "integer", "boolean"]`, but I think it's a more complex change since it wouldn't natively work for `MappedRelationship` types.