### PR TITLE
OPTIMIZATION: Support for omitting specific graph objects from file storage

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.2.1",
-    "@jupiterone/integration-sdk-runtime": "^5.2.1",
+    "@jupiterone/integration-sdk-core": "^5.3.0",
+    "@jupiterone/integration-sdk-runtime": "^5.3.0",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^5.2.1",
+    "@jupiterone/integration-sdk-runtime": "^5.3.0",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "lodash": "^4.17.19",
@@ -31,7 +31,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.2.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.3.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -71,6 +71,15 @@ export type IntegrationStep<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
 > = StepMetadata & Step<IntegrationStepExecutionContext<TConfig>>;
 
+export interface GraphObjectIndexMetadata {
+  /**
+   * Whether the index of the graph object store is enabled or not. For example,
+   * in the case leveraging the `FileSystemGraphObjectStore`, this value
+   * determines whether we need to write the specific graph object to disk.
+   */
+  enabled: boolean;
+}
+
 export interface StepGraphObjectMetadata {
   _type: string;
 
@@ -88,6 +97,11 @@ export interface StepGraphObjectMetadata {
    * * Ticket systems
    */
   partial?: boolean;
+
+  /**
+   * Contains metadadata that can be leveraged inside of the graph object store
+   */
+  indexMetadata?: GraphObjectIndexMetadata;
 }
 
 export interface StepEntityMetadata extends StepGraphObjectMetadata {

--- a/packages/integration-sdk-core/src/types/storage.ts
+++ b/packages/integration-sdk-core/src/types/storage.ts
@@ -5,6 +5,13 @@ import {
   GraphObjectLookupKey,
 } from './jobState';
 import { Relationship } from './relationship';
+import { GraphObjectIndexMetadata } from '../types/step';
+
+export interface GetIndexMetadataForGraphObjectTypeParams {
+  stepId: string;
+  _type: string;
+  graphObjectCollectionType: 'entities' | 'relationships';
+}
 
 /**
  * Persists entities and relationships to a durable medium for the duration of
@@ -39,4 +46,8 @@ export interface GraphObjectStore {
     onEntitiesFlushed?: (entities: Entity[]) => Promise<void>,
     onRelationshipsFlushed?: (relationships: Relationship[]) => Promise<void>,
   ): Promise<void>;
+
+  getIndexMetadataForGraphObjectType?: (
+    params: GetIndexMetadataForGraphObjectTypeParams,
+  ) => GraphObjectIndexMetadata | undefined;
 }

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^5.2.1",
-    "@jupiterone/integration-sdk-testing": "^5.2.1",
+    "@jupiterone/integration-sdk-cli": "^5.3.0",
+    "@jupiterone/integration-sdk-testing": "^5.3.0",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "node": "10.x || 12.x || 14.x"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.2.1",
+    "@jupiterone/integration-sdk-core": "^5.3.0",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.2.1",
+    "@jupiterone/integration-sdk-core": "^5.3.0",
     "@lifeomic/alpha": "^1.1.3",
     "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.2.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.3.0",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.2.1",
-    "@jupiterone/integration-sdk-runtime": "^5.2.1",
+    "@jupiterone/integration-sdk-core": "^5.3.0",
+    "@jupiterone/integration-sdk-runtime": "^5.3.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.2.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.3.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to
 
 ## Unreleased
 
+### 5.3.0 - 2020-12-27
+
+### Added
+
+- Support for omitting specific graph objects from file storage. Some entities
+  and relationships do not need to be stored on the file system at all. We only
+  need to store graph objects on the file system if we later intend to fetch the
+  data from the job state or iterate over the `_type`.
+
+  Usage in an integration step:
+
+  ```typescript
+  {
+    id: 'my-step',
+    name: 'My step',
+    entities: [
+      {
+        resourceName: 'The Record',
+        _type: 'my_record',
+        _class: ['Record'],
+        indexMetadata: {
+          // This _type will not be written to the file system
+          enabled: false,
+        },
+      },
+    ],
+    relationships: [],
+    async exeutionHandler() {
+      ...
+    }
+  }
+  ```
+
+  See PR [#404](https://github.com/JupiterOne/sdk/pull/404)
+
 ## 5.2.1 - 2020-12-23
 
 ### Fixed


### PR DESCRIPTION
Some entities and relationships do not need to be stored on the
file system at all. We only need to store graph objects on the file
system if we later intend to fetch the data from the job state or
iterate over the `_type`. This PR introduces support for specifying
metadata in each step that can be used by the `FileSystemGraphObjectStore`
that will be used to omit specific data from being written to disk
entirely. The data will still get uploaded.

A longer term optimization would be actually leveraging the dependency graph to automatically generate this information. We can also make a follow-up improvement that removes the entire locking behavior during these cases because no step will rely on the unindexed data, so there is no reason to lock.