### PR TITLE
Support controlling syncMode with invocationConfig

### DIFF
--- a/packages/integration-sdk-cli/src/commands/sync.ts
+++ b/packages/integration-sdk-cli/src/commands/sync.ts
@@ -1,13 +1,16 @@
 import { createCommand } from 'commander';
 
-import * as log from '../log';
 import {
-  getApiKeyFromEnvironment,
-  getApiBaseUrl,
   createApiClientWithApiKey,
+  createIntegrationInstanceForLocalExecution,
   createIntegrationLogger,
+  getApiBaseUrl,
+  getApiKeyFromEnvironment,
   synchronizeCollectedData,
 } from '@jupiterone/integration-sdk-runtime';
+
+import { loadConfig } from '../config';
+import * as log from '../log';
 
 export function sync() {
   return createCommand('sync')
@@ -35,10 +38,16 @@ export function sync() {
         pretty: true,
       });
 
+      const invocationConfig = await loadConfig();
+      const instance = createIntegrationInstanceForLocalExecution(
+        invocationConfig,
+      );
+
       const job = await synchronizeCollectedData({
         logger: logger.child({ integrationInstanceId }),
         apiClient,
         integrationInstanceId,
+        syncMode: await invocationConfig.getSyncMode?.({ logger, instance }),
       });
 
       log.displaySynchronizationResults(job);

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -1,18 +1,20 @@
-import { IntegrationInstanceConfig } from './instance';
-import { GetStepStartStatesFunction, Step } from './step';
-import { InvocationValidationFunction } from './validation';
 import {
   ExecutionContext,
   IntegrationExecutionContext,
-  StepExecutionContext,
   IntegrationStepExecutionContext,
+  StepExecutionContext,
 } from './context';
+import { IntegrationInstanceConfig } from './instance';
+import { GetStepStartStatesFunction, Step } from './step';
+import { GetSynchronizationModeFunction } from './synchronization';
+import { InvocationValidationFunction } from './validation';
 
 export interface InvocationConfig<
   TExecutionContext extends ExecutionContext,
   TStepExecutionContext extends StepExecutionContext
 > {
   validateInvocation?: InvocationValidationFunction<TExecutionContext>;
+  getSyncMode?: GetSynchronizationModeFunction<TExecutionContext>;
   getStepStartStates?: GetStepStartStatesFunction<TExecutionContext>;
   integrationSteps: Step<TStepExecutionContext>[];
 }

--- a/packages/integration-sdk-core/src/types/synchronization.ts
+++ b/packages/integration-sdk-core/src/types/synchronization.ts
@@ -1,3 +1,14 @@
+import { ExecutionContext } from "./context";
+
+export type GetSynchronizationModeFunction<T extends ExecutionContext> = (
+  context: T,
+) => SynchronizationMode | Promise<SynchronizationMode>;
+
+export enum SynchronizationMode {
+  DIFF = 'DIFF',
+  CREATE_OR_UPDATE = 'CREATE_OR_UPDATE',
+}
+
 export enum SynchronizationJobStatus {
   AWAITING_UPLOADS = 'AWAITING_UPLOADS',
   FINALIZE_PENDING = 'FINALIZE_PENDING',

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -65,7 +65,7 @@ export function executeIntegrationLocally(
  * Starts execution of an integration instance.
  */
 export async function executeIntegrationInstance(
-  logger: IntegrationLogger | IntegrationLogger,
+  logger: IntegrationLogger,
   instance: IntegrationInstance,
   config: IntegrationInvocationConfig,
   options: ExecuteIntegrationOptions = {},

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -1,29 +1,28 @@
-import path from 'path';
 import chunk from 'lodash/chunk';
 import pMap from 'p-map';
+import path from 'path';
 
 import {
-  PartialDatasets,
   Entity,
+  PartialDatasets,
   Relationship,
   SynchronizationJob,
+  SynchronizationMode,
 } from '@jupiterone/integration-sdk-core';
 
-import { IntegrationLogger } from '../logger';
-
+import { ApiClient } from '../api';
 import { ExecuteIntegrationResult } from '../execution';
-
 import {
   getRootStorageDirectory,
   readJsonFromPath,
   walkDirectory,
 } from '../fileSystem';
-import { synchronizationApiError } from './error';
-import { ApiClient } from '../api';
+import { IntegrationLogger } from '../logger';
 import { timeOperation } from '../metrics';
+import { synchronizationApiError } from './error';
+import { createEventPublishingQueue } from './events';
 
 export { synchronizationApiError };
-import { createEventPublishingQueue } from './events';
 export { createEventPublishingQueue } from './events';
 
 const UPLOAD_BATCH_SIZE = 250;
@@ -33,6 +32,7 @@ interface SynchronizeInput {
   logger: IntegrationLogger;
   apiClient: ApiClient;
   integrationInstanceId: string;
+  syncMode?: SynchronizationMode;
 }
 
 /**
@@ -88,6 +88,7 @@ export async function initiateSynchronization({
   logger,
   apiClient,
   integrationInstanceId,
+  syncMode,
 }: SynchronizeInput): Promise<SynchronizationJobContext> {
   logger.info('Initiating synchronization job...');
 
@@ -96,6 +97,7 @@ export async function initiateSynchronization({
     const response = await apiClient.post('/persister/synchronization/jobs', {
       source: 'integration-managed',
       integrationInstanceId,
+      syncMode,
     });
 
     job = response.data.job;

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Optional `InvocationConfig.getSyncMode(context)` to allow integrations to
+  control the synchronization mode. Previously, the default was to perform a
+  `DIFF` of the complete set. Now the option `CREATE_OR_UPDATE` will allow
+  integrations to only add data and never delete (useful in record collecting
+  integrations). This must be called before the syncronization job is started
+  since that API requires the value when the job is initialized.
+
+### Changed
+
+- The CLI `run` and `sync` commands will initialize the synchronization job
+  using the `InvocationConfig.getSyncMode(context)` when that function is
+  provided.
+
 ## 3.5.1 - 2020-10-05
 
 ### Changed


### PR DESCRIPTION
The tests need to be updated, but this proposed change allows an integration to control the sync mode. Please let me know if this approach looks sound. My understanding of the persister code is that we must provide the sync mode when initializing the synchronization job. I'll get the `sync` command tests passing if the approach looks good. I'll also need to make a change to `managed-integration-runtime` package I think to make it invoke `invocationConfig.syncMode()`.

The Qualys integration is going to need to be able to upload new data in a rolling fashion, without deleting old data. Older integrations such as the Jira and Bitbucket integration already do this kind of thing by sending only CREATE operations, so we'll need this for them to update to the new SDK at some point as well.