### PR TITLE
Expose onFailure callback in createIntegrationLogger

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^3.7.0",
-    "@jupiterone/integration-sdk-runtime": "^3.7.0",
+    "@jupiterone/integration-sdk-core": "^3.8.0",
+    "@jupiterone/integration-sdk-runtime": "^3.8.0",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^3.7.0",
+    "@jupiterone/integration-sdk-runtime": "^3.8.0",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "lodash": "^4.17.19",
@@ -31,7 +31,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^3.7.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^3.8.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^3.7.0",
-    "@jupiterone/integration-sdk-testing": "^3.7.0",
+    "@jupiterone/integration-sdk-cli": "^3.8.0",
+    "@jupiterone/integration-sdk-testing": "^3.8.0",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "node": "10.x || 12.x || 14.x"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^3.7.0",
+    "@jupiterone/integration-sdk-core": "^3.8.0",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^3.7.0",
+    "@jupiterone/integration-sdk-core": "^3.8.0",
     "@lifeomic/alpha": "^1.1.3",
     "async-sema": "^3.1.0",
     "axios": "^0.19.2",
@@ -42,7 +42,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^3.7.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^3.8.0",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -40,6 +40,7 @@ interface CreateLoggerInput<
   invocationConfig?: InvocationConfig<TExecutionContext, TStepExecutionContext>;
   pretty?: boolean;
   serializers?: Logger.Serializers;
+  onFailure?: OnFailureFunction;
 }
 
 interface CreateIntegrationLoggerInput
@@ -57,6 +58,7 @@ export function createLogger<
   name,
   pretty,
   serializers,
+  onFailure,
 }: CreateLoggerInput<
   TExecutionContext,
   TStepExecutionContext
@@ -84,6 +86,7 @@ export function createLogger<
   return new IntegrationLogger({
     logger,
     errorSet,
+    onFailure,
   });
 }
 
@@ -96,6 +99,7 @@ export function createIntegrationLogger({
   invocationConfig,
   pretty,
   serializers,
+  onFailure,
 }: CreateIntegrationLoggerInput): IntegrationLogger {
   const serializeInstanceConfig = createInstanceConfigSerializer(
     invocationConfig?.instanceConfigFields,
@@ -115,6 +119,7 @@ export function createIntegrationLogger({
       }),
       ...serializers,
     },
+    onFailure,
   });
 }
 

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^3.7.0",
-    "@jupiterone/integration-sdk-runtime": "^3.7.0",
+    "@jupiterone/integration-sdk-core": "^3.8.0",
+    "@jupiterone/integration-sdk-runtime": "^3.8.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^3.7.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^3.8.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## Unreleased
 
+## 3.8.0 - 2020-10-26
+
+- Expose `onFaliure` callback in `createIntegrationLogger`
+
 ## 3.7.0 - 2020-10-23
 
 ### Added


### PR DESCRIPTION
Add-on to #363. Unfortunately, that PR did not expose the callback in the `createIntegrationLogger` interface.