### PR TITLE
Local execution event emitters

### DIFF
--- a/packages/integration-sdk-runtime/test/lateLoggerRegistration.ts
+++ b/packages/integration-sdk-runtime/test/lateLoggerRegistration.ts
@@ -11,13 +11,11 @@ import {
 import { expect } from './util/expect'
 
 function throwsUnhandledRejection() {
-  return () => {
-    async function throwsException() {
-      await Promise.resolve();
-      throw new Error();
-    }
-    void throwsException();
-  };
+  async function throwsException() {
+    await Promise.resolve();
+    throw new Error();
+  }
+  void throwsException();
 }
 
 /**
@@ -53,7 +51,7 @@ export async function executeIntegrationInstanceWithLateRegisteredLogger() {
         name: '',
         entities: [],
         relationships: [],
-        executionHandler: throwsUnhandledRejection(),
+        executionHandler: throwsUnhandledRejection,
       },
     ],
   }, LOCAL_EXECUTION_HISTORY);

--- a/packages/integration-sdk-runtime/test/unregisterEventHandlers.ts
+++ b/packages/integration-sdk-runtime/test/unregisterEventHandlers.ts
@@ -11,13 +11,11 @@ import {
 import { expect } from './util/expect'
 
 function throwsUnhandledRejection() {
-  return () => {
-    async function throwsException() {
-      await Promise.resolve();
-      throw new Error();
-    }
-    void throwsException();
-  };
+  async function throwsException() {
+    await Promise.resolve();
+    throw new Error();
+  }
+  void throwsException();
 }
 
 /**
@@ -43,7 +41,7 @@ export async function executeIntegrationInstanceWithUnregisteredEventHandlers() 
         name: '',
         entities: [],
         relationships: [],
-        executionHandler: throwsUnhandledRejection(),
+        executionHandler: throwsUnhandledRejection,
       },
     ],
   }, LOCAL_EXECUTION_HISTORY);

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   `unregisterIntegrationLoggerEventHandlers` as convenience functions, since
   JupiterOne infrastructure will handle these event emitter failures by calling
   `logger.error()`.
+- Added `registerEventEmitters` to `executeIntegrationLocally`, so that events
+  are caught when running `yarn j1-integration collect`.
 
 ## 5.0.0 - 2020-11-24
 


### PR DESCRIPTION
I tested this by removing all but two fake steps in the `graph-bamboo` project, linking `@jupiterone/integration-sdk-runtime` and executing with the following fake execution handlers:

```typescript
async function emitsMultipleResolve() {
  await Promise.all([
    (async () => {
      await Promise.resolve();
      throw new Error('Multiple Resolves Error #1');
    })(),
    (async () => {
      await Promise.resolve();
      throw new Error('Multiple Resolves Error #2');
    })(),
  ]);
}

function emitsUnhandledRejection() {
  async function throwsException() {
    await Promise.resolve();
    throw new Error('Unhandled Rejection');
  }
  void throwsException();
}
```

The console printed the following, showing both **Multiple Resolves Error #2** and **Unhandled Rejection**

```shell
nickdowmon@Nicks-MacBook-Pro graph-bamboohr % yarn start
yarn run v1.22.10
$ j1-integration collect
TypeScript files detected. Registering ts-node.

Configuration loaded! Running integration...

executing integration locally (linked)
23:21:58.754Z  INFO Local: Starting execution with config... (compressionEnabled=false)
23:21:58.757Z  INFO Local: Collected metric.
  metric: {
    "name": "disk-usage",
    "value": 558,
    "unit": "Bytes",
    "timestamp": 1607124118757
  }
23:21:58.762Z  INFO Local: Starting step "Fetch Account Details"... (stepId=fetch-account)
23:21:58.762Z  INFO Local: Starting step "Other"... (stepId=other)
23:21:58.762Z  INFO Local: Completed step "Fetch Account Details". (stepId=fetch-account)
23:21:58.767Z ERROR Local: Step "Other" failed to complete due to error. (errorCode="UNEXPECTED_ERROR", errorId="01d3a004-b8c3-4c80-8f74-1daf795f8a4e", reason="Unexpected error occurred executing integration! Please contact us in Slack or at https://support.jupiterone.io if the problem continues to occur.") (stepId=other, errorId=01d3a004-b8c3-4c80-8f74-1daf795f8a4e)
  Error: Multiple Resolves Error #1
      at /Users/nickdowmon/projects/github/graph-bamboohr/src/steps/account.ts:43:13
      at async Promise.all (index 0)
      at Object.emitsMultipleResolve [as executionHandler] (/Users/nickdowmon/projects/github/graph-bamboohr/src/steps/account.ts:40:3)
      at executeStep (/Users/nickdowmon/projects/github/sdk/packages/integration-sdk-runtime/dist/src/execution/dependencyGraph.js:194:17)
      at Object.timeOperation (/Users/nickdowmon/projects/github/sdk/packages/integration-sdk-runtime/dist/src/metrics/index.js:6:12)
      at run (/Users/nickdowmon/projects/github/sdk/node_modules/p-queue/dist/index.js:256:29)
23:21:58.767Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "fetch-account"
    },
    "value": 6,
    "timestamp": 1607124118767
  }
23:21:58.768Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "other"
    },
    "value": 6,
    "timestamp": 1607124118768
  }
23:21:58.768Z ERROR Local: Multiple Resolves Error #2 (event=multipleResolves)
  Error: Multiple Resolves Error #2
      at /Users/nickdowmon/projects/github/graph-bamboohr/src/steps/account.ts:47:13
      at async Promise.all (index 1)
      at Object.emitsMultipleResolve [as executionHandler] (/Users/nickdowmon/projects/github/graph-bamboohr/src/steps/account.ts:40:3)
      at executeStep (/Users/nickdowmon/projects/github/sdk/packages/integration-sdk-runtime/dist/src/execution/dependencyGraph.js:194:17)
      at Object.timeOperation (/Users/nickdowmon/projects/github/sdk/packages/integration-sdk-runtime/dist/src/metrics/index.js:6:12)
      at run (/Users/nickdowmon/projects/github/sdk/node_modules/p-queue/dist/index.js:256:29)
23:21:58.769Z ERROR Local: Unhandled Rejection (event=unhandledRejection)
  Error: Unhandled Rejection
      at throwsException (/Users/nickdowmon/projects/github/graph-bamboohr/src/steps/account.ts:55:11)
23:21:58.770Z  INFO Local: Integration data collection has completed.
  collectionResult: {
    "integrationStepResults": [
      {
        "id": "fetch-account",
        "name": "Fetch Account Details",
        "declaredTypes": [],
        "partialTypes": [],
        "encounteredTypes": [],
        "status": "success"
      },
      {
        "id": "other",
        "name": "Other",
        "declaredTypes": [],
        "partialTypes": [],
        "encounteredTypes": [],
        "status": "failure"
      }
    ],
    "metadata": {
      "partialDatasets": {
        "types": []
      }
    }
  }
23:21:58.771Z  INFO Local: Collected metric.
  metric: {
    "name": "disk-usage",
    "value": 558,
    "unit": "Bytes",
    "timestamp": 1607124118771
  }
23:21:58.772Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-collect",
    "unit": "Milliseconds",
    "value": 19,
    "timestamp": 1607124118772
  }

Results:

Step "fetch-account" completed with status: success
Step "other" completed with status: failure
✨  Done in 0.83s.
```