### PR TITLE
Update the EntityRawData type to be in-line with the persister

### DIFF
--- a/packages/integration-sdk-core/src/data/rawData.ts
+++ b/packages/integration-sdk-core/src/data/rawData.ts
@@ -8,10 +8,10 @@ import { EntityRawData, RawDataTracking } from '../types';
  * @param name name of raw data, unique within scope of entity; `'default'`
  * unless otherwise specified
  */
-export function getRawData<T>(
+export function getRawData(
   trackingEntity: RawDataTracking,
   name: string = 'default',
-): T | undefined {
+): EntityRawData['rawData'] | undefined {
   if (!trackingEntity._rawData || trackingEntity._rawData.length === 0) {
     return undefined;
   }

--- a/packages/integration-sdk-core/src/types/entity.ts
+++ b/packages/integration-sdk-core/src/types/entity.ts
@@ -93,7 +93,9 @@ export type EntityRawData = {
   name: string;
 
   /**
-   * Any type of data representing the source content used to build an entity.
+   * A string or an object of any type representing the source content used to build an entity.
    */
-  rawData: any;
+  rawData: NonArrayObject | string;
 };
+
+type NonArrayObject = Record<string, unknown>;


### PR DESCRIPTION
### Description
The persister does schema validation on the `_rawData` value of entities that is different from this TypeScript type, which causes confusing upload errors like:

```
Error uploading collected data (API response: code=ENTITY_UPLOAD_FAILED_VALIDATION, message="1 validation error(s):
- Error in entities[0]._rawData (reason=Expected { [_: string]: { body: string | { [_: string]: unknown }; contentType: string | undefined; } } | undefined, but was object in _rawData)
").
```

This change will let Typescript tell us if we put in an array instead an object, thus preventing these errors:
<img width="789" alt="Screen Shot 2021-03-26 at 1 06 04 PM" src="https://user-images.githubusercontent.com/25489482/112674983-9853bb80-8e34-11eb-8a43-84af453ed6f2.png">

Fixes #441 