### PR TITLE
Retry and increase concurrency on file uploads

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.0.0",
-    "@jupiterone/integration-sdk-runtime": "^5.0.0",
+    "@jupiterone/integration-sdk-core": "^5.1.0",
+    "@jupiterone/integration-sdk-runtime": "^5.1.0",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^5.0.0",
+    "@jupiterone/integration-sdk-runtime": "^5.1.0",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "lodash": "^4.17.19",
@@ -31,7 +31,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.1.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^5.0.0",
-    "@jupiterone/integration-sdk-testing": "^5.0.0",
+    "@jupiterone/integration-sdk-cli": "^5.1.0",
+    "@jupiterone/integration-sdk-testing": "^5.1.0",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "node": "10.x || 12.x || 14.x"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.0.0",
+    "@jupiterone/integration-sdk-core": "^5.1.0",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@jupiterone/integration-sdk-core": "^5.0.0",
     "@lifeomic/alpha": "^1.1.3",
+    "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
     "axios": "^0.19.2",
     "bunyan": "^1.8.12",

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.0.0",
+    "@jupiterone/integration-sdk-core": "^5.1.0",
     "@lifeomic/alpha": "^1.1.3",
     "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.1.0",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.0.0",
-    "@jupiterone/integration-sdk-runtime": "^5.0.0",
+    "@jupiterone/integration-sdk-core": "^5.1.0",
+    "@jupiterone/integration-sdk-runtime": "^5.1.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.1.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## Unreleased
 
+## 5.1.0 - 2020-12-08
+
 ### Added
 
 - Added `registerEventHandlers` and `unregisterEventHandlers` exports from the
@@ -26,6 +28,11 @@ and this project adheres to
   are caught when running `yarn j1-integration collect`.
 - Made `registerIntegrationEventHandlers` call the integration logger
   `onFailure` function.
+
+### Changed
+
+- Increase concurrency on integration data uploads
+- Implement retry logic around integration data uploads
 
 ## 5.0.0 - 2020-11-24
 


### PR DESCRIPTION
This should decrease the time it takes to upload all of our integration data by 3x and improve resiliency