### PR TITLE
Improve uploader queue to respect queue size instead of waiting for idle

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -55,7 +55,7 @@ export function createQueuedStepGraphObjectDataUploader({
       // than `onIdle` in this case because we really don't care whether all
       // promises have settled, we only care that additional work is not being
       // created and subsequently kicked off.
-      if (queue.size === maximumQueueSize) {
+      if (queue.size >= maximumQueueSize) {
         if (onThrottleEnqueue) {
           // Mainly just used for testing that our custom throttling works.
           onThrottleEnqueue();

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -25,66 +25,82 @@ export interface CreateQueuedStepGraphObjectDataUploaderParams {
 
 export function createQueuedStepGraphObjectDataUploader({
   stepId,
-  uploadConcurrency,
+  uploadConcurrency: maximumQueueSize,
   upload,
   onThrottleEnqueue,
 }: CreateQueuedStepGraphObjectDataUploaderParams): StepGraphObjectDataUploader {
   const queue = new PQueue({
-    concurrency: uploadConcurrency,
+    concurrency: maximumQueueSize,
   });
 
+  let completed = false;
   const uploadErrors: Error[] = [];
 
   return {
     stepId,
     async enqueue(graphObjectData) {
-      if (queue.isPaused) {
-        // This step already failed an upload. We do not want to enqueue more
-        // for this step.
+      if (completed) {
+        // This step has already called ran `waitUntilUploadsComplete`, so we
+        // do not want to allow any additional enqueuing.
         return;
       }
 
       // OPTIMIZATION: We do not want to buffer a lot of graph objects
       // into memory inside of the queue. If the queue concurrency has been
-      // reached, we wait for the queue to flush so that this step has the
-      // opportunity to upload more data.
-      if (
-        queue.pending >= uploadConcurrency ||
-        queue.size >= uploadConcurrency
-      ) {
+      // reached, we wait for the queue to become `empty` so that this step has
+      // the opportunity to upload more data.
+      //
+      // NOTE: Internally, `p-queue` will respect concurrency and _not_ kick off
+      // a task until there is bandwidth to do so. `onEmpty` is a better choice
+      // than `onIdle` in this case because we really don't care whether all
+      // promises have settled, we only care that additional work is not being
+      // created and subsequently kicked off.
+      if (queue.size === maximumQueueSize) {
         if (onThrottleEnqueue) {
           // Mainly just used for testing that our custom throttling works.
           onThrottleEnqueue();
         }
 
-        await queue.onIdle();
+        await queue.onEmpty();
       }
 
       queue
         .add(() => upload(graphObjectData))
         .catch((err) => {
-          // Pause this queue and free up any memory on it. We do not want to
-          // continue processing if there is a failure uploading for a step. This
-          // step should get marked as "partial" and other steps can continue
-          // to run.
-          queue.pause();
-          queue.clear();
-
+          // Do not pause the queue entirely. We will try to prevent additional
+          // tasks from being added to the queue, but even if an error occurs,
+          // we should try uploading the remaining data that we have queued up.
+          // The JupiterOne synchronization should be resilient enough to handle
+          // cases where this could cause an issue (e.g. a relationship getting
+          // uploaded that references an entity that failed to upload).
           uploadErrors.push(err);
         });
     },
 
     async waitUntilUploadsComplete() {
+      try {
+        // Even if our `uploadErrors.length > 0` right now, we let the remaining
+        // promises that were added to the queue settle before rethrowing to
+        // maximize the amount of data that we are capable of actually uploading.
+        await queue.onIdle();
+      } finally {
+        // Wait until the entire queue has settled to mark as completed. During
+        // this time, we could be receiving additional tasks in our queue that
+        // will grow the queue.
+        completed = true;
+      }
+
       if (uploadErrors.length) {
         throw new IntegrationError({
           code: 'UPLOAD_ERROR',
           message: `Error(s) uploading graph object data (stepId=${stepId}, errorMessages=${uploadErrors.join(
             ',',
           )})`,
+          // Just include the first error cause. We should be able to gather
+          // additional information from the joined error messages.
+          cause: uploadErrors[0],
         });
       }
-
-      await queue.onIdle();
     },
   };
 }

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -176,6 +176,13 @@ export async function uploadGraphObjectData(
 ) {
   try {
     if (Array.isArray(graphObjectData.entities)) {
+      synchronizationJobContext.logger.info(
+        {
+          entities: graphObjectData.entities.length,
+        },
+        'Uploading entities',
+      );
+
       await uploadData(
         synchronizationJobContext,
         'entities',
@@ -184,6 +191,13 @@ export async function uploadGraphObjectData(
     }
 
     if (Array.isArray(graphObjectData.relationships)) {
+      synchronizationJobContext.logger.info(
+        {
+          relationships: graphObjectData.relationships.length,
+        },
+        'Uploading relationships',
+      );
+
       await uploadData(
         synchronizationJobContext,
         'relationships',

--- a/packages/integration-sdk-runtime/test/util/fixtures.ts
+++ b/packages/integration-sdk-runtime/test/util/fixtures.ts
@@ -1,4 +1,8 @@
-import { ExecutionHistory, IntegrationInstance } from "@jupiterone/integration-sdk-core/src";
+import {
+  ExecutionHistory,
+  IntegrationInstance,
+  IntegrationLogger,
+} from '@jupiterone/integration-sdk-core';
 
 export const LOCAL_INTEGRATION_INSTANCE: IntegrationInstance = {
   id: 'local-integration-instance',
@@ -18,7 +22,9 @@ export const LOCAL_EXECUTION_HISTORY: ExecutionHistory = {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-export function createMockIntegrationLogger(overrides) {
+export function createMockIntegrationLogger(
+  overrides?: Partial<IntegrationLogger>,
+) {
   return {
     trace: noop,
     debug: noop,
@@ -38,5 +44,5 @@ export function createMockIntegrationLogger(overrides) {
     publishEvent: noop,
     publishErrorEvent: noop,
     ...overrides,
-  };
+  } as IntegrationLogger;
 }


### PR DESCRIPTION
Put this in a separate PR as it will be easier to review and manage any feedback.

See here for motivation (thanks @mknoedel!): https://github.com/JupiterOne/sdk/pull/396/files#r545299685

I also decided to make some additional changes to the behavior around when we allow additional tasks to be pushed into the queue. I think it makes more sense to _not_ fail as fast as we can, but rather take the approach that we should upload as much data for a step as possible as we are already going to mark it as partial. The J1 synchronizer will handle edge cases that would cause issues (e.g. a relationship gets uploaded and one/both of the related entities failed to upload).

This idea is similar to the idea that we should be moving towards a world where integration steps do not fail fast in general (perhaps some cases where necessary, e.g. authentication failure). We should try to collect as much data as we can regardless of a failure. As long as the step is tracking these errors and ultimately throws at the end, we will be able to potentially upload a lot more data than we would have otherwise because of a single error. That is more of a bigger thought/development style change, but it has become particularly important in the Qualys integration where simply re-running the entire integration upon an intermittent failure (or even non-intermittent) is not a great option.