### PR TITLE
Entity.id as string | string[]

### DIFF
--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -23,7 +23,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/data-model": "^0.10.0",
+    "@jupiterone/data-model": "^0.12.0",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
@@ -61,6 +61,40 @@ describe('createIntegrationEntity', () => {
     expect(entity).toHaveProperty('active', true);
   });
 
+  test.each(['id', 'providerId'])(
+    'requires _key when %s is not a single string value',
+    (prop) => {
+      expect(() =>
+        createIntegrationEntity({
+          entityData: {
+            assign: networkAssigns,
+            source: {
+              ...networkSourceData,
+              [prop]: ['yodog', 1234],
+            },
+          },
+        }),
+      ).toThrow(/as type string/);
+
+      const entity = createIntegrationEntity({
+        entityData: {
+          assign: {
+            ...networkAssigns,
+            _key: 'assigned-because-id-isnt-usable',
+          },
+          source: {
+            ...networkSourceData,
+            [prop]: ['yodog', 1234],
+          },
+        },
+      });
+
+      expect(entity).toMatchObject({
+        _key: 'assigned-because-id-isnt-usable',
+      });
+    },
+  );
+
   test('should assign createdOn timestamp from creationDate', () => {
     const entity = createIntegrationEntity({
       entityData: {

--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
@@ -84,7 +84,7 @@ describe('createIntegrationEntity', () => {
           },
           source: {
             ...networkSourceData,
-            [prop]: ['yodog', 1234],
+            [prop]: ['yodog', 'numbers'],
           },
         },
       });

--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
@@ -258,7 +258,7 @@ describe('MappedRelationshipLiteralOptions', () => {
           targetEntity: {
             _key: 'b',
             _type: 'b_entity',
-            id: [123, 'abc'],
+            id: ['123', 'abc'],
           },
           targetFilterKeys: [['something']],
           sourceEntityKey: 'a',
@@ -270,7 +270,7 @@ describe('MappedRelationshipLiteralOptions', () => {
         ...expected._mapping,
         targetEntity: {
           ...expected._mapping.targetEntity,
-          id: [123, 'abc'],
+          id: ['123', 'abc'],
         },
       },
     });

--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationRelationship.test.ts
@@ -1,3 +1,5 @@
+import { RelationshipClass } from '@jupiterone/data-model';
+
 import {
   Entity,
   MappedRelationship,
@@ -5,11 +7,10 @@ import {
   RelationshipDirection,
 } from '../../types';
 import {
-  generateRelationshipType,
   createDirectRelationship,
   createMappedRelationship,
+  generateRelationshipType,
 } from '../createIntegrationRelationship';
-import { RelationshipClass } from '@jupiterone/data-model';
 
 describe('DirectRelationshipOptions', () => {
   const entityA: Entity = {
@@ -246,6 +247,33 @@ describe('MappedRelationshipLiteralOptions', () => {
         },
       }),
     ).toEqual(expected);
+  });
+
+  test('id', () => {
+    expect(
+      createMappedRelationship({
+        _class: RelationshipClass.HAS,
+        _mapping: {
+          relationshipDirection: RelationshipDirection.REVERSE,
+          targetEntity: {
+            _key: 'b',
+            _type: 'b_entity',
+            id: [123, 'abc'],
+          },
+          targetFilterKeys: [['something']],
+          sourceEntityKey: 'a',
+        },
+      }),
+    ).toEqual({
+      ...expected,
+      _mapping: {
+        ...expected._mapping,
+        targetEntity: {
+          ...expected._mapping.targetEntity,
+          id: [123, 'abc'],
+        },
+      },
+    });
   });
 
   test('missing _type in targetEntity', () => {

--- a/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
@@ -191,12 +191,22 @@ function generateEntity({
   return entity;
 }
 
+/**
+ * Generates an entity `_key` value from the source data when possible or throws
+ * an error. It is expected that this won't be called when a `_key` is
+ * explicitly assigned.
+ *
+ * @param data any source data object
+ * @throws IntegrationError when there is no suitable value
+ */
 function generateEntityKey(data: any): string {
   const id = data.providerId || data.id;
-  if (!id) {
+  if (typeof id !== 'string') {
     throw new IntegrationError({
       code: 'INVALID_INPUT_TO_GENERATE_ENTITY_KEY',
-      message: 'Entity key generation requires one of data.{providerId,id}',
+      message: `Entity key generation requires one of data.{providerId,id} as type string, received ${JSON.stringify(
+        id,
+      )}`,
     });
   }
   return id;

--- a/packages/integration-sdk-core/src/types/entity.ts
+++ b/packages/integration-sdk-core/src/types/entity.ts
@@ -7,16 +7,21 @@ type EntityIdProperty = {
   /**
    * The natural identifier of the entity as provided by the data source API.
    *
-   * Many APIs answer resources having a property representing the identify of
-   * the resource within the target system. This value should be transferred to
-   * the entity's `id` property.
+   * Many APIs answer resources having a property representing the identity of
+   * the resource within the data source system. This value should be
+   * transferred to the entity's `id` property.
    *
-   * In some cases an entity is known to a number of systems. The systems that
-   * do not own the entity will use mapped relationships and provide the `id`
-   * value they maintain for the resource. The mapping system will merge the
-   * values into a single Array.
+   * In some cases an entity is known to a number of systems. The integrations
+   * that do not own the entity will use mapped relationships and provide the
+   * `id` value the data source maintains for the resource. The mapper will
+   * merge the values into a single Array.
+   *
+   * An identity value that is maintained as a number must be converted to a
+   * string. It is advisable to store the value in an additional property, such
+   * as `<resource>Id`, where `<resource>` reflects the type of resource
+   * represented by the entity (i.e. `domainId`, `userId`, etc.)
    */
-  id?: string | number | (string | number)[];
+  id?: string | string[];
 };
 
 type PrimitiveEntityAdditionalProperties = Record<

--- a/packages/integration-sdk-core/src/types/entity.ts
+++ b/packages/integration-sdk-core/src/types/entity.ts
@@ -3,17 +3,27 @@ import { PersistedObject } from './persistedObject';
 export type PrimitiveEntity = EntityCoreProperties &
   PrimitiveEntityAdditionalProperties;
 
+type EntityIdProperty = {
+  /**
+   * The natural identifier of the entity as provided by the data source API.
+   *
+   * Many APIs answer resources having a property representing the identify of
+   * the resource within the target system. This value should be transferred to
+   * the entity's `id` property.
+   *
+   * In some cases an entity is known to a number of systems. The systems that
+   * do not own the entity will use mapped relationships and provide the `id`
+   * value they maintain for the resource. The mapping system will merge the
+   * values into a single Array.
+   */
+  id?: string | number | (string | number)[];
+};
+
 type PrimitiveEntityAdditionalProperties = Record<
   string,
   PrimitiveEntityPropertyValue
-> & {
-  /**
-   * The natural identifier of the entity as provided by the data source API.
-   * Many APIs answer resources that each have an `id` property that should be
-   * transferred to this entity property.
-   */
-  id?: string;
-};
+> &
+  EntityIdProperty;
 
 type PrimitiveEntityPropertyValue =
   | Array<string | number | boolean>
@@ -34,14 +44,8 @@ interface EntityCoreProperties extends Omit<PersistedObject, '_class'> {
   _class: string | string[];
 }
 
-type EntityAdditionalProperties = Record<string, EntityPropertyValue> & {
-  /**
-   * The natural identifier of the entity as provided by the data source API.
-   * Many APIs answer resources that each have an `id` property that should be
-   * transferred to this entity property.
-   */
-  id?: string;
-};
+type EntityAdditionalProperties = Record<string, EntityPropertyValue> &
+  EntityIdProperty;
 
 type EntityPropertyValue = PrimitiveEntityPropertyValue | EntityRawData[];
 

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 
 ### Changed
 
+- Upgrade to `@jupiterone/data-model@0.12.0`
 - `Entity.id` is now `string | string[]` in the `data-model` (see
   [PR](https://github.com/JupiterOne/data-model/pull/44)). Integrations may
   enrich existing entities through mapped relationship `targetEntity.id` values.

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to
 
 - Added `toMatchDirectRelationshipSchema` matcher.
 
+### Changed
+
+- `PrimitiveEntity.id` & `Entity.id` is now
+  `string | number | (string|number)[]` in the `data-model` (see
+  [PR](https://github.com/JupiterOne/data-model/pull/44)). This is fully
+  backward compatible.
+
 ## 3.3.0 - 2020-09-25
 
 ### Added

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -15,10 +15,9 @@ and this project adheres to
 
 ### Changed
 
-- `PrimitiveEntity.id` & `Entity.id` is now
-  `string | number | (string|number)[]` in the `data-model` (see
-  [PR](https://github.com/JupiterOne/data-model/pull/44)). This is fully
-  backward compatible.
+- `Entity.id` is now `string | string[]` in the `data-model` (see
+  [PR](https://github.com/JupiterOne/data-model/pull/44)). Integrations may
+  enrich existing entities through mapped relationship `targetEntity.id` values.
 
 ## 3.3.0 - 2020-09-25
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,10 +567,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jupiterone/data-model@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.10.0.tgz#a9f859e89be7ea59c500accd81ed396022f12e32"
-  integrity sha512-kmYPOrVLCIxHviw69/OS5tHlHPFlUN0bsckjowiYRUmM3QoeOqkr7hMSm7qFqUBosCz30uqtbFSoJgEayQ+dWQ==
+"@jupiterone/data-model@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.12.0.tgz#b31e2d83b15cf97c314c61167c50874e1e599ae6"
+  integrity sha512-9nHMHOKXWl1Fys0BGx2FtfBkm/MDwOQbi4400vEFSmFxtcBB9xnWgFMNwkn/HaZkCihF4U17iipoQejcXuzNcA==
   dependencies:
     ajv "^6.12.0"
 


### PR DESCRIPTION
Related to https://github.com/JupiterOne/data-model/pull/44. These changes will allow the Qualys integration to provide `id: [number, number]`, the two values by which a `Host` is identified in that system. These values will be added to the `id` property of the `Host` entities in a mapped relationship, `Service - SCANS -> Host`.