### PR TITLE
Uploads should skip logging warn on CredentialsError

### DIFF
--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -275,7 +275,13 @@ async function uploadDataChunk<T extends UploadDataLookup, K extends keyof T>({
       delay: 200,
       factor: 1.05,
       handleError(err, attemptContext) {
-        if (attemptContext.attemptsRemaining) {
+        if (
+          attemptContext.attemptsRemaining &&
+          // There are sometimes intermittent credentials errors when running
+          // a managed integration on AWS Fargate. They consistently succeed
+          // with retry logic, so we don't want to log a warn.
+          err.code !== 'CredentialsError'
+        ) {
           logger.warn(
             {
               err,

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+## Changed
+
+- Skip logging warn message when a `CredentialsError` is received in graph
+  object uploads.
+
 ### 5.5.0 - 2020-01-02
 
 ## Added


### PR DESCRIPTION
There are sometimes intermittent credentials errors when running a managed integration on AWS Fargate. They consistently succeed with retry logic, so we don't want to log a bunch of warns.