### PR TITLE
Upload entities and relationships continuously during ingestion

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -1,12 +1,12 @@
 import {
-  IntegrationDuplicateKeyError,
   Entity,
-  Relationship,
+  IntegrationDuplicateKeyError,
   JobState,
   KeyNormalizationFunction,
+  Relationship,
 } from '@jupiterone/integration-sdk-core';
 
-import { FileSystemGraphObjectStore } from '../storage';
+import { GraphObjectStore } from '../storage';
 
 export interface DuplicateKeyTrackerGraphObjectMetadata {
   _type: string;
@@ -76,7 +76,7 @@ export interface CreateStepJobStateParams {
   stepId: string;
   duplicateKeyTracker: DuplicateKeyTracker;
   typeTracker: TypeTracker;
-  graphObjectStore: FileSystemGraphObjectStore;
+  graphObjectStore: GraphObjectStore;
   dataStore: MemoryDataStore;
 }
 

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -1,18 +1,19 @@
-import pMap from 'p-map';
 import { Sema } from 'async-sema';
+import pMap from 'p-map';
 
 import {
   Entity,
-  Relationship,
   GraphObjectFilter,
   GraphObjectIteratee,
+  GraphObjectLookupKey,
   IntegrationDuplicateKeyError,
   IntegrationMissingKeyError,
-  GraphObjectLookupKey,
+  Relationship,
 } from '@jupiterone/integration-sdk-core';
 
-import { flushDataToDisk } from './flushDataToDisk';
+import { GraphObjectStore } from '../types';
 import { BucketMap } from './BucketMap';
+import { flushDataToDisk } from './flushDataToDisk';
 import {
   iterateEntityTypeIndex,
   iterateRelationshipTypeIndex,
@@ -24,7 +25,7 @@ export const GRAPH_OBJECT_BUFFER_THRESHOLD = 500; // arbitrarily selected, subje
 // to ensure that only one operation can be performed at a time.
 const BINARY_SEMAPHORE_CONCURRENCY = 1;
 
-export class FileSystemGraphObjectStore {
+export class FileSystemGraphObjectStore implements GraphObjectStore {
   semaphore: Sema;
   entityStorageMap: BucketMap<Entity>;
   relationshipStorageMap: BucketMap<Relationship>;

--- a/packages/integration-sdk-runtime/src/storage/index.ts
+++ b/packages/integration-sdk-runtime/src/storage/index.ts
@@ -1,1 +1,2 @@
+export { GraphObjectStore } from './types';
 export * from './FileSystemGraphObjectStore';

--- a/packages/integration-sdk-runtime/src/storage/types.ts
+++ b/packages/integration-sdk-runtime/src/storage/types.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  GraphObjectFilter,
+  GraphObjectIteratee,
+  GraphObjectLookupKey,
+  Relationship,
+} from '@jupiterone/integration-sdk-core';
+
+/**
+ * Persists entities and relationships to a durable medium for the duration of
+ * integration execution.
+ */
+export interface GraphObjectStore {
+  addEntities(stepId: string, newEntities: Entity[]): Promise<void>;
+
+  addRelationships(
+    stepId: string,
+    newRelationships: Relationship[],
+  ): Promise<void>;
+
+  getEntity({ _key, _type }: GraphObjectLookupKey): Promise<Entity>;
+
+  iterateEntities<T extends Entity = Entity>(
+    filter: GraphObjectFilter,
+    iteratee: GraphObjectIteratee<T>,
+  ): Promise<void>;
+
+  iterateRelationships<T extends Relationship = Relationship>(
+    filter: GraphObjectFilter,
+    iteratee: GraphObjectIteratee<T>,
+  ): Promise<void>;
+
+  flush(): Promise<void>;
+}


### PR DESCRIPTION
After reviewing the code, I think the easiest way to get this feature working is through the `GraphObjectStore` interface, which the `JobState` implementation interacts to get entities and relationships out of memory. I am thinking to have an implementation of the `GraphObjectStore` that wraps a `FileSystemGraphObjectStore` and a reference to an initiated `SynchronizationJob` and something like a `PersisterService`. When the `GraphObjectStore.flush()` function is invoked (including threshold-induced invocations), it will queue up requests to upload the data.

The managed runtime would use this this all the time, the CLI could be left unchanged or we could easily support an option like `--continuous-upload`.

Please let me know if you think this approach is sound and I'll continue to push it forward.