### PR TITLE
AB#4717- Only upload entities and relationships in the step they were created in

### DIFF
--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -123,8 +123,11 @@ export interface JobState {
    * Ensures all current state is written to persistent storage. It is not
    * necessary to invoke this in an integration; the state is periodically
    * flushed to reduce memory consumption.
+   *
+   * @param stepId is an optonal parameter used to only flush data that was
+   * generated from a specific step; not all the data in the jobState.
    */
-  flush: () => Promise<void>;
+  flush: (stepId?: string) => Promise<void>;
 
   /**
    * A job state may be created with a graph object uploader. This function

--- a/packages/integration-sdk-core/src/types/storage.ts
+++ b/packages/integration-sdk-core/src/types/storage.ts
@@ -45,6 +45,7 @@ export interface GraphObjectStore {
   flush(
     onEntitiesFlushed?: (entities: Entity[]) => Promise<void>,
     onRelationshipsFlushed?: (relationships: Relationship[]) => Promise<void>,
+    stepId?: string,
   ): Promise<void>;
 
   getIndexMetadataForGraphObjectType?: (

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -278,7 +278,6 @@ export function executeStepDependencyGraph<
 
       try {
         await step.executionHandler(context);
-        context.logger.stepSuccess(step);
 
         if (stepHasDependencyFailure(stepId)) {
           status = StepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE;
@@ -297,7 +296,7 @@ export function executeStepDependencyGraph<
         status = StepResultStatus.FAILURE;
       }
 
-      await context.jobState.flush();
+      await context.jobState.flush(stepId);
 
       if (context.jobState.waitUntilUploadsComplete) {
         try {
@@ -305,6 +304,9 @@ export function executeStepDependencyGraph<
           // fatal failure. We just want to make this step as a partial success
           // and move on with our lives!
           await context.jobState.waitUntilUploadsComplete();
+          if (status != StepResultStatus.FAILURE) {
+            context.logger.stepSuccess(step);
+          }
         } catch (err) {
           context.logger.stepFailure(step, err);
           status = StepResultStatus.FAILURE;

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -189,7 +189,7 @@ export function createStepJobState({
     iterateRelationships: (filter, iteratee) =>
       graphObjectStore.iterateRelationships(filter, iteratee),
 
-    flush: () =>
+    flush: (stepId?: string) =>
       graphObjectStore.flush(
         async (entities) =>
           uploader?.enqueue({
@@ -201,6 +201,7 @@ export function createStepJobState({
             entities: [],
             relationships,
           }),
+        stepId,
       ),
 
     async waitUntilUploadsComplete() {

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -148,7 +148,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
       const context = jobContextWithUploaderMetadataLogger({
         synchronizationJobContext,
         uploadId: uuid(),
-        stepId: stepId,
+        stepId,
       });
 
       try {

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -210,19 +210,21 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
   async flush(
     onEntitiesFlushed?: (entities: Entity[]) => Promise<void>,
     onRelationshipsFlushed?: (relationships: Relationship[]) => Promise<void>,
+    stepId?: string,
   ) {
     await Promise.all([
-      this.flushEntitiesToDisk(onEntitiesFlushed),
-      this.flushRelationshipsToDisk(onRelationshipsFlushed),
+      this.flushEntitiesToDisk(onEntitiesFlushed, stepId),
+      this.flushRelationshipsToDisk(onRelationshipsFlushed, stepId),
     ]);
   }
 
   async flushEntitiesToDisk(
     onEntitiesFlushed?: (entities: Entity[]) => Promise<void>,
+    onlyThisStepId?: string,
   ) {
     await this.lockOperation(() =>
       pMap(
-        this.localGraphObjectStore.collectEntitiesByStep(),
+        this.localGraphObjectStore.collectEntitiesByStep(onlyThisStepId),
         async ([stepId, entities]) => {
           const indexable = entities.filter((e) => {
             const indexMetadata = this.getIndexMetadataForGraphObjectType({
@@ -259,10 +261,11 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
 
   async flushRelationshipsToDisk(
     onRelationshipsFlushed?: (relationships: Relationship[]) => Promise<void>,
+    onlyThisStepId?: string,
   ) {
     await this.lockOperation(() =>
       pMap(
-        this.localGraphObjectStore.collectRelationshipsByStep(),
+        this.localGraphObjectStore.collectRelationshipsByStep(onlyThisStepId),
         async ([stepId, relationships]) => {
           const indexable = relationships.filter((r) => {
             const indexMetadata = this.getIndexMetadataForGraphObjectType({

--- a/packages/integration-sdk-runtime/src/storage/memory.ts
+++ b/packages/integration-sdk-runtime/src/storage/memory.ts
@@ -212,11 +212,12 @@ export class InMemoryGraphObjectStore {
     }
   }
 
-  collectEntitiesByStep(): Map<string, Entity[]> {
+  collectEntitiesByStep(onlyThisStepId?: string): Map<string, Entity[]> {
     const entitiesByStepMap = new Map<string, Entity[]>();
 
     for (const [_key, graphObjectData] of this.entityKeyToEntityMap) {
       const { stepId, entity } = graphObjectData;
+      if (onlyThisStepId && onlyThisStepId !== stepId) continue;
 
       const entitiesByStepArray = entitiesByStepMap.get(stepId);
       if (entitiesByStepArray) {
@@ -229,12 +230,15 @@ export class InMemoryGraphObjectStore {
     return entitiesByStepMap;
   }
 
-  collectRelationshipsByStep(): Map<string, Relationship[]> {
+  collectRelationshipsByStep(
+    onlyThisStepId?: string,
+  ): Map<string, Relationship[]> {
     const relationshipsByStepMap = new Map<string, Relationship[]>();
 
     for (const [_key, graphObjectData] of this
       .relationshipKeyToRelationshipMap) {
       const { stepId, relationship } = graphObjectData;
+      if (onlyThisStepId && onlyThisStepId !== stepId) continue;
 
       const relationshipsByStepArray = relationshipsByStepMap.get(stepId);
       if (relationshipsByStepArray) {

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -198,6 +198,6 @@ export function createMockJobState({
       }
     },
 
-    flush: (): Promise<void> => Promise.resolve(),
+    flush: (stepId?: string): Promise<void> => Promise.resolve(),
   };
 }


### PR DESCRIPTION
This is fixing an issue were entities from long-running steps were being flushed by later, un-related steps. 