### PR TITLE
Add normalization function for DuplicateKeyTracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint --ext .ts,.tsx,.js,.jsx --cache .",
     "test": "jest",
     "test:ci": "yarn lint && yarn build --force && jest",
-    "build": "tsc -b packages/integration-sdk-core packages/integration-sdk-runtime packages/integration-sdk-private-test-utils packages/integration-sdk-cli",
+    "build": "tsc -b packages/integration-sdk-core packages/integration-sdk-runtime packages/integration-sdk-private-test-utils packages/integration-sdk-cli packages/integration-sdk-testing",
     "build:dist": "lerna run build:dist",
     "format": "prettier --write '**/*.{js,ts,md,json}'",
     "prepush": "yarn lint && yarn build:dist && yarn jest --changedSince master"

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -8,6 +8,21 @@ import {
   IntegrationStepExecutionContext,
 } from './context';
 
+export type KeyNormalizationFunction = (_key: string) => string;
+
+export interface InvocationConfigOptions {
+  /**
+   * Normalization transform for tracking keys in an integration. Allows
+   * entities to be tracked and looked up using the provided transformation.
+   * One use case of this normalization function is to track duplicates
+   * among case-insensitive keys.
+   *
+   * Example:
+   *   (_key: string) => _key.toLowerCase()
+   */
+  keyNormalizationFunction?: KeyNormalizationFunction;
+}
+
 export interface InvocationConfig<
   TExecutionContext extends ExecutionContext,
   TStepExecutionContext extends StepExecutionContext
@@ -15,6 +30,7 @@ export interface InvocationConfig<
   validateInvocation?: InvocationValidationFunction<TExecutionContext>;
   getStepStartStates?: GetStepStartStatesFunction<TExecutionContext>;
   integrationSteps: Step<TStepExecutionContext>[];
+  invocationConfigOptions?: InvocationConfigOptions;
 }
 
 export interface IntegrationInvocationConfig<

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -8,20 +8,16 @@ import {
   IntegrationStepExecutionContext,
 } from './context';
 
+/**
+ * Normalization transform for tracking keys in an integration. Allows
+ * entities to be tracked and looked up using the provided transformation.
+ * One use case of this normalization function is to track duplicates
+ * among case-insensitive keys.
+ *
+ * Example:
+ *   (_key: string) => _key.toLowerCase()
+ */
 export type KeyNormalizationFunction = (_key: string) => string;
-
-export interface InvocationConfigOptions {
-  /**
-   * Normalization transform for tracking keys in an integration. Allows
-   * entities to be tracked and looked up using the provided transformation.
-   * One use case of this normalization function is to track duplicates
-   * among case-insensitive keys.
-   *
-   * Example:
-   *   (_key: string) => _key.toLowerCase()
-   */
-  keyNormalizationFunction?: KeyNormalizationFunction;
-}
 
 export interface InvocationConfig<
   TExecutionContext extends ExecutionContext,
@@ -30,7 +26,7 @@ export interface InvocationConfig<
   validateInvocation?: InvocationValidationFunction<TExecutionContext>;
   getStepStartStates?: GetStepStartStatesFunction<TExecutionContext>;
   integrationSteps: Step<TStepExecutionContext>[];
-  invocationConfigOptions?: InvocationConfigOptions;
+  normalizeGraphObjectKey?: KeyNormalizationFunction;
 }
 
 export interface IntegrationInvocationConfig<

