### PR TITLE
Add yarn build to readme development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ details about how to develop integrations with this SDK.
 
 ## Development
 
-First install dependencies using `yarn`.
+To get started with development:
+
+1. Install dependencies using `yarn`
+1. Run `yarn build`
 
 This project utilizes TypeScript project references for incremental builds. To
 prepare all of the packages, run `yarn build`. If you are making a changes


### PR DESCRIPTION
Just wanted to make this a bit clearer - somehow my local links got messed up and it wasn't immediately clear that a fresh install will require `yarn build`.