### PR TITLE
Trim integration config values

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/__tests__/trimStringValues.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/trimStringValues.test.ts
@@ -1,0 +1,28 @@
+import { IntegrationInstance } from '@jupiterone/integration-sdk-core';
+import { trimStringValues } from '../utils/trimStringValues';
+
+describe('trimStringValues', () => {
+  test('provides generated logger and instance', () => {
+    const untrimmedIntegrationInstance: IntegrationInstance = {
+      id: ' test ',
+      accountId: ' test',
+      name: 'test ',
+      integrationDefinitionId: '    test',
+      description: 'test    ',
+      config: {
+        test: '   test   ',
+      },
+    };
+    const expected = {
+      id: 'test',
+      accountId: 'test',
+      name: 'test',
+      integrationDefinitionId: 'test',
+      description: 'test',
+      config: {
+        test: 'test',
+      },
+    };
+    expect(trimStringValues(untrimmedIntegrationInstance)).toEqual(expected);
+  });
+});

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -33,6 +33,7 @@ import {
   getDefaultStepStartStates,
 } from './step';
 import { CreateStepGraphObjectDataUploaderFunction } from './uploader';
+import { trimStringValues } from './utils/trimStringValues';
 import { validateStepStartStates } from './validation';
 
 export interface ExecuteIntegrationResult {
@@ -109,7 +110,7 @@ export async function executeIntegrationInstance(
     operation: () =>
       executeWithContext(
         {
-          instance,
+          instance: trimStringValues(instance),
           logger,
           executionHistory,
         },

--- a/packages/integration-sdk-runtime/src/execution/utils/trimStringValues.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/trimStringValues.ts
@@ -1,0 +1,13 @@
+import { cloneDeep, isObject, isString } from 'lodash';
+
+export function trimStringValues<T extends { [k: string]: any }>(object: T): T {
+  const trimmed = cloneDeep(object);
+  Object.keys(trimmed).forEach((key: keyof typeof trimmed) => {
+    if (isString(trimmed[key])) {
+      trimmed[key] = trimmed[key].trim();
+    } else if (isObject(trimmed[key])) {
+      trimmed[key] = trimStringValues(trimmed[key]);
+    }
+  });
+  return trimmed;
+}


### PR DESCRIPTION
This is in response to [this ticket](https://dev.azure.com/jupiterone/Platform/_sprints/taskboard/Integrations%20Team/Platform/Sprint%2062?workitem=2100) where a company accidentally added a space to their accountId. We could change the UI, but I feel that it also makes sense to  check before running integrations as welll.