### PR TITLE
ExecutionContext.history

### DIFF
--- a/packages/integration-sdk-core/src/types/context.ts
+++ b/packages/integration-sdk-core/src/types/context.ts
@@ -2,8 +2,19 @@ import { IntegrationInstance, IntegrationInstanceConfig } from './instance';
 import { JobState } from './jobState';
 import { IntegrationLogger } from './logger';
 
+export type Execution = {
+  startedOn: number;
+  endedOn?: number;
+};
+
+export type ExecutionHistory = {
+  lastExecution: Execution;
+  lastSuccessfulExecution?: Execution;
+};
+
 export interface ExecutionContext {
   logger: IntegrationLogger;
+  history?: ExecutionHistory;
 }
 
 /**

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -1,5 +1,6 @@
 import {
   ExecutionContext,
+  ExecutionHistory,
   IntegrationInstance,
   IntegrationInvocationConfig,
   IntegrationLogger,
@@ -36,7 +37,7 @@ export interface ExecuteIntegrationResult {
 
 interface ExecuteIntegrationOptions {
   enableSchemaValidation?: boolean;
-  performContinuousUploads?: boolean;
+  executionHistory?: ExecutionHistory;
 }
 
 /**
@@ -68,7 +69,7 @@ export function executeIntegrationLocally(
  * Starts execution of an integration instance.
  */
 export async function executeIntegrationInstance(
-  logger: IntegrationLogger | IntegrationLogger,
+  logger: IntegrationLogger,
   instance: IntegrationInstance,
   config: IntegrationInvocationConfig,
   options: ExecuteIntegrationOptions = {},
@@ -85,6 +86,7 @@ export async function executeIntegrationInstance(
         {
           instance,
           logger,
+          history: options.executionHistory,
         },
         config,
       ),

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- `ExecutionContext.history?: ExecutionHistory` provides information about the
+  `lastExecution` and `lastSuccessfulExecution`. Integrations may use this to
+  limit data ingestion.
+
 ## 4.0.1 - 2020-10-30
 
 - Upgrade `@jupiterone/data-model@^0.15.0`


### PR DESCRIPTION
I propose this change to allow the `managed-integration-runtime` to provide job execution history information to the integration. This will allow an integration to only ingest data since the last execution. It is related to #353, which is required to allow the integration to only add new data.