### PR TITLE
Expose BucketMap and FileSystemGraphObjectStore

### DIFF
--- a/packages/integration-sdk-runtime/src/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/__tests__/index.test.ts
@@ -1,0 +1,11 @@
+import { BucketMap, FileSystemGraphObjectStore } from '../index';
+
+describe('#storage', () => {
+  test('should expose BucketMap', () => {
+    expect(BucketMap).not.toEqual(undefined);
+  });
+
+  test('should expose FileSystemGraphObjectStore', () => {
+    expect(FileSystemGraphObjectStore).not.toEqual(undefined);
+  });
+});

--- a/packages/integration-sdk-runtime/src/index.ts
+++ b/packages/integration-sdk-runtime/src/index.ts
@@ -4,4 +4,4 @@ export * from './synchronization';
 export * from './fileSystem';
 export * from './logger';
 export * from './metrics';
-export { GraphObjectStore } from './storage/types';
+export * from './storage';

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/BucketMap.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/BucketMap.ts
@@ -6,7 +6,11 @@
  * and also tracks the total count of objects stored.
  */
 export class BucketMap<T = any> extends Map<string, T[]> {
-  totalItemCount = 0;
+  private internalTotalItemCount = 0;
+
+  get totalItemCount() {
+    return this.internalTotalItemCount;
+  }
 
   add(key: string, values: T[]) {
     const existingValues = this.get(key);
@@ -16,7 +20,7 @@ export class BucketMap<T = any> extends Map<string, T[]> {
   set(key: string, values: T[]) {
     const existingItemCount = this.get(key)?.length ?? 0;
     super.set(key, values);
-    this.totalItemCount += values.length - existingItemCount;
+    this.internalTotalItemCount += values.length - existingItemCount;
     return this;
   }
 
@@ -24,7 +28,7 @@ export class BucketMap<T = any> extends Map<string, T[]> {
     const existingItemCount = this.get(key)?.length ?? 0;
     const deleteResult = super.delete(key);
 
-    this.totalItemCount -= existingItemCount;
+    this.internalTotalItemCount -= existingItemCount;
 
     return deleteResult;
   }

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/index.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/index.ts
@@ -1,1 +1,2 @@
 export * from './FileSystemGraphObjectStore';
+export * from './BucketMap';

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
   limit data ingestion.
 
 - Allow `executeIntegrationInstance` to take a custom `GraphObjectStore`
+- Expose `BucketMap` and `FileSystemGraphObjectStore` from
+  `@jupiterone/integration-sdk-runtime`
 
 ### Changed
 


### PR DESCRIPTION
Going to be using `BucketMap` in the managed `GraphObjectStore` implementation. Exposing `FileSystemGraphObjectStore` is not a necessary change, but I figured it didn't hurt to expose this to potential implementors who may want to extend it now that we are allowing a custom `graphObjectStore` to be passed into `executeIntegrationInstance`.