### PR TITLE
Add link to data-model when jest matchers fail to validate schema

### DIFF
--- a/packages/integration-sdk-testing/src/__tests__/jest.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jest.test.ts
@@ -307,7 +307,10 @@ describe('#toMatchGraphObjectSchema', () => {
         data,
         null,
         2,
-      )}, errors=${expectedSerialzedErrors}, index=0)`,
+      )}, errors=${expectedSerialzedErrors}, index=0)
+
+Find out more about JupiterOne schemas: https://github.com/JupiterOne/data-model/tree/master/src/schemas
+`,
     );
   });
 
@@ -324,7 +327,10 @@ describe('#toMatchGraphObjectSchema', () => {
     });
 
     expect(result.message()).toEqual(
-      `Error loading schemas for class (err=Invalid _class passed in schema for "toMatchGraphObjectSchema" (_class=#INVALID_DATA_MODEL_CLASS))`,
+      `Error loading schemas for class (err=Invalid _class passed in schema for "toMatchGraphObjectSchema" (_class=#INVALID_DATA_MODEL_CLASS)
+
+Find out more about JupiterOne schemas: https://github.com/JupiterOne/data-model/tree/master/src/schemas
+)`,
     );
   });
 });
@@ -411,7 +417,10 @@ describe('#toMatchDirectRelationshipSchema', () => {
     },
     "message": "should be boolean,integer,null,number,string"
   }
-], index=0)`);
+], index=0)
+
+Find out more about JupiterOne schemas: https://github.com/JupiterOne/data-model/tree/master/src/schemas
+`);
   });
 
   test('should fail for relationship with object property', () => {
@@ -446,7 +455,10 @@ describe('#toMatchDirectRelationshipSchema', () => {
     },
     "message": "should be boolean,integer,null,number,string"
   }
-], index=0)`);
+], index=0)
+
+Find out more about JupiterOne schemas: https://github.com/JupiterOne/data-model/tree/master/src/schemas
+`);
   });
 });
 

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -17,6 +17,9 @@ declare global {
   }
 }
 
+const FIND_OUT_MORE =
+  '\n\nFind out more about JupiterOne schemas: https://github.com/JupiterOne/data-model/tree/master/src/schemas\n';
+
 function createGraphObjectSchemaValidationError<T>(
   ajv: typeof dataModel.IntegrationSchema,
   data: T,
@@ -27,7 +30,7 @@ function createGraphObjectSchemaValidationError<T>(
 
   return {
     message: () =>
-      `Error validating graph object against schema (data=${serializedData}, errors=${serializedErrors}, index=${index})`,
+      `Error validating graph object against schema (data=${serializedData}, errors=${serializedErrors}, index=${index})${FIND_OUT_MORE}`,
     pass: false,
   };
 }
@@ -42,7 +45,7 @@ function collectSchemasFromRef(
 
   if (!dataModelClassSchema || !dataModelClassSchema.schema) {
     throw new Error(
-      `Invalid _class passed in schema for "toMatchGraphObjectSchema" (_class=${classSchemaRef})`,
+      `Invalid _class passed in schema for "toMatchGraphObjectSchema" (_class=${classSchemaRef})${FIND_OUT_MORE}`,
     );
   }
 


### PR DESCRIPTION
I think it can be hard for external developers (or candidates working on coding challenges) to know where to look when `toMatchGraphObjectSchema()` matchers throw errors about invalid classes/schemas. This change is meant to make it easier for devs to know where to look for our data model schemas.