### PR TITLE
Only allow primitives & arrays on mapped relationship target entities

### DIFF
--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
@@ -103,13 +103,13 @@ describe('DirectRelationshipLiteralOptions', () => {
 });
 
 describe('MappedRelationshipOptions', () => {
-  const entityA: Entity = {
+  const entityA = {
     _type: 'a_entity',
     _class: 'A',
     _key: 'a',
   };
 
-  const entityB: Entity = {
+  const entityB = {
     _type: 'b_entity',
     _class: 'B',
     _key: 'b',

--- a/packages/integration-sdk-core/src/types/entity.ts
+++ b/packages/integration-sdk-core/src/types/entity.ts
@@ -1,5 +1,30 @@
 import { PersistedObject } from './persistedObject';
 
+export type PrimitiveEntity = EntityCoreProperties &
+  PrimitiveEntityAdditionalProperties;
+
+type PrimitiveEntityAdditionalProperties = Record<
+  string,
+  PrimitiveEntityPropertyValue
+> & {
+  /**
+   * The natural identifier of the entity as provided by the data source API.
+   * Many APIs answer resources that each have an `id` property that should be
+   * transferred to this entity property.
+   */
+  id?: string;
+};
+
+type PrimitiveEntityPropertyValue =
+  | Array<string | number | boolean>
+  | string
+  | string[]
+  | number
+  | number[]
+  | boolean
+  | undefined
+  | null;
+
 export type Entity = EntityCoreProperties &
   RawDataTracking &
   EntityAdditionalProperties;
@@ -18,16 +43,7 @@ type EntityAdditionalProperties = Record<string, EntityPropertyValue> & {
   id?: string;
 };
 
-type EntityPropertyValue =
-  | Array<string | number | boolean>
-  | string
-  | string[]
-  | number
-  | number[]
-  | boolean
-  | undefined
-  | null
-  | EntityRawData[];
+type EntityPropertyValue = PrimitiveEntityPropertyValue | EntityRawData[];
 
 export interface RawDataTracking {
   /**

--- a/packages/integration-sdk-core/src/types/relationship.ts
+++ b/packages/integration-sdk-core/src/types/relationship.ts
@@ -1,5 +1,5 @@
 import { PersistedObject } from './persistedObject';
-import { Entity } from './entity';
+import { PrimitiveEntity } from './entity';
 
 export type Relationship = ExplicitRelationship | MappedRelationship;
 
@@ -33,7 +33,11 @@ type RelationshipPropertyValue =
   | RelationshipMapping;
 
 export type TargetFilterKey = string | string[];
-export type TargetEntityProperties = Partial<Entity>;
+
+/** According to Persister, must be one of
+ * string | string[] | number | number[] | boolean | boolean[]
+ */
+export type TargetEntityProperties = Partial<PrimitiveEntity>;
 
 /**
  * Relationship direction.


### PR DESCRIPTION
In the Artifactory integration, a call was made to `createMappedRelationship` with an actual persisted entity, and should have instead been made to `createDirectRelationship`. This was not noticed in code review, and ended up making it into production. 

In production, the integration failed with:

```
(1:38:55 PM) - [job_abort] - Aborting integration job. (reason=Error uploading collected data (API response: code=RELATIONSHIP_UPLOAD_FAILED_VALIDATION, message="2 validation error(s): - Error in relationships[0]._mapping.targetEntity._rawData (reason=Expected string | number | boolean | string[] | number[] | boolean[], but was object in _mapping.targetEntity._rawData) - Error in relationships[1]._mapping.targetEntity._rawData (reason=Expected string | number | boolean | string[] | number[] | boolean[], but was object in _mapping.targetEntity._rawData) (code=RELATIONSHIP_UPLOAD_FAILED_VALIDATION, statusCode=400,
```

The typing for target entities expected `Partial<Entity>`, which was not strict enough to generate entities that pass persister validation.

This change introduces `PrimitiveEntity` and uses `Partial<PrimitiveEntity>` as the typing for target entities in mapped relationships, essentially omittig the `_rawData` property & data type from acceptable property types. This should guard developers from making this same mistake in the future.

For the record, the following used to pass type checking, but now fails:

```typescript
createMappedRelationship({
  _class: RelationshipClass.HAS,
  source: {
    _key: 'some-key',
    _class: 'EntityClass',
    _type: 'some-type',
  },
  target: {
    _rawData: [{
      name: 'default',
      rawData: {
        key: 'mapped relationship targets cannot have objects as property values!'
      }
    }]
  }
})
```