### PR TITLE
Support tokens for authorization

### DIFF
--- a/packages/cli/src/__tests__/cli-export.test.ts
+++ b/packages/cli/src/__tests__/cli-export.test.ts
@@ -194,13 +194,18 @@ test('should log error when export fails', async () => {
 
 test('should throw error when missing api key', async () => {
   await expect(
-    createCli().parseAsync(['node', 'j1', 'export']),
+    createCli().parseAsync([
+      'node',
+      'j1',
+      'export',
+      `--account=${TEST_ACCOUNT}`,
+    ]),
   ).rejects.toThrow(
     /Missing option! Set the JUPITERONE_API_KEY environment variable or supply the --api-key option./,
   );
 });
 
-test('should throw error when missing api key', async () => {
+test('should throw error when missing account', async () => {
   await expect(
     createCli().parseAsync([
       'node',

--- a/packages/cli/src/__tests__/cli-export.test.ts
+++ b/packages/cli/src/__tests__/cli-export.test.ts
@@ -3,7 +3,7 @@ import { mocked } from 'ts-jest/utils';
 import * as runtime from '@jupiterone/integration-sdk-runtime';
 
 import { createCli } from '..';
-import { TEST_API_KEY } from './utils';
+import { TEST_API_KEY, TEST_ACCOUNT } from './utils';
 import * as log from '../log';
 import { vol } from 'memfs';
 import { createEntity, createRelationship } from '../export/__tests__/utils';
@@ -15,7 +15,7 @@ jest.mock('fs');
 jest.mock('../log');
 
 const mockedAxios = mocked(axios, true);
-const mockedCreateApiClient = mocked(runtime.createApiClientWithApiKey, true);
+const mockedCreateApiClient = mocked(runtime.createApiClient, true);
 
 beforeEach(() => {
   mockedCreateApiClient.mockReturnValue(axios);
@@ -59,6 +59,7 @@ test('should export assets', async () => {
       'node',
       'j1',
       'export',
+      `--account=${TEST_ACCOUNT}`,
       `--api-key=${TEST_API_KEY}`,
     ]),
   ).resolves.toEqual(expect.anything());
@@ -110,6 +111,7 @@ test('should only export relationships when specified', async () => {
       'node',
       'j1',
       'export',
+      `--account=${TEST_ACCOUNT}`,
       `--api-key=${TEST_API_KEY}`,
       `--no-include-entities`,
     ]),
@@ -156,6 +158,7 @@ test('should only export entities when specified', async () => {
       'node',
       'j1',
       'export',
+      `--account=${TEST_ACCOUNT}`,
       `--api-key=${TEST_API_KEY}`,
       `--no-include-entities`,
     ]),
@@ -181,6 +184,7 @@ test('should log error when export fails', async () => {
       'node',
       'j1',
       'export',
+      `--account=${TEST_ACCOUNT}`,
       `--api-key=${TEST_API_KEY}`,
     ]),
   ).rejects.toThrow(error);
@@ -192,6 +196,19 @@ test('should throw error when missing api key', async () => {
   await expect(
     createCli().parseAsync(['node', 'j1', 'export']),
   ).rejects.toThrow(
-    /Missing apiKey! Set the JUPITERONE_API_KEY environment variable or supply the --api-key option./,
+    /Missing option! Set the JUPITERONE_API_KEY environment variable or supply the --api-key option./,
+  );
+});
+
+test('should throw error when missing api key', async () => {
+  await expect(
+    createCli().parseAsync([
+      'node',
+      'j1',
+      'export',
+      `--api-key=${TEST_API_KEY}`,
+    ]),
+  ).rejects.toThrow(
+    /Missing option! Set the JUPITERONE_ACCOUNT environment variable or supply the --account option./,
   );
 });

--- a/packages/cli/src/__tests__/cli-import.test.ts
+++ b/packages/cli/src/__tests__/cli-import.test.ts
@@ -5,8 +5,16 @@ import { vol } from 'memfs';
 import { v4 as uuid } from 'uuid';
 import globby from 'globby';
 
-import { TEST_API_KEY, TEST_STORAGE_LOCATION } from "../__tests__/utils";
-import { createRelationship, parseToCsv, createEntity } from "../export/__tests__/utils";
+import {
+  TEST_ACCOUNT,
+  TEST_API_KEY,
+  TEST_STORAGE_LOCATION,
+} from '../__tests__/utils';
+import {
+  createRelationship,
+  parseToCsv,
+  createEntity,
+} from '../export/__tests__/utils';
 import * as log from '../log';
 import { createCli } from '..';
 
@@ -18,22 +26,24 @@ jest.mock('globby');
 jest.mock('../pause');
 jest.mock('../log');
 
-const mockedCreateApiClient = mocked(runtime.createApiClientWithApiKey, true);
+const mockedCreateApiClient = mocked(runtime.createApiClient, true);
 const mockedAxios = mocked(axios, true);
 const mockedGlobby = mocked(globby, true);
 
 const type1Entities = [
   createEntity({
-    id: '1', type: '1', optionalProps: {
+    id: '1',
+    type: '1',
+    optionalProps: {
       'tag.Production': JSON.stringify({
         nested: {
-          object: 'foobar'
-        }
-      })
-    }
+          object: 'foobar',
+        },
+      }),
+    },
   }),
   createEntity({ id: '2', type: '1' }),
-]
+];
 
 const type2Entities = [
   createEntity({ id: '3', type: '2' }),
@@ -44,23 +54,33 @@ const type1Relationships = [
   createRelationship({
     from: createEntity({ id: '3', type: '2' }),
     to: createEntity({ id: '4', type: '2' }),
-  })
+  }),
 ];
 
 beforeEach(async () => {
   mockedCreateApiClient.mockReturnValue(axios);
   vol.reset();
   vol.fromJSON({
-    [`${TEST_STORAGE_LOCATION}/csv/entities/entity_type_1/${uuid()}.csv`]: await parseToCsv(type1Entities),
-    [`${TEST_STORAGE_LOCATION}/csv/entities/entity_type_2/${uuid()}.csv`]: await parseToCsv(type2Entities),
-    [`${TEST_STORAGE_LOCATION}/csv/relationships/relationship_type_1/${uuid()}.csv`]: await parseToCsv(type1Relationships),
-  })
+    [`${TEST_STORAGE_LOCATION}/csv/entities/entity_type_1/${uuid()}.csv`]: await parseToCsv(
+      type1Entities,
+    ),
+    [`${TEST_STORAGE_LOCATION}/csv/entities/entity_type_2/${uuid()}.csv`]: await parseToCsv(
+      type2Entities,
+    ),
+    [`${TEST_STORAGE_LOCATION}/csv/relationships/relationship_type_1/${uuid()}.csv`]: await parseToCsv(
+      type1Relationships,
+    ),
+  });
   mockedGlobby.mockImplementation((path) => {
     let paths: string[] = [];
     if (path.includes('entities')) {
-      paths = Object.keys(vol.toJSON()).filter(file => file.includes('/entities/'));
+      paths = Object.keys(vol.toJSON()).filter((file) =>
+        file.includes('/entities/'),
+      );
     } else {
-      paths = Object.keys(vol.toJSON()).filter(file => file.includes('/relationships/'));
+      paths = Object.keys(vol.toJSON()).filter((file) =>
+        file.includes('/relationships/'),
+      );
     }
 
     return Promise.resolve(paths);
@@ -70,119 +90,185 @@ beforeEach(async () => {
 
 test('should import json assets', async () => {
   const jobId = uuid();
-  mockedAxios.post
-    .mockResolvedValue({ data: { job: { id: jobId } } })
-  mockedAxios.get
-    .mockResolvedValue({ data: { job: { id: jobId, status: 'FINISHED' } } })
+  mockedAxios.post.mockResolvedValue({ data: { job: { id: jobId } } });
+  mockedAxios.get.mockResolvedValue({
+    data: { job: { id: jobId, status: 'FINISHED' } },
+  });
 
   const scope = uuid();
   await createCli().parseAsync([
     'node',
     'j1',
     'import',
+    `--account=${TEST_ACCOUNT}`,
     `--api-key=${TEST_API_KEY}`,
     `--scope=${scope}`,
   ]);
 
-  expect(mockedAxios.post).toHaveBeenCalledWith('/persister/synchronization/jobs', {
-    source: 'api',
-    scope
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/relationships?ignoreDuplicates=true&ignoreIllegalProperties=true`, await parseToCsv(type1Relationships), {
-    headers: { 'Content-Type': 'text/csv' }
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`, await parseToCsv(type1Entities), {
-    headers: { 'Content-Type': 'text/csv' }
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`, await parseToCsv(type2Entities), {
-    headers: { 'Content-Type': 'text/csv' }
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/finalize`);
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    '/persister/synchronization/jobs',
+    {
+      source: 'api',
+      scope,
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/relationships?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+    await parseToCsv(type1Relationships),
+    {
+      headers: { 'Content-Type': 'text/csv' },
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+    await parseToCsv(type1Entities),
+    {
+      headers: { 'Content-Type': 'text/csv' },
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+    await parseToCsv(type2Entities),
+    {
+      headers: { 'Content-Type': 'text/csv' },
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/finalize`,
+  );
 });
 
 test('should exclude relationships when specified', async () => {
   const jobId = uuid();
-  mockedAxios.post
-    .mockResolvedValue({ data: { job: { id: jobId } } })
-  mockedAxios.get
-    .mockResolvedValue({ data: { job: { id: jobId, status: 'FINISHED' } } })
+  mockedAxios.post.mockResolvedValue({ data: { job: { id: jobId } } });
+  mockedAxios.get.mockResolvedValue({
+    data: { job: { id: jobId, status: 'FINISHED' } },
+  });
 
   const scope = uuid();
   await createCli().parseAsync([
     'node',
     'j1',
     'import',
+    `--account=${TEST_ACCOUNT}`,
     `--api-key=${TEST_API_KEY}`,
     `--scope=${scope}`,
-    `--no-include-relationships`
+    `--no-include-relationships`,
   ]);
 
-  expect(mockedAxios.post).toHaveBeenCalledWith('/persister/synchronization/jobs', {
-    source: 'api',
-    scope
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`, await parseToCsv(type1Entities), {
-    headers: { 'Content-Type': 'text/csv' }
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`, await parseToCsv(type2Entities), {
-    headers: { 'Content-Type': 'text/csv' }
-  });
-  expect(mockedAxios.post).not.toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/relationships?ignoreDuplicates=true&ignoreIllegalProperties=true`, expect.anything(), {
-    headers: { 'Content-Type': 'text/csv' }
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/finalize`);
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    '/persister/synchronization/jobs',
+    {
+      source: 'api',
+      scope,
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+    await parseToCsv(type1Entities),
+    {
+      headers: { 'Content-Type': 'text/csv' },
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+    await parseToCsv(type2Entities),
+    {
+      headers: { 'Content-Type': 'text/csv' },
+    },
+  );
+  expect(mockedAxios.post).not.toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/relationships?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+    expect.anything(),
+    {
+      headers: { 'Content-Type': 'text/csv' },
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/finalize`,
+  );
 });
 
 test('should exclude relationships when specified', async () => {
   const jobId = uuid();
-  mockedAxios.post
-    .mockResolvedValue({ data: { job: { id: jobId } } })
-  mockedAxios.get
-    .mockResolvedValue({ data: { job: { id: jobId, status: 'FINISHED' } } })
+  mockedAxios.post.mockResolvedValue({ data: { job: { id: jobId } } });
+  mockedAxios.get.mockResolvedValue({
+    data: { job: { id: jobId, status: 'FINISHED' } },
+  });
 
   const scope = uuid();
   await createCli().parseAsync([
     'node',
     'j1',
     'import',
+    `--account=${TEST_ACCOUNT}`,
     `--api-key=${TEST_API_KEY}`,
     `--scope=${scope}`,
-    `--no-include-entities`
+    `--no-include-entities`,
   ]);
 
-  expect(mockedAxios.post).toHaveBeenCalledWith('/persister/synchronization/jobs', {
-    source: 'api',
-    scope
-  });
-  expect(mockedAxios.post).not.toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`, expect.anything(), {
-    headers: { 'Content-Type': 'text/csv' }
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/relationships?ignoreDuplicates=true&ignoreIllegalProperties=true`, await parseToCsv(type1Relationships), {
-    headers: { 'Content-Type': 'text/csv' }
-  });
-  expect(mockedAxios.post).toHaveBeenCalledWith(`/persister/synchronization/jobs/${jobId}/finalize`);
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    '/persister/synchronization/jobs',
+    {
+      source: 'api',
+      scope,
+    },
+  );
+  expect(mockedAxios.post).not.toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/entities?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+    expect.anything(),
+    {
+      headers: { 'Content-Type': 'text/csv' },
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/relationships?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+    await parseToCsv(type1Relationships),
+    {
+      headers: { 'Content-Type': 'text/csv' },
+    },
+  );
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    `/persister/synchronization/jobs/${jobId}/finalize`,
+  );
 });
 
 test('should throw error when missing api key', async () => {
-  await expect(createCli().parseAsync([
-    'node',
-    'j1',
-    'import',
-    `--scope=${uuid()}`,
-  ])).rejects.toThrow(/Missing apiKey! Set the JUPITERONE_API_KEY environment variable or supply the --api-key option./);
+  await expect(
+    createCli().parseAsync(['node', 'j1', 'import', `--scope=${uuid()}`]),
+  ).rejects.toThrow(
+    /Missing option! Set the JUPITERONE_API_KEY environment variable or supply the --api-key option./,
+  );
+});
+
+test('should throw error when missing account', async () => {
+  await expect(
+    createCli().parseAsync([
+      'node',
+      'j1',
+      'import',
+      `--api-key=${TEST_API_KEY}`,
+      `--scope=${uuid()}`,
+    ]),
+  ).rejects.toThrow(
+    /Missing option! Set the JUPITERONE_ACCOUNT environment variable or supply the --account option./,
+  );
 });
 
 test('should log error when import fails', async () => {
   const error = new Error();
   mockedAxios.post.mockRejectedValue(error);
 
-  await expect(createCli().parseAsync([
-    'node',
-    'j1',
-    'import',
-    `--api-key=${TEST_API_KEY}`,
-    `--scope=${uuid()}`,
-  ])).rejects.toThrow(error);
+  await expect(
+    createCli().parseAsync([
+      'node',
+      'j1',
+      'import',
+      `--account=${TEST_ACCOUNT}`,
+      `--api-key=${TEST_API_KEY}`,
+      `--scope=${uuid()}`,
+    ]),
+  ).rejects.toThrow(error);
 
   expect(log.error).toHaveBeenCalledWith(error);
 });

--- a/packages/cli/src/__tests__/utils/constants.ts
+++ b/packages/cli/src/__tests__/utils/constants.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_EXPORT_DIRECTORY } from "../../commands";
+import { DEFAULT_EXPORT_DIRECTORY } from '../../commands';
 
 export const TEST_STORAGE_LOCATION = DEFAULT_EXPORT_DIRECTORY;
+export const TEST_ACCOUNT = 'account';
 export const TEST_API_KEY = 'apiKey';

--- a/packages/cli/src/commands/j1Export.ts
+++ b/packages/cli/src/commands/j1Export.ts
@@ -3,10 +3,11 @@ import path from 'path';
 
 import * as log from '../log';
 import exportAssets from '../export/exportAssets';
-import { validateApiKey } from '../validateApiKey';
+import { validateOption } from '../validateOption';
 
 export interface ExportOptions {
   dataDir: string;
+  account: string;
   apiKey: string;
   includeEntities: boolean;
   includeRelationships: boolean;
@@ -22,6 +23,10 @@ export function j1Export() {
       '-d, --data-dir <relative_directory>',
       'The directory where entities/relationships will be downloaded',
       DEFAULT_EXPORT_DIRECTORY,
+    )
+    .option(
+      '--account <account>',
+      'The JupiterOne account you are importing entities/relationships into',
     )
     .option(
       '--api-key <key>',
@@ -43,8 +48,17 @@ export function j1Export() {
     .action(async (options: ExportOptions) => {
       log.info(`Starting export...`);
       const storageDirectory = path.join(process.cwd(), options.dataDir);
-      const apiKey = validateApiKey(options.apiKey);
+      const apiKey = validateOption({
+        option: '--api-key',
+        value: options.apiKey,
+        defaultEnvironmentVariable: 'JUPITERONE_API_KEY',
+      });
+      const account = validateOption({
+        option: '--account',
+        value: options.account,
+        defaultEnvironmentVariable: 'JUPITERONE_ACCOUNT',
+      });
 
-      await exportAssets({ ...options, storageDirectory, apiKey });
+      await exportAssets({ ...options, storageDirectory, account, apiKey });
     });
 }

--- a/packages/cli/src/commands/j1Export.ts
+++ b/packages/cli/src/commands/j1Export.ts
@@ -26,7 +26,7 @@ export function j1Export() {
     )
     .option(
       '--account <account>',
-      'The JupiterOne account you are importing entities/relationships into',
+      'The JupiterOne account you are exporting entities/relationships from',
     )
     .option(
       '--api-key <key>',

--- a/packages/cli/src/commands/j1Import.ts
+++ b/packages/cli/src/commands/j1Import.ts
@@ -2,20 +2,21 @@ import { createCommand } from 'commander';
 import * as log from '../log';
 import path from 'path';
 import { importAssets } from '../import/importAssets';
-import { validateApiKey } from '../validateApiKey';
+import { validateOption } from '../validateOption';
 
 export interface ImportOptions {
   dataDir: string;
   includeEntities?: boolean;
   includeRelationships?: boolean;
   scope: string;
-  apiKey?: string;
+  account: string;
+  apiKey: string;
 }
 
 export function j1Import() {
   return createCommand('import')
     .description(
-      'Imports exported account entities/relationships into j1 account',
+      'Imports exported account entities/relationships into JupiterOne account',
     )
     .option(
       '-d --data-dir <relative_directory>',
@@ -25,6 +26,10 @@ export function j1Import() {
     .requiredOption(
       '--scope <scope>',
       'A unique id that identifies the synchronization job that will be importing your assets, use any id of your choosing.',
+    )
+    .option(
+      '--account <account>',
+      'The JupiterOne account you are importing entities/relationships into',
     )
     .option(
       '--api-key <key>',
@@ -41,8 +46,17 @@ export function j1Import() {
     .action(async (options: ImportOptions) => {
       log.info(`Importing entities into account...`);
       const storageDirectory = path.join(process.cwd(), options.dataDir);
-      const apiKey = validateApiKey(options.apiKey);
+      const apiKey = validateOption({
+        option: '--api-key',
+        value: options.apiKey,
+        defaultEnvironmentVariable: 'JUPITERONE_API_KEY',
+      });
+      const account = validateOption({
+        option: '--account',
+        value: options.account,
+        defaultEnvironmentVariable: 'JUPITERONE_ACCOUNT',
+      });
 
-      await importAssets({ ...options, storageDirectory, apiKey });
+      await importAssets({ ...options, storageDirectory, account, apiKey });
     });
 }

--- a/packages/cli/src/export/bulkDownloadToJson.ts
+++ b/packages/cli/src/export/bulkDownloadToJson.ts
@@ -1,49 +1,72 @@
-import { createApiClientWithApiKey, getApiBaseUrl } from "@jupiterone/integration-sdk-runtime";
+import {
+  createApiClient,
+  getApiBaseUrl,
+} from '@jupiterone/integration-sdk-runtime';
 import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
-import { Entity, Relationship } from "@jupiterone/integration-sdk-core";
+import { Entity, Relationship } from '@jupiterone/integration-sdk-core';
 
-import { ensureDirectoryExists, writeFileToPath } from "../fileSystem";
-import path from "path";
-import { sanitizeContent } from "./util";
+import { ensureDirectoryExists, writeFileToPath } from '../fileSystem';
+import path from 'path';
+import { sanitizeContent } from './util';
 
 const J1_ENDPOINT = getApiBaseUrl({ dev: !!process.env.JUPITERONE_DEV });
 
 interface BulkEntitiesData {
-  items: Entity[],
-  endCursor?: string
+  items: Entity[];
+  endCursor?: string;
 }
 
 interface BulkRelationshipsData {
-  items: Relationship[],
-  endCursor?: string
+  items: Relationship[];
+  endCursor?: string;
 }
 
-async function exportAssetGroupToJson(assetPath: string, objects: Entity[] | Relationship[]) {
-  const groups = _.groupBy(objects, '_type')
-  await Promise.all(Object.keys(groups).map(async (type) => {
-    const group = groups[type];
-    const groupTypePath = path.join(assetPath, type);
+async function exportAssetGroupToJson(
+  assetPath: string,
+  objects: Entity[] | Relationship[],
+) {
+  const groups = _.groupBy(objects, '_type');
+  await Promise.all(
+    Object.keys(groups).map(async (type) => {
+      const group = groups[type];
+      const groupTypePath = path.join(assetPath, type);
 
-    await writeFileToPath({ filePath: path.join(groupTypePath, `${uuid()}.json`), content: sanitizeContent(JSON.stringify(group)) })
-  }));
+      await writeFileToPath({
+        filePath: path.join(groupTypePath, `${uuid()}.json`),
+        content: sanitizeContent(JSON.stringify(group)),
+      });
+    }),
+  );
 }
 
 export type BulkDownloadParams = {
   assetType: 'entities' | 'relationships';
   storageDirectory: string;
+  account: string;
   apiKey: string;
   includeDeleted: boolean;
-  progress: (totalDownloaded: number) => void
-}
+  progress: (totalDownloaded: number) => void;
+};
 
 export const ASSET_DOWNLOAD_LIMIT = 4000;
 
-export async function bulkDownloadToJson({ storageDirectory, assetType, apiKey, includeDeleted, progress }: BulkDownloadParams) {
+export async function bulkDownloadToJson({
+  storageDirectory,
+  assetType,
+  account,
+  apiKey,
+  includeDeleted,
+  progress,
+}: BulkDownloadParams) {
   let endCursor: string | undefined;
   let assetCount = 0;
 
-  const apiClient = createApiClientWithApiKey({ apiBaseUrl: J1_ENDPOINT, apiKey });
+  const apiClient = createApiClient({
+    apiBaseUrl: J1_ENDPOINT,
+    account,
+    accessToken: apiKey,
+  });
 
   const assetPath = path.join(storageDirectory, 'json', assetType);
   await ensureDirectoryExists(assetPath);
@@ -53,8 +76,14 @@ export async function bulkDownloadToJson({ storageDirectory, assetType, apiKey, 
   do {
     let data: any;
     try {
-      const response = await apiClient.get<BulkEntitiesData | BulkRelationshipsData>(`/${assetType}?limit=${limit}&includeDeleted=${includeDeleted}${endCursor ? '&cursor=' + endCursor : ''}`);
-      data = response.data
+      const response = await apiClient.get<
+        BulkEntitiesData | BulkRelationshipsData
+      >(
+        `/${assetType}?limit=${limit}&includeDeleted=${includeDeleted}${
+          endCursor ? '&cursor=' + endCursor : ''
+        }`,
+      );
+      data = response.data;
       limit = ASSET_DOWNLOAD_LIMIT;
       tooLarge = false;
     } catch (e) {
@@ -62,8 +91,7 @@ export async function bulkDownloadToJson({ storageDirectory, assetType, apiKey, 
         limit /= 2;
         tooLarge = true;
         continue;
-      }
-      else {
+      } else {
         throw e;
       }
     }
@@ -74,5 +102,5 @@ export async function bulkDownloadToJson({ storageDirectory, assetType, apiKey, 
     assetCount += data.items.length;
 
     progress(assetCount);
-  } while (endCursor || tooLarge)
+  } while (endCursor || tooLarge);
 }

--- a/packages/cli/src/export/exportAssetsToJson.ts
+++ b/packages/cli/src/export/exportAssetsToJson.ts
@@ -4,46 +4,59 @@ import { bulkDownloadToJson } from './bulkDownloadToJson';
 import { ExportAssetsParams } from './exportAssets';
 import * as log from '../log';
 
-export type ExportAssetsToJsonParams = ExportAssetsParams & { apiKey: string };
-
-export async function exportAssetsToJson({ storageDirectory, includeDeleted, includeEntities, includeRelationships, apiKey }: ExportAssetsToJsonParams) {
+export async function exportAssetsToJson({
+  storageDirectory,
+  includeDeleted,
+  includeEntities,
+  includeRelationships,
+  account,
+  apiKey,
+}: ExportAssetsParams) {
   const spinner = createSpinner('Exporting assets to JSON').start();
   try {
     let entityCount = 0;
     let relationshipCount = 0;
     const updateSpinner = () => {
-      spinner.text = `Downloaded ${entityCount} entities and ${relationshipCount} relationships...`
+      spinner.text = `Downloaded ${entityCount} entities and ${relationshipCount} relationships...`;
     };
     const bulkDownloads: Promise<void>[] = [];
 
     if (includeEntities) {
-      bulkDownloads.push(bulkDownloadToJson({
-        storageDirectory,
-        assetType: 'entities',
-        apiKey,
-        includeDeleted,
-        progress: count => {
-          entityCount = count;
-          updateSpinner();
-        }
-      }));
+      bulkDownloads.push(
+        bulkDownloadToJson({
+          storageDirectory,
+          assetType: 'entities',
+          account,
+          apiKey,
+          includeDeleted,
+          progress: (count) => {
+            entityCount = count;
+            updateSpinner();
+          },
+        }),
+      );
     }
 
     if (includeRelationships) {
-      bulkDownloads.push(bulkDownloadToJson({
-        storageDirectory,
-        assetType: 'relationships',
-        apiKey,
-        includeDeleted,
-        progress: count => {
-          relationshipCount = count;
-          updateSpinner();
-        }
-      }));
+      bulkDownloads.push(
+        bulkDownloadToJson({
+          storageDirectory,
+          assetType: 'relationships',
+          account,
+          apiKey,
+          includeDeleted,
+          progress: (count) => {
+            relationshipCount = count;
+            updateSpinner();
+          },
+        }),
+      );
     }
 
     await Promise.all(bulkDownloads);
-    spinner.succeed(`Export Successful, Downloaded ${entityCount} entities and ${relationshipCount} relationships!`);
+    spinner.succeed(
+      `Export Successful, Downloaded ${entityCount} entities and ${relationshipCount} relationships!`,
+    );
   } catch (e) {
     const failMessage = 'Failed to export assets to JSON';
     log.error(failMessage);

--- a/packages/cli/src/export/exportJsonAssetsToCsv.ts
+++ b/packages/cli/src/export/exportJsonAssetsToCsv.ts
@@ -3,42 +3,51 @@ import createSpinner from 'ora';
 import _ from 'lodash';
 import path from 'path';
 
-import { ExportAssetsParams as ExportAssetParams } from "./exportAssets";
-import { getJsonAssetsDirectory, getCsvAssetsDirectory, } from "../fileSystem";
+import { ExportAssetsParams as ExportAssetParams } from './exportAssets';
+import { getJsonAssetsDirectory, getCsvAssetsDirectory } from '../fileSystem';
 import { groupJsonAssetsByType } from './groupJsonAssetsByType';
 import * as log from '../log';
 import { writeAssetsToCsv } from './writeAssetsToCsv';
 
-type ExportAssetTypeParams = ExportJsonAssetParams & { type: 'entities' | 'relationships' };
+type ExportAssetTypeParams = ExportAssetParams & {
+  type: 'entities' | 'relationships';
+};
 
 export async function exportJsonAssetTypeToCsv(options: ExportAssetTypeParams) {
   const jsonAssetsDirectory = getJsonAssetsDirectory(options.storageDirectory);
-  const groupedAssetFiles = await groupJsonAssetsByType({ assetDirectory: `${jsonAssetsDirectory}/${options.type}` });
+  const groupedAssetFiles = await groupJsonAssetsByType({
+    assetDirectory: `${jsonAssetsDirectory}/${options.type}`,
+  });
 
-  const directory = path.join(getCsvAssetsDirectory(options.storageDirectory), options.type);
+  const directory = path.join(
+    getCsvAssetsDirectory(options.storageDirectory),
+    options.type,
+  );
   await writeAssetsToCsv({ groupedAssetFiles, directory });
 }
 
-type ExportJsonAssetParams = Omit<ExportAssetParams, 'includeDeleted'>;
-
-export async function exportJsonAssetsToCsv(options: ExportJsonAssetParams) {
+export async function exportJsonAssetsToCsv(options: ExportAssetParams) {
   const spinner = createSpinner('Exporting JSON Assets to CSV').start();
 
   try {
     const exports: Promise<void>[] = [];
 
     if (options.includeEntities) {
-      exports.push(exportJsonAssetTypeToCsv({
-        ...options,
-        type: 'entities'
-      }));
+      exports.push(
+        exportJsonAssetTypeToCsv({
+          ...options,
+          type: 'entities',
+        }),
+      );
     }
 
     if (options.includeRelationships) {
-      exports.push(exportJsonAssetTypeToCsv({
-        ...options,
-        type: 'relationships'
-      }));
+      exports.push(
+        exportJsonAssetTypeToCsv({
+          ...options,
+          type: 'relationships',
+        }),
+      );
     }
 
     await Promise.all(exports);

--- a/packages/cli/src/import/importAssets.ts
+++ b/packages/cli/src/import/importAssets.ts
@@ -1,11 +1,15 @@
-import { ImportOptions } from "../commands";
+import { ImportOptions } from '../commands';
 import * as log from '../log';
-import { importAssetsFromCsv } from "./importAssetsFromCsv";
+import { importAssetsFromCsv } from './importAssetsFromCsv';
 
-export type ImportAssetsParams = Omit<ImportOptions, 'dataDir'> & { storageDirectory: string, apiKey: string };
+export type ImportAssetsParams = Omit<ImportOptions, 'dataDir'> & {
+  storageDirectory: string;
+};
 
 export async function importAssets(options: ImportAssetsParams) {
-  log.info(`Starting account import from the [${options.storageDirectory}] directory`);
+  log.info(
+    `Starting account import from the [${options.storageDirectory}] directory`,
+  );
   log.info(`Importing Entities: ${options.includeEntities}`);
   log.info(`Importing Relationships: ${options.includeRelationships}`);
 

--- a/packages/cli/src/import/importAssetsFromCsv.ts
+++ b/packages/cli/src/import/importAssetsFromCsv.ts
@@ -9,23 +9,26 @@ import { retry } from '@lifeomic/attempt';
 import * as log from '../log';
 import { ImportAssetsParams } from './importAssets';
 import { readFileFromPath, getCsvAssetsDirectory } from '../fileSystem';
-import { createApiClientWithApiKey, getApiBaseUrl } from '@jupiterone/integration-sdk-runtime';
+import {
+  createApiClient,
+  getApiBaseUrl,
+} from '@jupiterone/integration-sdk-runtime';
 import { sanitizeContent } from '../export/util';
 import { pause } from '../pause';
-
-export type ImportAssetsFromCsvParams = ImportAssetsParams & { apiKey: string };
 
 const J1_ENDPOINT = getApiBaseUrl({ dev: !!process.env.JUPITERONE_DEV });
 
 async function waitForSyncCompletion({ jobId, apiClient, progress }) {
   let status;
   do {
-    const { data: { job: jobStatus } } = await apiClient.get(`/persister/synchronization/jobs/${jobId}`);
+    const {
+      data: { job: jobStatus },
+    } = await apiClient.get(`/persister/synchronization/jobs/${jobId}`);
 
     progress(jobStatus);
     status = jobStatus.status;
     await pause(5000);
-  } while (status !== 'FINISHED')
+  } while (status !== 'FINISHED');
 }
 
 interface ImportAssetsTypeParams {
@@ -36,46 +39,84 @@ interface ImportAssetsTypeParams {
   progress: (currentFile: string) => void;
 }
 
-async function importAssetTypeFromCsv({ storageDirectory, apiClient, jobId, assetType, progress }: ImportAssetsTypeParams) {
+async function importAssetTypeFromCsv({
+  storageDirectory,
+  apiClient,
+  jobId,
+  assetType,
+  progress,
+}: ImportAssetsTypeParams) {
   const csvDir = getCsvAssetsDirectory(storageDirectory);
-  const assetFiles = await globby(upath.toUnix(`${csvDir}/${assetType}/bulk_upload_relationship/**/*.csv`));
+  const assetFiles = await globby(
+    upath.toUnix(`${csvDir}/${assetType}/bulk_upload_relationship/**/*.csv`),
+  );
 
-  await pMap(assetFiles, async assetFile => {
-
-    const assets = sanitizeContent(await readFileFromPath(assetFile));
-    try {
-      await retry(() => apiClient.post(`/persister/synchronization/jobs/${jobId}/${assetType}?ignoreDuplicates=true&ignoreIllegalProperties=true`, assets, {
-        headers: {
-          'Content-Type': 'text/csv'
+  await pMap(
+    assetFiles,
+    async (assetFile) => {
+      const assets = sanitizeContent(await readFileFromPath(assetFile));
+      try {
+        await retry(
+          () =>
+            apiClient.post(
+              `/persister/synchronization/jobs/${jobId}/${assetType}?ignoreDuplicates=true&ignoreIllegalProperties=true`,
+              assets,
+              {
+                headers: {
+                  'Content-Type': 'text/csv',
+                },
+              },
+            ),
+          { delay: 500 },
+        );
+      } catch (e) {
+        if (e?.response?.data.error) {
+          log.error(
+            `\n\n${assetFile}: ${JSON.stringify(e?.response?.data)}\n\n`,
+          );
         }
-      }), { delay: 500 });
-    } catch (e) {
-
-      if (e?.response?.data.error) {
-        log.error(`\n\n${assetFile}: ${JSON.stringify(e?.response?.data)}\n\n`)
       }
-    }
-    progress(assetFile)
-  }, {
-    concurrency: 5,
-  });
+      progress(assetFile);
+    },
+    {
+      concurrency: 5,
+    },
+  );
 }
 
-export async function importAssetsFromCsv({ apiKey, includeEntities, includeRelationships, storageDirectory, scope }: ImportAssetsFromCsvParams) {
+export async function importAssetsFromCsv({
+  account,
+  apiKey,
+  includeEntities,
+  includeRelationships,
+  storageDirectory,
+  scope,
+}: ImportAssetsParams) {
   const spinner = createSpinner('Importing csv assets into account').start();
 
   try {
-    const apiClient = createApiClientWithApiKey({ apiBaseUrl: J1_ENDPOINT, apiKey });
-    const { data: { job } } = await apiClient.post('/persister/synchronization/jobs', {
+    const apiClient = createApiClient({
+      apiBaseUrl: J1_ENDPOINT,
+      account,
+      accessToken: apiKey,
+    });
+    const {
+      data: { job },
+    } = await apiClient.post('/persister/synchronization/jobs', {
       source: 'api',
-      scope
+      scope,
     });
 
-    const generateProgressTracker = (assetType: 'entities' | 'relationships') => {
+    const generateProgressTracker = (
+      assetType: 'entities' | 'relationships',
+    ) => {
       return (currentFile: string) => {
-        spinner.text = `Importing ${assetType}: ${path.relative(process.cwd(), currentFile)}`
-      }
-    }
+        spinner.text = `Importing ${assetType}: ${path.relative(
+          process.cwd(),
+          currentFile,
+        )}`;
+      };
+    };
 
     if (includeEntities) {
       await importAssetTypeFromCsv({
@@ -83,8 +124,8 @@ export async function importAssetsFromCsv({ apiKey, includeEntities, includeRela
         apiClient,
         jobId: job.id,
         assetType: 'entities',
-        progress: generateProgressTracker('entities')
-      })
+        progress: generateProgressTracker('entities'),
+      });
     }
 
     if (includeRelationships) {
@@ -93,8 +134,8 @@ export async function importAssetsFromCsv({ apiKey, includeEntities, includeRela
         apiClient,
         jobId: job.id,
         assetType: 'relationships',
-        progress: generateProgressTracker('relationships')
-      })
+        progress: generateProgressTracker('relationships'),
+      });
     }
 
     await apiClient.post(`/persister/synchronization/jobs/${job.id}/finalize`);
@@ -102,15 +143,19 @@ export async function importAssetsFromCsv({ apiKey, includeEntities, includeRela
     await waitForSyncCompletion({
       apiClient,
       jobId: job.id,
-      progress: jobStatus => {
+      progress: (jobStatus) => {
         const {
-          numEntitiesUploaded, numEntitiesCreated, numEntitiesUpdated,
-          numRelationshipsUploaded, numRelationshipsCreated, numRelationshipsUpdated,
+          numEntitiesUploaded,
+          numEntitiesCreated,
+          numEntitiesUpdated,
+          numRelationshipsUploaded,
+          numRelationshipsCreated,
+          numRelationshipsUpdated,
         } = jobStatus;
 
         spinner.text = `\nEntities:\tCreated: ${numEntitiesCreated}\tUpdated: ${numEntitiesUpdated}\tUploaded: ${numEntitiesUploaded}\n
-Relationships:\tCreated: ${numRelationshipsCreated}\tUpdated: ${numRelationshipsUpdated}\tUploaded: ${numRelationshipsUploaded}`
-      }
+Relationships:\tCreated: ${numRelationshipsCreated}\tUpdated: ${numRelationshipsUpdated}\tUploaded: ${numRelationshipsUploaded}`;
+      },
     });
 
     spinner.succeed('Csv Import Successful');
@@ -120,10 +165,10 @@ Relationships:\tCreated: ${numRelationshipsCreated}\tUpdated: ${numRelationships
     spinner.fail(failMessage);
 
     if (e?.response?.data.error) {
-      log.error(JSON.stringify(e?.response?.data))
-      throw new Error(e)
+      log.error(JSON.stringify(e?.response?.data));
+      throw new Error(e);
     }
 
     throw e;
   }
-};
+}

--- a/packages/cli/src/validateApiKey.ts
+++ b/packages/cli/src/validateApiKey.ts
@@ -1,9 +1,0 @@
-export function validateApiKey(apiKey?: string) {
-  apiKey = apiKey ?? process.env.JUPITERONE_API_KEY;
-
-  if (!apiKey) {
-    throw new Error('Missing apiKey! Set the JUPITERONE_API_KEY environment variable or supply the --api-key option.');
-  }
-
-  return apiKey;
-}

--- a/packages/cli/src/validateOption.ts
+++ b/packages/cli/src/validateOption.ts
@@ -1,0 +1,17 @@
+export function validateOption(options: {
+  option: string;
+  value: string | undefined;
+  defaultEnvironmentVariable: string;
+}) {
+  const { option, value: passedValue, defaultEnvironmentVariable } = options;
+
+  const value = passedValue ?? process.env[defaultEnvironmentVariable];
+
+  if (!value) {
+    throw new Error(
+      `Missing option! Set the ${defaultEnvironmentVariable} environment variable or supply the ${option} option.`,
+    );
+  }
+
+  return value;
+}

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -40,7 +40,6 @@
     "@types/pollyjs__core": "^4.0.0",
     "@types/pollyjs__persister": "^2.0.1",
     "@types/vis": "^4.21.20",
-    "jsonwebtoken": "^8.5.1",
     "memfs": "^3.2.0",
     "uuid": "^8.2.0"
   }

--- a/packages/integration-sdk-cli/src/__tests__/cli-run-failure.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-run-failure.test.ts
@@ -9,7 +9,6 @@ import { mocked } from 'ts-jest/utils';
 import { Polly } from '@pollyjs/core';
 import NodeHttpAdapter from '@pollyjs/adapter-node-http';
 import FSPersister from '@pollyjs/persister-fs';
-import jwt from 'jsonwebtoken';
 
 import { loadProjectStructure } from '@jupiterone/integration-sdk-private-test-utils';
 import { SynchronizationJobStatus } from '@jupiterone/integration-sdk-core';
@@ -34,7 +33,8 @@ const { createIntegrationLogger } = jest.requireActual(
 let polly: Polly;
 
 beforeEach(() => {
-  process.env.JUPITERONE_API_KEY = jwt.sign({ account: 'mochi' }, 'test');
+  process.env.JUPITERONE_API_KEY = 'testing-key';
+  process.env.JUPITERONE_ACCOUNT = 'mochi';
   loadProjectStructure('validationFailure');
 
   polly = new Polly('run-cli-failure', {

--- a/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
@@ -1,7 +1,6 @@
 import { Polly } from '@pollyjs/core';
 import NodeHttpAdapter from '@pollyjs/adapter-node-http';
 import FSPersister from '@pollyjs/persister-fs';
-import jwt from 'jsonwebtoken';
 
 import { createCli } from '../index';
 import { loadProjectStructure } from '@jupiterone/integration-sdk-private-test-utils';
@@ -26,7 +25,8 @@ Polly.register(FSPersister);
 let polly: Polly;
 
 beforeEach(() => {
-  process.env.JUPITERONE_API_KEY = jwt.sign({ account: 'mochi' }, 'test');
+  process.env.JUPITERONE_API_KEY = 'testing-key';
+  process.env.JUPITERONE_ACCOUNT = 'mochi';
 
   polly = new Polly('run-cli', {
     adapters: ['node-http'],

--- a/packages/integration-sdk-cli/src/__tests__/cli-sync.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-sync.test.ts
@@ -1,7 +1,6 @@
 import { Polly } from '@pollyjs/core';
 import NodeHttpAdapter from '@pollyjs/adapter-node-http';
 import FSPersister from '@pollyjs/persister-fs';
-import jwt from 'jsonwebtoken';
 
 import { loadProjectStructure } from '@jupiterone/integration-sdk-private-test-utils';
 import { SynchronizationJobStatus } from '@jupiterone/integration-sdk-core';
@@ -23,7 +22,8 @@ Polly.register(FSPersister);
 let polly: Polly;
 
 beforeEach(() => {
-  process.env.JUPITERONE_API_KEY = jwt.sign({ account: 'mochi' }, 'test');
+  process.env.JUPITERONE_API_KEY = 'testing-key';
+  process.env.JUPITERONE_ACCOUNT = 'mochi';
 
   polly = new Polly('sync-cli', {
     adapters: ['node-http'],

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -3,8 +3,9 @@ import { createCommand } from 'commander';
 import * as log from '../log';
 import {
   getApiKeyFromEnvironment,
+  getAccountFromEnvironment,
   getApiBaseUrl,
-  createApiClientWithApiKey,
+  createApiClient,
   initiateSynchronization,
   uploadCollectedData,
   finalizeSynchronization,
@@ -27,15 +28,20 @@ export function run() {
     )
     .action(async (options) => {
       log.debug('Loading API Key from JUPITERONE_API_KEY environment variable');
-      const apiKey = getApiKeyFromEnvironment();
+      const accessToken = getApiKeyFromEnvironment();
+
+      log.debug('Loading account from JUPITERONE_ACCOUNT environment variable');
+      const account = getAccountFromEnvironment();
+
       const apiBaseUrl = getApiBaseUrl({ dev: !!process.env.JUPITERONE_DEV });
       log.debug(`Configuring client to access "${apiBaseUrl}"`);
 
       const startTime = Date.now();
 
-      const apiClient = createApiClientWithApiKey({
+      const apiClient = createApiClient({
         apiBaseUrl,
-        apiKey,
+        accessToken,
+        account,
       });
 
       const { integrationInstanceId } = options;

--- a/packages/integration-sdk-cli/src/commands/sync.ts
+++ b/packages/integration-sdk-cli/src/commands/sync.ts
@@ -3,8 +3,9 @@ import { createCommand } from 'commander';
 import * as log from '../log';
 import {
   getApiKeyFromEnvironment,
+  getAccountFromEnvironment,
   getApiBaseUrl,
-  createApiClientWithApiKey,
+  createApiClient,
   createIntegrationLogger,
   synchronizeCollectedData,
 } from '@jupiterone/integration-sdk-runtime';
@@ -18,14 +19,18 @@ export function sync() {
     )
     .action(async (options) => {
       log.debug('Loading API Key from JUPITERONE_API_KEY environment variable');
-      const apiKey = getApiKeyFromEnvironment();
-      const apiBaseUrl = getApiBaseUrl({ dev: !!process.env.JUPITERONE_DEV });
+      const accessToken = getApiKeyFromEnvironment();
 
+      log.debug('Loading account from JUPITERONE_ACCOUNT environment variable');
+      const account = getAccountFromEnvironment();
+
+      const apiBaseUrl = getApiBaseUrl({ dev: !!process.env.JUPITERONE_DEV });
       log.debug(`Configuring client to access "${apiBaseUrl}"`);
 
-      const apiClient = createApiClientWithApiKey({
+      const apiClient = createApiClient({
         apiBaseUrl,
-        apiKey,
+        account,
+        accessToken,
       });
 
       const { integrationInstanceId } = options;

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -34,7 +34,6 @@
     "dotenv-expand": "^5.1.0",
     "get-folder-size": "^2.0.1",
     "globby": "^11.0.0",
-    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
     "p-map": "^4.0.0",
     "p-queue": "^6.3.0",

--- a/packages/integration-sdk-runtime/src/api/error.ts
+++ b/packages/integration-sdk-runtime/src/api/error.ts
@@ -1,29 +1,19 @@
 import { IntegrationError } from '@jupiterone/integration-sdk-core';
 
-export class IntegrationMalformedApiKeyError extends IntegrationError {
-  constructor(message: string) {
-    super({
-      code: 'MALFORMED_API_KEY_ERROR',
-      message,
-    });
-  }
-}
-
 export class IntegrationApiKeyRequiredError extends IntegrationError {
-  constructor(message: string) {
+  constructor() {
     super({
-      code: 'JUPITER_ONE_API_KEY_ENVIRONMENT_VARIABLE_NOT_SET',
-      message,
+      code: 'JUPITERONE_API_KEY_ENVIRONMENT_VARIABLE_NOT_SET',
+      message: 'The JUPITERONE_API_KEY environment variable must be set',
     });
   }
 }
 
-export function malformedApiKeyError() {
-  return new IntegrationMalformedApiKeyError('Malformed API Key provided');
-}
-
-export function apiKeyRequiredError() {
-  return new IntegrationMalformedApiKeyError(
-    'The JUPITERONE_API_KEY environment variable must be set',
-  );
+export class IntegrationAccountRequiredError extends IntegrationError {
+  constructor() {
+    super({
+      code: 'JUPITERONE_ACCOUNT_ENVIRONMENT_VARIABLE_NOT_SET',
+      message: 'The JUPITERONE_ACCOUNT environment variable must be set',
+    });
+  }
 }

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,9 +9,16 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Removed `createApiClientWithApiKey` helper from runtime package. You must use
+  `createApiClient` for compatibility with new service tokens.
+
 ## 3.8.0 - 2020-10-26
 
-- Expose `onFaliure` callback in `createIntegrationLogger`
+### Added
+
+- Expose `onFailure` callback in `createIntegrationLogger`
 
 ## 3.7.0 - 2020-10-23
 


### PR DESCRIPTION
We should be able to use the old JWT user keys and the new service tokens for authorization. Thus, we cannot depend on having the account ID embedded in the access token. This change to the API client interface requires callers to provide an account ID and an access token instead of only a JWT user key. Since a public helper function is being removed, this will require a major version bump.