### PR TITLE
Allow duplicate key tracker to grow greater than V8 engine limit

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.6.0",
-    "@jupiterone/integration-sdk-runtime": "^5.6.0",
+    "@jupiterone/integration-sdk-core": "^5.6.1",
+    "@jupiterone/integration-sdk-runtime": "^5.6.1",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^5.6.0",
+    "@jupiterone/integration-sdk-runtime": "^5.6.1",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "lodash": "^4.17.19",
@@ -31,7 +31,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.6.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.6.1",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^5.6.0",
-    "@jupiterone/integration-sdk-testing": "^5.6.0",
+    "@jupiterone/integration-sdk-cli": "^5.6.1",
+    "@jupiterone/integration-sdk-testing": "^5.6.1",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "node": "10.x || 12.x || 14.x"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.6.0",
+    "@jupiterone/integration-sdk-core": "^5.6.1",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.6.0",
+    "@jupiterone/integration-sdk-core": "^5.6.1",
     "@lifeomic/alpha": "^1.1.3",
     "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.6.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.6.1",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -8,11 +8,14 @@ import {
 
 import { GraphObjectStore } from '../storage';
 import { StepGraphObjectDataUploader } from './uploader';
+import { BigMap } from './utils/bigMap';
 
 export interface DuplicateKeyTrackerGraphObjectMetadata {
   _type: string;
   _key: string;
 }
+
+const DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE = 2000000;
 
 /**
  * Contains a map of every graph object key to a specific set of metadata about
@@ -22,15 +25,17 @@ export interface DuplicateKeyTrackerGraphObjectMetadata {
  * table.
  */
 export class DuplicateKeyTracker {
-  private readonly graphObjectKeyMap = new Map<
-    string,
+  private readonly graphObjectKeyMap: BigMap<
     DuplicateKeyTrackerGraphObjectMetadata
-  >();
-
+  >;
   private readonly normalizationFunction: KeyNormalizationFunction;
 
   constructor(normalizationFunction?: KeyNormalizationFunction) {
     this.normalizationFunction = normalizationFunction || ((_key) => _key);
+
+    this.graphObjectKeyMap = new BigMap<DuplicateKeyTrackerGraphObjectMetadata>(
+      DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE,
+    );
   }
 
   registerKey(_key: string, metadata: DuplicateKeyTrackerGraphObjectMetadata) {

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -26,6 +26,7 @@ const DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE = 2000000;
  */
 export class DuplicateKeyTracker {
   private readonly graphObjectKeyMap: BigMap<
+    string,
     DuplicateKeyTrackerGraphObjectMetadata
   >;
   private readonly normalizationFunction: KeyNormalizationFunction;
@@ -33,9 +34,10 @@ export class DuplicateKeyTracker {
   constructor(normalizationFunction?: KeyNormalizationFunction) {
     this.normalizationFunction = normalizationFunction || ((_key) => _key);
 
-    this.graphObjectKeyMap = new BigMap<DuplicateKeyTrackerGraphObjectMetadata>(
-      DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE,
-    );
+    this.graphObjectKeyMap = new BigMap<
+      string,
+      DuplicateKeyTrackerGraphObjectMetadata
+    >(DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE);
   }
 
   registerKey(_key: string, metadata: DuplicateKeyTrackerGraphObjectMetadata) {

--- a/packages/integration-sdk-runtime/src/execution/utils/bigMap.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/bigMap.test.ts
@@ -2,7 +2,7 @@ import { BigMap } from './bigMap';
 
 describe('#BigMap', () => {
   test('should insert data into default map if under maximum key space limit', () => {
-    const m = new BigMap<number>(5);
+    const m = new BigMap<string, number>(5);
     m.set('a', 1);
     expect(m.has('a')).toEqual(true);
     expect(m.get('a')).toEqual(1);
@@ -11,7 +11,7 @@ describe('#BigMap', () => {
 
   test('should create a new map when key space limit reached', () => {
     const maximumMapKeySpace = 5;
-    const m = new BigMap<number>(maximumMapKeySpace);
+    const m = new BigMap<string, number>(maximumMapKeySpace);
     const totalKeys = maximumMapKeySpace + 1;
 
     for (let i = 0; i < totalKeys; i++) {
@@ -26,12 +26,12 @@ describe('#BigMap', () => {
   });
 
   test('#get should return undefined if key not found', () => {
-    const m = new BigMap<number>(5);
+    const m = new BigMap<string, number>(5);
     expect(m.get('a')).toEqual(undefined);
   });
 
   test('#has should return false if key not found', () => {
-    const m = new BigMap<number>(5);
+    const m = new BigMap<string, number>(5);
     expect(m.has('a')).toEqual(false);
   });
 });

--- a/packages/integration-sdk-runtime/src/execution/utils/bigMap.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/bigMap.test.ts
@@ -1,0 +1,37 @@
+import { BigMap } from './bigMap';
+
+describe('#BigMap', () => {
+  test('should insert data into default map if under maximum key space limit', () => {
+    const m = new BigMap<number>(5);
+    m.set('a', 1);
+    expect(m.has('a')).toEqual(true);
+    expect(m.get('a')).toEqual(1);
+    expect(m.getMapsLength()).toEqual(1);
+  });
+
+  test('should create a new map when key space limit reached', () => {
+    const maximumMapKeySpace = 5;
+    const m = new BigMap<number>(maximumMapKeySpace);
+    const totalKeys = maximumMapKeySpace + 1;
+
+    for (let i = 0; i < totalKeys; i++) {
+      m.set(`k_${i}`, i);
+    }
+
+    for (let i = 0; i < totalKeys; i++) {
+      expect(m.get(`k_${i}`)).toEqual(i);
+    }
+
+    expect(m.getMapsLength()).toEqual(2);
+  });
+
+  test('#get should return undefined if key not found', () => {
+    const m = new BigMap<number>(5);
+    expect(m.get('a')).toEqual(undefined);
+  });
+
+  test('#has should return false if key not found', () => {
+    const m = new BigMap<number>(5);
+    expect(m.has('a')).toEqual(false);
+  });
+});

--- a/packages/integration-sdk-runtime/src/execution/utils/bigMap.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/bigMap.ts
@@ -1,5 +1,5 @@
-export class BigMap<T> {
-  private maps: Map<string, T>[] = [new Map<string, T>()];
+export class BigMap<K, V> {
+  private maps: Map<K, V>[] = [new Map<K, V>()];
 
   readonly maximumMapKeySpace: number;
 
@@ -7,11 +7,11 @@ export class BigMap<T> {
     this.maximumMapKeySpace = maximumMapKeySpace;
   }
 
-  set(key: string, value: T): Map<string, T> {
+  set(key: K, value: V): Map<K, V> {
     const map = this.maps[this.maps.length - 1];
 
     if (map.size === this.maximumMapKeySpace) {
-      const newMap = new Map<string, T>();
+      const newMap = new Map<K, V>();
       const result = newMap.set(key, value);
       this.maps.push(newMap);
       return result;
@@ -20,11 +20,11 @@ export class BigMap<T> {
     }
   }
 
-  has(key: string) {
+  has(key: K) {
     return mapForKey(this.maps, key) !== undefined;
   }
 
-  get(key: string) {
+  get(key: K) {
     return valueForKey(this.maps, key);
   }
 
@@ -33,10 +33,7 @@ export class BigMap<T> {
   }
 }
 
-function mapForKey<T>(
-  maps: Map<string, T>[],
-  key: string,
-): Map<string, T> | undefined {
+function mapForKey<K, V>(maps: Map<K, V>[], key: K): Map<K, V> | undefined {
   for (let index = maps.length - 1; index >= 0; index--) {
     const map = maps[index];
 
@@ -46,7 +43,7 @@ function mapForKey<T>(
   }
 }
 
-function valueForKey<T>(maps: Map<string, T>[], key: string): T | undefined {
+function valueForKey<K, V>(maps: Map<K, V>[], key: K): V | undefined {
   for (let index = maps.length - 1; index >= 0; index--) {
     const map = maps[index];
     const value = map.get(key);

--- a/packages/integration-sdk-runtime/src/execution/utils/bigMap.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/bigMap.ts
@@ -1,0 +1,58 @@
+export class BigMap<T> {
+  private maps: Map<string, T>[] = [new Map<string, T>()];
+
+  readonly maximumMapKeySpace: number;
+
+  constructor(maximumMapKeySpace: number) {
+    this.maximumMapKeySpace = maximumMapKeySpace;
+  }
+
+  set(key: string, value: T): Map<string, T> {
+    const map = this.maps[this.maps.length - 1];
+
+    if (map.size === this.maximumMapKeySpace) {
+      const newMap = new Map<string, T>();
+      const result = newMap.set(key, value);
+      this.maps.push(newMap);
+      return result;
+    } else {
+      return map.set(key, value);
+    }
+  }
+
+  has(key: string) {
+    return mapForKey(this.maps, key) !== undefined;
+  }
+
+  get(key: string) {
+    return valueForKey(this.maps, key);
+  }
+
+  getMapsLength() {
+    return this.maps.length;
+  }
+}
+
+function mapForKey<T>(
+  maps: Map<string, T>[],
+  key: string,
+): Map<string, T> | undefined {
+  for (let index = maps.length - 1; index >= 0; index--) {
+    const map = maps[index];
+
+    if (map.has(key)) {
+      return map;
+    }
+  }
+}
+
+function valueForKey<T>(maps: Map<string, T>[], key: string): T | undefined {
+  for (let index = maps.length - 1; index >= 0; index--) {
+    const map = maps[index];
+    const value = map.get(key);
+
+    if (value !== undefined) {
+      return value;
+    }
+  }
+}

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.6.0",
-    "@jupiterone/integration-sdk-runtime": "^5.6.0",
+    "@jupiterone/integration-sdk-core": "^5.6.1",
+    "@jupiterone/integration-sdk-runtime": "^5.6.1",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.6.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.6.1",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"

--- a/packages/integration-sdk/CHANGELOG.md
+++ b/packages/integration-sdk/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## Unreleased
 
+### 5.6.1 - 2020-01-20
+
+## Fixed
+
+- Allow duplicate key tracker to grow greater than V8 engine limit. See
+  [#420](https://github.com/JupiterOne/sdk/pull/420).
+
 ### 5.6.0 - 2020-01-14
 
 ## Added


### PR DESCRIPTION
Never hit this issue before...

The Qualys integration run on a machine that has >30GB of memory. We allow V8 to use the entire ~30GB memory section using the `--max-old-space-size` Node option when the we start the process. The Qualys integration exited with an out of memory error despite only consuming ~20% of the total memory. I learned that V8 has an internal 1GB limit allocated to each `Map`, or 2^24 keys. We are hitting the 1GB limit. See: https://stackoverflow.com/questions/54452896/maximum-number-of-entries-in-node-js-map/54466812#54466812

This change implements a basic `BigMap` that is an array of maps. We start with a map with a maximum key space of 2,000,000 keys and will add a map every time we reach that threshold. I realize this is not perfect because some integrations will produce smaller or larger keys, but to avoid too much complexity and potential slowness accrued from a lot of calculations at runtime, this is probably a good enough approach.