### PR TITLE
Trim integration config values

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/__tests__/executeIntegration.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/executeIntegration.test.ts
@@ -20,10 +20,7 @@ import {
 import { InMemoryGraphObjectStore } from '@jupiterone/integration-sdk-private-test-utils';
 
 import * as integrationFileSystem from '../../fileSystem';
-import {
-  createIntegrationLogger,
-  IntegrationLogger as IntegrationLoggerImpl,
-} from '../../logger';
+import { IntegrationLogger as IntegrationLoggerImpl } from '../../logger';
 import { FlushedGraphObjectData } from '../../storage/types';
 import {
   executeIntegrationInstance,
@@ -32,13 +29,14 @@ import {
   ExecuteIntegrationResult,
 } from '../executeIntegration';
 import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
+import { createInstanceConfiguration } from './utils/createIntegrationConfig';
 
 const brotliDecompress = promisify(zlib.brotliDecompress);
 
 jest.mock('fs');
 
 function sleep(ms: number) {
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     setTimeout(() => resolve(), ms);
   });
 }
@@ -48,30 +46,6 @@ export interface InstanceConfigurationData {
   instance: IntegrationInstance;
   invocationConfig: IntegrationInvocationConfig;
   logger: IntegrationLogger;
-}
-
-function createInstanceConfiguration(
-  options?: Partial<InstanceConfigurationData>,
-): InstanceConfigurationData {
-  const validateInvocation: IntegrationInvocationValidationFunction =
-    options?.validateInvocation || jest.fn();
-
-  const invocationConfig: IntegrationInvocationConfig = {
-    validateInvocation,
-    integrationSteps: [],
-    ...options?.invocationConfig,
-  };
-
-  return {
-    validateInvocation,
-    invocationConfig,
-    instance: LOCAL_INTEGRATION_INSTANCE,
-    logger: createIntegrationLogger({
-      name: 'integration-name',
-      invocationConfig,
-    }),
-    ...options,
-  };
 }
 
 afterEach(() => {

--- a/packages/integration-sdk-runtime/src/execution/__tests__/getMaskedFields.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/getMaskedFields.test.ts
@@ -1,0 +1,23 @@
+import { getMaskedFields } from '../utils/getMaskedFields';
+import { createInstanceConfiguration } from './utils/createIntegrationConfig';
+
+test('getMaskedFields', () => {
+  const invocationConfig = {
+    integrationSteps: [],
+    instanceConfigFields: {
+      a: {
+        mask: true,
+      },
+      b: {
+        mask: false,
+      },
+      c: {},
+      d: {
+        mask: true,
+      },
+    },
+  };
+  const testConfig = createInstanceConfiguration({ invocationConfig })
+    .invocationConfig;
+  expect(getMaskedFields(testConfig)).toEqual(['a', 'd']);
+});

--- a/packages/integration-sdk-runtime/src/execution/__tests__/trimStringValues.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/trimStringValues.test.ts
@@ -1,0 +1,54 @@
+import { IntegrationInstance } from '@jupiterone/integration-sdk-core';
+import { trimStringValues } from '../utils/trimStringValues';
+
+describe('trimStringValues', () => {
+  const untrimmedIntegrationInstance: IntegrationInstance = {
+    id: ' test ',
+    accountId: ' test',
+    name: 'test ',
+    integrationDefinitionId: '    test',
+    description: 'test    ',
+    config: {
+      test: '   test   ',
+      test2: 'test',
+    },
+  };
+
+  test('trims spaces on all keys', () => {
+    const expected = {
+      id: 'test',
+      accountId: 'test',
+      name: 'test',
+      integrationDefinitionId: 'test',
+      description: 'test',
+      config: {
+        test: 'test',
+        test2: 'test',
+      },
+    };
+    expect(trimStringValues(untrimmedIntegrationInstance)).toEqual(expected);
+  });
+
+  test('leaves skipped fields unchanged', () => {
+    const expected = {
+      id: 'test',
+      accountId: untrimmedIntegrationInstance.accountId,
+      name: 'test',
+      integrationDefinitionId:
+        untrimmedIntegrationInstance.integrationDefinitionId,
+      description: 'test',
+      config: {
+        test: untrimmedIntegrationInstance.config.test,
+        test2: 'test',
+      },
+    };
+    expect(
+      trimStringValues(untrimmedIntegrationInstance, [
+        'accountId',
+        'integrationDefinitionId',
+        'unincludedKey',
+        'test',
+      ]),
+    ).toEqual(expected);
+  });
+});

--- a/packages/integration-sdk-runtime/src/execution/__tests__/utils/createIntegrationConfig.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/utils/createIntegrationConfig.ts
@@ -1,0 +1,31 @@
+import {
+  IntegrationInvocationValidationFunction,
+  IntegrationInvocationConfig,
+} from '@jupiterone/integration-sdk-core';
+import { LOCAL_INTEGRATION_INSTANCE } from '../..';
+import { createIntegrationLogger } from '../../..';
+import { InstanceConfigurationData } from '../executeIntegration.test';
+
+export function createInstanceConfiguration(
+  options?: Partial<InstanceConfigurationData>,
+): InstanceConfigurationData {
+  const validateInvocation: IntegrationInvocationValidationFunction =
+    options?.validateInvocation || jest.fn();
+
+  const invocationConfig: IntegrationInvocationConfig = {
+    validateInvocation,
+    integrationSteps: [],
+    ...options?.invocationConfig,
+  };
+
+  return {
+    validateInvocation,
+    invocationConfig,
+    instance: LOCAL_INTEGRATION_INSTANCE,
+    logger: createIntegrationLogger({
+      name: 'integration-name',
+      invocationConfig,
+    }),
+    ...options,
+  };
+}

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -33,6 +33,8 @@ import {
   getDefaultStepStartStates,
 } from './step';
 import { CreateStepGraphObjectDataUploaderFunction } from './uploader';
+import { getMaskedFields } from './utils/getMaskedFields';
+import { trimStringValues } from './utils/trimStringValues';
 import { validateStepStartStates } from './validation';
 
 export interface ExecuteIntegrationResult {
@@ -109,7 +111,7 @@ export async function executeIntegrationInstance(
     operation: () =>
       executeWithContext(
         {
-          instance,
+          instance: trimStringValues(instance, getMaskedFields(config)),
           logger,
           executionHistory,
         },

--- a/packages/integration-sdk-runtime/src/execution/utils/getMaskedFields.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/getMaskedFields.ts
@@ -1,0 +1,6 @@
+import { IntegrationInvocationConfig } from '@jupiterone/integration-sdk-core';
+import { keys, pickBy } from 'lodash';
+
+export function getMaskedFields(config: IntegrationInvocationConfig) {
+  return keys(pickBy(config.instanceConfigFields, (val) => val.mask));
+}

--- a/packages/integration-sdk-runtime/src/execution/utils/trimStringValues.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/trimStringValues.ts
@@ -1,0 +1,17 @@
+import { cloneDeep, isObject, isString } from 'lodash';
+
+export function trimStringValues<T extends { [k: string]: any }>(
+  object: T,
+  fieldsToSkip: string[] = [],
+): T {
+  const trimmed = cloneDeep(object);
+  Object.keys(trimmed).forEach((key: keyof T) => {
+    const val = trimmed[key];
+    if (isString(val) && !fieldsToSkip.includes(key as string)) {
+      trimmed[key] = val.trim();
+    } else if (isObject(val)) {
+      trimmed[key] = trimStringValues(val, fieldsToSkip);
+    }
+  });
+  return trimmed;
+}

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## Unreleased
 
+## Added
+
+- Whitespace trimming of integration config values.
+
 ## Changed
 
 - Skip logging warn message when a `CredentialsError` is received in graph


### PR DESCRIPTION
Trim integration all unmasked config values prior to executing an integration.

Masked values are skipped because they may contain spaces at the start or the end. If you think there is a good place to put that information in the code let me know and I will add it!