### PR TITLE
Only write prettified files to the file system on local collection

### DIFF
--- a/packages/integration-sdk-cli/src/commands/collect.ts
+++ b/packages/integration-sdk-cli/src/commands/collect.ts
@@ -33,7 +33,7 @@ export function collect() {
       log.info('\nConfiguration loaded! Running integration...\n');
 
       const graphObjectStore = new FileSystemGraphObjectStore({
-        prettyFile: true,
+        prettifyFiles: true,
       });
 
       const results = await executeIntegrationLocally(

--- a/packages/integration-sdk-cli/src/commands/collect.ts
+++ b/packages/integration-sdk-cli/src/commands/collect.ts
@@ -2,6 +2,7 @@ import { createCommand } from 'commander';
 
 import {
   executeIntegrationLocally,
+  FileSystemGraphObjectStore,
   prepareLocalStepCollection,
 } from '@jupiterone/integration-sdk-runtime';
 
@@ -30,6 +31,11 @@ export function collect() {
       const enableSchemaValidation = !options.disableSchemaValidation;
       const config = prepareLocalStepCollection(await loadConfig(), options);
       log.info('\nConfiguration loaded! Running integration...\n');
+
+      const graphObjectStore = new FileSystemGraphObjectStore({
+        prettyFile: true,
+      });
+
       const results = await executeIntegrationLocally(
         config,
         {
@@ -39,6 +45,7 @@ export function collect() {
         },
         {
           enableSchemaValidation,
+          graphObjectStore,
         },
       );
       log.displayExecutionResults(results);

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -8,6 +8,7 @@ import {
   createIntegrationInstanceForLocalExecution,
   createIntegrationLogger,
   executeIntegrationInstance,
+  FileSystemGraphObjectStore,
   finalizeSynchronization,
   getAccountFromEnvironment,
   getApiBaseUrl,
@@ -72,6 +73,10 @@ export function run() {
 
       const invocationConfig = await loadConfig();
 
+      const graphObjectStore = new FileSystemGraphObjectStore({
+        prettyFile: true,
+      });
+
       try {
         const executionResults = await executeIntegrationInstance(
           logger,
@@ -84,6 +89,7 @@ export function run() {
           },
           {
             enableSchemaValidation: true,
+            graphObjectStore,
             createStepGraphObjectDataUploader(stepId) {
               return createPersisterApiStepGraphObjectDataUploader({
                 stepId,

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -74,7 +74,7 @@ export function run() {
       const invocationConfig = await loadConfig();
 
       const graphObjectStore = new FileSystemGraphObjectStore({
-        prettyFile: true,
+        prettifyFiles: true,
       });
 
       try {

--- a/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
+++ b/packages/integration-sdk-cli/src/visualization/generateVisualization.ts
@@ -27,9 +27,11 @@ export async function generateVisualization(
     log.warn(`Unable to find any files under path: ${resolvedIntegrationPath}`);
   }
 
-  const { entities, relationships, mappedRelationships } = await retrieveIntegrationData(
-    entitiesAndRelationshipPaths,
-  );
+  const {
+    entities,
+    relationships,
+    mappedRelationships,
+  } = await retrieveIntegrationData(entitiesAndRelationshipPaths);
 
   const nodeDataSets = entities.map((entity) => ({
     id: getNodeIdFromEntity(entity, []),
@@ -45,10 +47,10 @@ export async function generateVisualization(
   );
 
   const {
-    mappedRelationshipEdges, 
+    mappedRelationshipEdges,
     mappedRelationshipNodes,
   } = createMappedRelationshipNodesAndEdges({
-    mappedRelationships, 
+    mappedRelationships,
     explicitEntities: entities,
   });
 
@@ -56,7 +58,10 @@ export async function generateVisualization(
 
   await writeFileToPath({
     path: htmlFileLocation,
-    content: generateVisHTML([...nodeDataSets, ...mappedRelationshipNodes], [...explicitEdgeDataSets, ...mappedRelationshipEdges]),
+    content: generateVisHTML(
+      [...nodeDataSets, ...mappedRelationshipNodes],
+      [...explicitEdgeDataSets, ...mappedRelationshipEdges],
+    ),
   });
 
   return htmlFileLocation;

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -429,7 +429,7 @@ describe('executeStepDependencyGraph', () => {
 
       // each step should have just generated one file
       const writtenData = await fs.readFile(`${directory}/${files[0]}`, 'utf8');
-      expect(writtenData).toEqual(JSON.stringify({ [type]: data }, null, 2));
+      expect(writtenData).toEqual(JSON.stringify({ [type]: data }));
     }
   });
 

--- a/packages/integration-sdk-runtime/src/fileSystem.ts
+++ b/packages/integration-sdk-runtime/src/fileSystem.ts
@@ -35,6 +35,7 @@ export function getRootStorageDirectorySize(): Promise<number> {
 interface WriteDataToPathInput {
   path: string;
   data: object;
+  pretty?: boolean;
 }
 
 /**
@@ -47,10 +48,13 @@ interface WriteDataToPathInput {
 export async function writeJsonToPath({
   path: relativePath,
   data,
+  pretty = false,
 }: WriteDataToPathInput) {
+  const content = pretty ? JSON.stringify(data, null, 2) : JSON.stringify(data);
+
   await writeFileToPath({
     path: relativePath,
-    content: JSON.stringify(data, null, 2),
+    content,
   });
 }
 
@@ -191,7 +195,7 @@ export async function removeStorageDirectory() {
 }
 
 function removeDirectory(directory: string) {
-  return new Promise((resolve, reject) =>
+  return new Promise<void>((resolve, reject) =>
     rimraf(directory, (err) => {
       if (err) {
         return reject(err);

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -38,21 +38,21 @@ export interface FileSystemGraphObjectStoreParams {
   /**
    * Whether the files that are written to disk should be minified or not
    */
-  prettyFile?: boolean;
+  prettifyFiles?: boolean;
 }
 
 export class FileSystemGraphObjectStore implements GraphObjectStore {
   private readonly semaphore: Sema;
   private readonly localGraphObjectStore = new InMemoryGraphObjectStore();
   private readonly graphObjectBufferThreshold: number;
-  private readonly prettyFile: boolean;
+  private readonly prettifyFiles: boolean;
 
   constructor(params?: FileSystemGraphObjectStoreParams) {
     this.semaphore = new Sema(BINARY_SEMAPHORE_CONCURRENCY);
     this.graphObjectBufferThreshold =
       params?.graphObjectBufferThreshold ||
       DEFAULT_GRAPH_OBJECT_BUFFER_THRESHOLD;
-    this.prettyFile = params?.prettyFile || false;
+    this.prettifyFiles = params?.prettifyFiles || false;
   }
 
   async addEntities(
@@ -164,7 +164,7 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
             storageDirectoryPath: stepId,
             collectionType: 'entities',
             data: entities,
-            pretty: this.prettyFile,
+            pretty: this.prettifyFiles,
           });
 
           this.localGraphObjectStore.flushEntities(entities);
@@ -188,7 +188,7 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
             storageDirectoryPath: stepId,
             collectionType: 'relationships',
             data: relationships,
-            pretty: this.prettyFile,
+            pretty: this.prettifyFiles,
           });
 
           this.localGraphObjectStore.flushRelationships(relationships);

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -33,19 +33,26 @@ export interface FileSystemGraphObjectStoreParams {
    *
    * Default: 500
    */
-  graphObjectBufferThreshold: number;
+  graphObjectBufferThreshold?: number;
+
+  /**
+   * Whether the files that are written to disk should be minified or not
+   */
+  prettyFile?: boolean;
 }
 
 export class FileSystemGraphObjectStore implements GraphObjectStore {
   private readonly semaphore: Sema;
   private readonly localGraphObjectStore = new InMemoryGraphObjectStore();
   private readonly graphObjectBufferThreshold: number;
+  private readonly prettyFile: boolean;
 
   constructor(params?: FileSystemGraphObjectStoreParams) {
     this.semaphore = new Sema(BINARY_SEMAPHORE_CONCURRENCY);
     this.graphObjectBufferThreshold =
       params?.graphObjectBufferThreshold ||
       DEFAULT_GRAPH_OBJECT_BUFFER_THRESHOLD;
+    this.prettyFile = params?.prettyFile || false;
   }
 
   async addEntities(
@@ -157,6 +164,7 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
             storageDirectoryPath: stepId,
             collectionType: 'entities',
             data: entities,
+            pretty: this.prettyFile,
           });
 
           this.localGraphObjectStore.flushEntities(entities);
@@ -180,6 +188,7 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
             storageDirectoryPath: stepId,
             collectionType: 'relationships',
             data: relationships,
+            pretty: this.prettyFile,
           });
 
           this.localGraphObjectStore.flushRelationships(relationships);

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/flushDataToDisk.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/flushDataToDisk.test.ts
@@ -70,6 +70,38 @@ test('should group objects by "_type" and write them to separate files', async (
   });
 });
 
+test('should allow prettifying files', async () => {
+  const _type = uuid();
+  const entities = times(2, () => createTestEntity({ _type }));
+  const storageDirectoryPath = uuid();
+
+  await flushDataToDisk({
+    storageDirectoryPath,
+    collectionType: 'entities',
+    data: entities,
+    pretty: true,
+  });
+
+  const entitiesDirectory = path.join(
+    getRootStorageDirectory(),
+    'graph',
+    storageDirectoryPath,
+    'entities',
+  );
+
+  const entityFiles = await fs.readdir(entitiesDirectory);
+  expect(entityFiles).toHaveLength(1);
+
+  const fileData = await fs.readFile(
+    path.join(entitiesDirectory, entityFiles[0]),
+    {
+      encoding: 'utf-8',
+    },
+  );
+
+  expect(fileData).toEqual(JSON.stringify({ entities }, null, 2));
+});
+
 function randomizeOrder<T>(things: T[]): T[] {
   return sortBy(things, () => Math.random());
 }

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/flushDataToDisk.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/flushDataToDisk.ts
@@ -16,6 +16,7 @@ interface FlushDataToDiskInput {
   storageDirectoryPath: string;
   collectionType: CollectionType;
   data: Entity[] | Relationship[];
+  pretty?: boolean;
 }
 
 /**
@@ -27,6 +28,7 @@ export async function flushDataToDisk({
   storageDirectoryPath,
   collectionType,
   data,
+  pretty,
 }: FlushDataToDiskInput) {
   // split the data by type first
   const groupedCollections = groupBy(data, '_type');
@@ -49,6 +51,7 @@ export async function flushDataToDisk({
         data: {
           [collectionType]: collection,
         },
+        pretty,
       });
 
       await symlink({


### PR DESCRIPTION
Small change that should marginally improve integrations that produce a significant amount of graph objects locally.

- Less disk usage
- Faster reads
- Faster writes
