### PR TITLE
362 failure callback in logger

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^3.6.0",
-    "@jupiterone/integration-sdk-runtime": "^3.6.0",
+    "@jupiterone/integration-sdk-core": "^3.7.0",
+    "@jupiterone/integration-sdk-runtime": "^3.7.0",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^3.6.0",
+    "@jupiterone/integration-sdk-runtime": "^3.7.0",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "lodash": "^4.17.19",
@@ -31,7 +31,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^3.6.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^3.7.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^3.6.0",
-    "@jupiterone/integration-sdk-testing": "^3.6.0",
+    "@jupiterone/integration-sdk-cli": "^3.7.0",
+    "@jupiterone/integration-sdk-testing": "^3.7.0",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "node": "10.x || 12.x || 14.x"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^3.6.0",
+    "@jupiterone/integration-sdk-core": "^3.7.0",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^3.6.0",
+    "@jupiterone/integration-sdk-core": "^3.7.0",
     "@lifeomic/alpha": "^1.1.3",
     "async-sema": "^3.1.0",
     "axios": "^0.19.2",
@@ -42,7 +42,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^3.6.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^3.7.0",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -680,7 +680,7 @@ describe('executeStepDependencyGraph', () => {
 
     expect(errorLogSpy).toHaveBeenCalledTimes(1);
     expect(errorLogSpy).toHaveBeenCalledWith(
-      { step: 'a', err: error, errorId: expect.any(String) },
+      { err: error, errorId: expect.any(String) },
       expect.stringMatching(
         new RegExp(
           `Step "a" failed to complete due to error. \\(errorCode="ABC-123", errorId="(.*)"\\)$`,

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -268,20 +268,8 @@ describe('step event publishing', () => {
     logger.stepSuccess(step);
 
     expect(infoSpy).toHaveBeenCalledTimes(2);
-    expect(infoSpy).toHaveBeenNthCalledWith(
-      1,
-      {
-        step: step.id,
-      },
-      `Starting step "Mochi"...`,
-    );
-    expect(infoSpy).toHaveBeenNthCalledWith(
-      2,
-      {
-        step: step.id,
-      },
-      `Completed step "Mochi".`,
-    );
+    expect(infoSpy).toHaveBeenNthCalledWith(1, {}, `Starting step "Mochi"...`);
+    expect(infoSpy).toHaveBeenNthCalledWith(2, {}, `Completed step "Mochi".`);
 
     const error = new IntegrationLocalConfigFieldMissingError('ripperoni');
     logger.stepFailure(step, error);
@@ -292,7 +280,6 @@ describe('step event publishing', () => {
       {
         err: error,
         errorId: expect.any(String),
-        step: step.id,
       },
       expect.stringContaining(
         `Step "Mochi" failed to complete due to error. (errorCode="${error.code}"`,

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -667,3 +667,68 @@ describe('#publishErrorEvent', () => {
     });
   });
 });
+
+describe('#handleFailure', () => {
+  test('should invoke callback on handleFailure', () => {
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    const errorSpy = jest.spyOn(logger, 'error');
+    const publishEventSpy = jest.spyOn(logger, 'publishEvent');
+
+    const onFailureSpy = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // Property 'onFailure' is private and only accessible within class 'IntegrationLogger'.ts(2341)
+    logger.onFailure = onFailureSpy;
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // Property 'handleFailure' is private and only accessible within class 'IntegrationLogger'.ts(2341)
+    logger.handleFailure({
+      err: new Error(),
+      errorId: 'SOME_ERROR_ID',
+      eventName: 'SOME_EVENT',
+      description: 'an error :(',
+    });
+
+    expect(onFailureSpy).toHaveBeenCalledTimes(1);
+    expect(publishEventSpy).toHaveBeenCalledTimes(1);
+
+    // should call error
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('should invoke callback on handleFailure', () => {
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    const warnSpy = jest.spyOn(logger, 'warn');
+    const publishEventSpy = jest.spyOn(logger, 'publishEvent');
+
+    const onFailureSpy = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // Property 'onFailure' is private and only accessible within class 'IntegrationLogger'.ts(2341)
+    logger.onFailure = onFailureSpy;
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // Property 'handleFailure' is private and only accessible within class 'IntegrationLogger'.ts(2341)
+    logger.handleFailure({
+      err: new IntegrationValidationError(''),
+      errorId: 'SOME_ERROR_ID',
+      eventName: 'SOME_EVENT',
+      description: 'an error :(',
+    });
+
+    expect(onFailureSpy).toHaveBeenCalledTimes(1);
+    expect(publishEventSpy).toHaveBeenCalledTimes(1);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -268,8 +268,8 @@ describe('step event publishing', () => {
     logger.stepSuccess(step);
 
     expect(infoSpy).toHaveBeenCalledTimes(2);
-    expect(infoSpy).toHaveBeenNthCalledWith(1, {}, `Starting step "Mochi"...`);
-    expect(infoSpy).toHaveBeenNthCalledWith(2, {}, `Completed step "Mochi".`);
+    expect(infoSpy).toHaveBeenNthCalledWith(1, `Starting step "Mochi"...`);
+    expect(infoSpy).toHaveBeenNthCalledWith(2, `Completed step "Mochi".`);
 
     const error = new IntegrationLocalConfigFieldMissingError('ripperoni');
     logger.stepFailure(step, error);
@@ -669,7 +669,7 @@ describe('#publishErrorEvent', () => {
 });
 
 describe('#handleFailure', () => {
-  test('should invoke callback on handleFailure', () => {
+  test('should invoke callback on handleFailure and call error on generic error', () => {
     const logger = createIntegrationLogger({
       name,
       invocationConfig,
@@ -690,7 +690,7 @@ describe('#handleFailure', () => {
     logger.handleFailure({
       err: new Error(),
       errorId: 'SOME_ERROR_ID',
-      eventName: 'SOME_EVENT',
+      eventName: 'step_failure',
       description: 'an error :(',
     });
 
@@ -701,7 +701,7 @@ describe('#handleFailure', () => {
     expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('should invoke callback on handleFailure', () => {
+  test('should invoke callback on handleFailure and call warn on validation error', () => {
     const logger = createIntegrationLogger({
       name,
       invocationConfig,
@@ -722,7 +722,7 @@ describe('#handleFailure', () => {
     logger.handleFailure({
       err: new IntegrationValidationError(''),
       errorId: 'SOME_ERROR_ID',
-      eventName: 'SOME_EVENT',
+      eventName: 'step_failure',
       description: 'an error :(',
     });
 
@@ -730,5 +730,40 @@ describe('#handleFailure', () => {
     expect(publishEventSpy).toHaveBeenCalledTimes(1);
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('should invoke handleFailure on validationFailure', () => {
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // Argument of type '"handleFailure"' is not assignable to parameter of type 'never'.ts(2769)
+    const handleFailureSpy = jest.spyOn(logger, 'handleFailure');
+
+    logger.validationFailure(new Error());
+
+    expect(handleFailureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('should invoke handleFailure on stepFailure', () => {
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // Argument of type '"handleFailure"' is not assignable to parameter of type 'never'.ts(2769)
+    const handleFailureSpy = jest.spyOn(logger, 'handleFailure');
+
+    logger.stepFailure(
+      { id: 'step-id', name: 'step-name', entities: [], relationships: [] },
+      new Error(),
+    );
+
+    expect(handleFailureSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -669,20 +669,17 @@ describe('#publishErrorEvent', () => {
 });
 
 describe('#handleFailure', () => {
-  test('should invoke callback on handleFailure and call error on generic error', () => {
+  test('should invoke onFailure and publishEvent', () => {
     const logger = createIntegrationLogger({
       name,
       invocationConfig,
     });
 
-    const errorSpy = jest.spyOn(logger, 'error');
-    const publishEventSpy = jest.spyOn(logger, 'publishEvent');
-
-    const onFailureSpy = jest.fn();
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // Property 'onFailure' is private and only accessible within class 'IntegrationLogger'.ts(2341)
-    logger.onFailure = onFailureSpy;
+    // Argument of type '"onFailure"' is not assignable to parameter of type 'never'.ts(2769)
+    const onFailureSpy = jest.spyOn(logger, 'onFailure');
+    const publishEventSpy = jest.spyOn(logger, 'publishEvent');
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -696,25 +693,36 @@ describe('#handleFailure', () => {
 
     expect(onFailureSpy).toHaveBeenCalledTimes(1);
     expect(publishEventSpy).toHaveBeenCalledTimes(1);
+  });
 
-    // should call error
+  test('should log as error when error is meant to be handled by an operator', () => {
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    const errorSpy = jest.spyOn(logger, 'error');
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // Property 'handleFailure' is private and only accessible within class 'IntegrationLogger'.ts(2341)
+    logger.handleFailure({
+      err: new Error(),
+      errorId: 'SOME_ERROR_ID',
+      eventName: 'step_failure',
+      description: 'an error :(',
+    });
+
     expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('should invoke callback on handleFailure and call warn on validation error', () => {
+  test('should log as warn when error is meant to be handled by a user', () => {
     const logger = createIntegrationLogger({
       name,
       invocationConfig,
     });
 
     const warnSpy = jest.spyOn(logger, 'warn');
-    const publishEventSpy = jest.spyOn(logger, 'publishEvent');
-
-    const onFailureSpy = jest.fn();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // Property 'onFailure' is private and only accessible within class 'IntegrationLogger'.ts(2341)
-    logger.onFailure = onFailureSpy;
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -725,9 +733,6 @@ describe('#handleFailure', () => {
       eventName: 'step_failure',
       description: 'an error :(',
     });
-
-    expect(onFailureSpy).toHaveBeenCalledTimes(1);
-    expect(publishEventSpy).toHaveBeenCalledTimes(1);
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -259,14 +259,14 @@ export class IntegrationLogger extends EventEmitter
   stepStart(step: StepMetadata) {
     const name = 'step_start';
     const description = `Starting step "${step.name}"...`;
-    this.info({}, description);
+    this.info(description);
     this.publishEvent({ name, description });
   }
 
   stepSuccess(step: StepMetadata) {
     const name = 'step_end';
     const description = `Completed step "${step.name}".`;
-    this.info({}, description);
+    this.info(description);
     this.publishEvent({ name, description });
   }
 
@@ -313,7 +313,7 @@ export class IntegrationLogger extends EventEmitter
   }
 
   private handleFailure(options: {
-    eventName: string;
+    eventName: 'validation_failure' | 'step_failure';
     errorId: string;
     err: Error;
     description: string;

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -248,14 +248,14 @@ export class IntegrationLogger extends EventEmitter
   stepStart(step: StepMetadata) {
     const name = 'step_start';
     const description = `Starting step "${step.name}"...`;
-    this.info({ step: step.id }, description);
+    this.info({}, description);
     this.publishEvent({ name, description });
   }
 
   stepSuccess(step: StepMetadata) {
     const name = 'step_end';
     const description = `Completed step "${step.name}".`;
-    this.info({ step: step.id }, description);
+    this.info({}, description);
     this.publishEvent({ name, description });
   }
 
@@ -266,7 +266,7 @@ export class IntegrationLogger extends EventEmitter
       `Step "${step.name}" failed to complete due to error.`,
     );
 
-    this.error({ errorId, err, step: step.id }, description);
+    this.error({ errorId, err }, description);
     this.publishEvent({ name, description });
   }
 

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^3.6.0",
-    "@jupiterone/integration-sdk-runtime": "^3.6.0",
+    "@jupiterone/integration-sdk-core": "^3.7.0",
+    "@jupiterone/integration-sdk-runtime": "^3.7.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^3.6.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^3.7.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- [#362](https://github.com/JupiterOne/sdk/issues/362) - Added `onFailure`
+  callback to integration logger constructor.
+
 ## 3.6.0 - 2020-10-19
 
 ### Added

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## Unreleased
 
+## 3.7.0 - 2020-10-23
+
 ### Added
 
 - [#362](https://github.com/JupiterOne/sdk/issues/362) - Added `onFailure`


### PR DESCRIPTION
Fixes #362 

Also removed the `step` property from logs, since there is already a `stepId` property attached in every step context: 
https://github.com/JupiterOne/sdk/blob/master/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts#L314