### PR TITLE
Update the EntityRawData type to be in-line with the persister

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.11.0",
-    "@jupiterone/integration-sdk-runtime": "^5.11.0",
+    "@jupiterone/integration-sdk-core": "^5.11.1",
+    "@jupiterone/integration-sdk-runtime": "^5.11.1",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^5.11.0",
+    "@jupiterone/integration-sdk-runtime": "^5.11.1",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "lodash": "^4.17.19",
@@ -31,7 +31,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.11.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.11.1",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-core/src/data/rawData.ts
+++ b/packages/integration-sdk-core/src/data/rawData.ts
@@ -8,10 +8,10 @@ import { EntityRawData, RawDataTracking } from '../types';
  * @param name name of raw data, unique within scope of entity; `'default'`
  * unless otherwise specified
  */
-export function getRawData<T>(
+export function getRawData(
   trackingEntity: RawDataTracking,
   name: string = 'default',
-): T | undefined {
+): EntityRawData['rawData'] | undefined {
   if (!trackingEntity._rawData || trackingEntity._rawData.length === 0) {
     return undefined;
   }

--- a/packages/integration-sdk-core/src/types/entity.ts
+++ b/packages/integration-sdk-core/src/types/entity.ts
@@ -93,7 +93,9 @@ export type EntityRawData = {
   name: string;
 
   /**
-   * Any type of data representing the source content used to build an entity.
+   * A string or an object of any type representing the source content used to build an entity.
    */
-  rawData: any;
+  rawData: NonArrayObject | string;
 };
+
+type NonArrayObject = Record<string, unknown>;

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^5.11.0",
-    "@jupiterone/integration-sdk-testing": "^5.11.0",
+    "@jupiterone/integration-sdk-cli": "^5.11.1",
+    "@jupiterone/integration-sdk-testing": "^5.11.1",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "node": "10.x || 12.x || 14.x"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.11.0",
+    "@jupiterone/integration-sdk-core": "^5.11.1",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.11.0",
+    "@jupiterone/integration-sdk-core": "^5.11.1",
     "@lifeomic/alpha": "^1.4.0",
     "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.11.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.11.1",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^5.11.0",
-    "@jupiterone/integration-sdk-runtime": "^5.11.0",
+    "@jupiterone/integration-sdk-core": "^5.11.1",
+    "@jupiterone/integration-sdk-runtime": "^5.11.1",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^5.11.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^5.11.1",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
### Description
The persister does schema validation on the `_rawData` value of entities that is different from this TypeScript type, which causes confusing upload errors like:

```
Error uploading collected data (API response: code=ENTITY_UPLOAD_FAILED_VALIDATION, message="1 validation error(s):
- Error in entities[0]._rawData (reason=Expected { [_: string]: { body: string | { [_: string]: unknown }; contentType: string | undefined; } } | undefined, but was object in _rawData)
").
```

This change will let Typescript tell us if we put in an array instead an object, thus preventing these errors:
<img width="789" alt="Screen Shot 2021-03-26 at 1 06 04 PM" src="https://user-images.githubusercontent.com/25489482/112674983-9853bb80-8e34-11eb-8a43-84af453ed6f2.png">

Fixes #441 