--- a/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
@@ -16,13 +16,13 @@ import {
 jest.mock('fs');
 
 function getMockCreateStepJobStateParams(options?: {
-  keyNormalizationFunction?: KeyNormalizationFunction;
+  normalizeGraphObjectKey?: KeyNormalizationFunction;
 }): CreateStepJobStateParams {
   return {
     stepId: uuid(),
     graphObjectStore: new FileSystemGraphObjectStore(),
     duplicateKeyTracker: new DuplicateKeyTracker(
-      options?.keyNormalizationFunction,
+      options?.normalizeGraphObjectKey,
     ),
     typeTracker: new TypeTracker(),
     dataStore: new MemoryDataStore(),
@@ -88,7 +88,7 @@ describe('#findEntity', () => {
 
   test('should find entity by _key with key normalization', async () => {
     const params = getMockCreateStepJobStateParams({
-      keyNormalizationFunction: (_key) => _key.toLowerCase(),
+      normalizeGraphObjectKey: (_key) => _key.toLowerCase(),
     });
     const jobState = createStepJobState(params);
     const entity: Entity = {

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -15,7 +15,7 @@ import {
   StepStartStates,
   ExecutionContext,
   StepExecutionContext,
-  InvocationConfigOptions,
+  KeyNormalizationFunction,
 } from '@jupiterone/integration-sdk-core';
 import { timeOperation } from '../metrics';
 
@@ -68,7 +68,7 @@ export function executeStepDependencyGraph<
   executionContext: TExecutionContext,
   inputGraph: DepGraph<Step<TStepExecutionContext>>,
   stepStartStates: StepStartStates,
-  invocationConfigOptions?: InvocationConfigOptions,
+  normalizeGraphObjectKey?: KeyNormalizationFunction,
 ): Promise<IntegrationStepResult[]> {
   // create a clone of the dependencyGraph because mutating
   // the input graph is icky
@@ -81,9 +81,7 @@ export function executeStepDependencyGraph<
   // create a queue for managing promises to be executed
   const promiseQueue = new PromiseQueue();
 
-  const duplicateKeyTracker = new DuplicateKeyTracker(
-    invocationConfigOptions?.keyNormalizationFunction,
-  );
+  const duplicateKeyTracker = new DuplicateKeyTracker(normalizeGraphObjectKey);
   const graphObjectStore = new FileSystemGraphObjectStore();
 
   const stepResultsMap = buildStepResultsMap(inputGraph, stepStartStates);

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -15,6 +15,7 @@ import {
   StepStartStates,
   ExecutionContext,
   StepExecutionContext,
+  InvocationConfigOptions,
 } from '@jupiterone/integration-sdk-core';
 import { timeOperation } from '../metrics';
 
@@ -67,6 +68,7 @@ export function executeStepDependencyGraph<
   executionContext: TExecutionContext,
   inputGraph: DepGraph<Step<TStepExecutionContext>>,
   stepStartStates: StepStartStates,
+  invocationConfigOptions?: InvocationConfigOptions,
 ): Promise<IntegrationStepResult[]> {
   // create a clone of the dependencyGraph because mutating
   // the input graph is icky
@@ -79,7 +81,9 @@ export function executeStepDependencyGraph<
   // create a queue for managing promises to be executed
   const promiseQueue = new PromiseQueue();
 
-  const duplicateKeyTracker = new DuplicateKeyTracker();
+  const duplicateKeyTracker = new DuplicateKeyTracker(
+    invocationConfigOptions?.keyNormalizationFunction,
+  );
   const graphObjectStore = new FileSystemGraphObjectStore();
 
   const stepResultsMap = buildStepResultsMap(inputGraph, stepStartStates);

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -120,6 +120,7 @@ export async function executeWithContext<
     context,
     config.integrationSteps,
     stepStartStates,
+    config.invocationConfigOptions,
   );
 
   const partialDatasets = determinePartialDatasetsFromStepExecutionResults(

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -120,7 +120,7 @@ export async function executeWithContext<
     context,
     config.integrationSteps,
     stepStartStates,
-    config.invocationConfigOptions,
+    config.normalizeGraphObjectKey,
   );
 
   const partialDatasets = determinePartialDatasetsFromStepExecutionResults(

--- a/packages/integration-sdk-runtime/src/execution/step.ts
+++ b/packages/integration-sdk-runtime/src/execution/step.ts
@@ -14,6 +14,7 @@ import {
   StepStartStates,
   PartialDatasets,
   Step,
+  InvocationConfigOptions,
 } from '@jupiterone/integration-sdk-core';
 
 export async function executeSteps<
@@ -21,11 +22,17 @@ export async function executeSteps<
   TStepExecutionContext extends StepExecutionContext
 >(
   context: TExecutionContext,
-  steps: Step<TStepExecutionContext>[],
+  integrationSteps: Step<TStepExecutionContext>[],
   stepStartStates: StepStartStates,
+  invocationConfigOptions?: InvocationConfigOptions,
 ): Promise<IntegrationStepResult[]> {
-  const stepGraph = buildStepDependencyGraph(steps);
-  return executeStepDependencyGraph(context, stepGraph, stepStartStates);
+  const stepGraph = buildStepDependencyGraph(integrationSteps);
+  return executeStepDependencyGraph(
+    context,
+    stepGraph,
+    stepStartStates,
+    invocationConfigOptions,
+  );
 }
 
 export function getDefaultStepStartStates<

--- a/packages/integration-sdk-runtime/src/execution/step.ts
+++ b/packages/integration-sdk-runtime/src/execution/step.ts
@@ -14,7 +14,7 @@ import {
   StepStartStates,
   PartialDatasets,
   Step,
-  InvocationConfigOptions,
+  KeyNormalizationFunction,
 } from '@jupiterone/integration-sdk-core';
 
 export async function executeSteps<
@@ -24,14 +24,14 @@ export async function executeSteps<
   context: TExecutionContext,
   integrationSteps: Step<TStepExecutionContext>[],
   stepStartStates: StepStartStates,
-  invocationConfigOptions?: InvocationConfigOptions,
+  normalizeGraphObjectKey?: KeyNormalizationFunction,
 ): Promise<IntegrationStepResult[]> {
   const stepGraph = buildStepDependencyGraph(integrationSteps);
   return executeStepDependencyGraph(
     context,
     stepGraph,
     stepStartStates,
-    invocationConfigOptions,
+    normalizeGraphObjectKey,
   );
 }
 

--- a/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
@@ -83,9 +83,7 @@ describe('entities', () => {
 
   test('findEntity returns initialized entity from jobState when _key matches with key normalization', async () => {
     const jobState = createMockJobState({
-      invocationConfigOptions: {
-        keyNormalizationFunction: (_key) => _key.toLowerCase(),
-      },
+      normalizeGraphObjectKey: (_key) => _key.toLowerCase(),
     });
     const inputEntity = {
       _type: 'test',

--- a/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
@@ -81,6 +81,22 @@ describe('entities', () => {
     expect(result).toEqual(inputEntities[0]);
   });
 
+  test('findEntity returns initialized entity from jobState when _key matches with key normalization', async () => {
+    const jobState = createMockJobState({
+      invocationConfigOptions: {
+        keyNormalizationFunction: (_key) => _key.toLowerCase(),
+      },
+    });
+    const inputEntity = {
+      _type: 'test',
+      _class: 'Resource',
+      _key: 'INCONSISTENT-casing',
+    };
+    await jobState.addEntities([inputEntity]);
+    const result = await jobState.findEntity('inconsistent-CASING');
+    expect(result).toEqual(inputEntity);
+  });
+
   test('findEntity returns null when entity cannot be found in jobState', async () => {
     const jobState = createMockJobState();
     expect(await jobState.findEntity('does-not-exist')).toEqual(null);

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -5,6 +5,7 @@ import {
   IntegrationMissingKeyError,
   IntegrationDuplicateKeyError,
   GraphObjectLookupKey,
+  InvocationConfigOptions,
 } from '@jupiterone/integration-sdk-core';
 import {
   DuplicateKeyTracker,
@@ -16,6 +17,7 @@ export interface CreateMockJobStateOptions {
   entities?: Entity[];
   relationships?: Relationship[];
   setData?: { [key: string]: any };
+  invocationConfigOptions?: InvocationConfigOptions;
 }
 
 /**
@@ -40,23 +42,28 @@ export function createMockJobState({
   entities: inputEntities = [],
   relationships: inputRelationships = [],
   setData: inputData = {},
+  invocationConfigOptions,
 }: CreateMockJobStateOptions = {}): MockJobState {
   let collectedEntities: Entity[] = [];
   let collectedRelationships: Relationship[] = [];
 
-  const duplicateKeyTracker = new DuplicateKeyTracker();
+  const duplicateKeyTracker = new DuplicateKeyTracker(
+    invocationConfigOptions?.keyNormalizationFunction,
+  );
   const typeTracker = new TypeTracker();
   const dataStore = new MemoryDataStore();
 
   inputEntities.forEach((e) => {
     duplicateKeyTracker.registerKey(e._key, {
       _type: e._type,
+      _key: e._key,
     });
     typeTracker.registerType(e._type);
   });
   inputRelationships.forEach((r) => {
     duplicateKeyTracker.registerKey(r._key as string, {
       _type: r._type,
+      _key: r._key,
     });
     typeTracker.registerType(r._type as string);
   });
@@ -67,6 +74,7 @@ export function createMockJobState({
     newEntities.forEach((e) => {
       duplicateKeyTracker.registerKey(e._key, {
         _type: e._type,
+        _key: e._key,
       });
       typeTracker.registerType(e._type);
     });
@@ -78,6 +86,7 @@ export function createMockJobState({
     newRelationships.forEach((r) => {
       duplicateKeyTracker.registerKey(r._key as string, {
         _type: r._type,
+        _key: r._key,
       });
       typeTracker.registerType(r._type as string);
     });
@@ -165,7 +174,7 @@ export function createMockJobState({
       }
 
       const entity = await getEntity({
-        _key,
+        _key: graphObjectMetadata._key,
         _type: graphObjectMetadata._type,
       });
 

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -5,7 +5,7 @@ import {
   IntegrationMissingKeyError,
   IntegrationDuplicateKeyError,
   GraphObjectLookupKey,
-  InvocationConfigOptions,
+  KeyNormalizationFunction,
 } from '@jupiterone/integration-sdk-core';
 import {
   DuplicateKeyTracker,
@@ -17,7 +17,7 @@ export interface CreateMockJobStateOptions {
   entities?: Entity[];
   relationships?: Relationship[];
   setData?: { [key: string]: any };
-  invocationConfigOptions?: InvocationConfigOptions;
+  normalizeGraphObjectKey?: KeyNormalizationFunction;
 }
 
 /**
@@ -42,14 +42,12 @@ export function createMockJobState({
   entities: inputEntities = [],
   relationships: inputRelationships = [],
   setData: inputData = {},
-  invocationConfigOptions,
+  normalizeGraphObjectKey,
 }: CreateMockJobStateOptions = {}): MockJobState {
   let collectedEntities: Entity[] = [];
   let collectedRelationships: Relationship[] = [];
 
-  const duplicateKeyTracker = new DuplicateKeyTracker(
-    invocationConfigOptions?.keyNormalizationFunction,
-  );
+  const duplicateKeyTracker = new DuplicateKeyTracker(normalizeGraphObjectKey);
   const typeTracker = new TypeTracker();
   const dataStore = new MemoryDataStore();
 

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to
 ### Added
 
 - [#355](https://github.com/JupiterOne/sdk/issues/355) - Added
-  `keyNormalizationFunction` argument to normalize lookups in
+  `normalizeGraphObjectKey` argument to normalize lookups in
   `DuplicateKeyTracker`.
 
 ## 3.5.1 - 2020-10-05

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- [#355](https://github.com/JupiterOne/sdk/issues/355) - Added
+  `keyNormalizationFunction` argument to normalize lookups in
+  `DuplicateKeyTracker`.
+
 ## 3.5.1 - 2020-10-05
 
 ### Changed


### PR DESCRIPTION
The azure integration has been hitting some issues where entity `id`s are returned with inconsistent casing. This makes the `findEntity` function useless in most cases, and prohibits us from identifying valid relationships across an environment. This PR allows users to pass a `keyNormalizationFunction` into an `InvocationConfig` that transforms keys before storing them (or retrieving them from) the `DuplicateKeyTracker`.

Closes #355 