### PR TITLE
add diffing functionality to the sdk

### DIFF
--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -25,6 +25,7 @@
     "@jupiterone/integration-sdk-runtime": "^6.3.0",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
+    "json-diff": "^0.5.4",
     "lodash": "^4.17.19",
     "markdown-table": "^2.0.0",
     "upath": "^1.2.0",

--- a/packages/integration-sdk-cli/src/commands/compare.ts
+++ b/packages/integration-sdk-cli/src/commands/compare.ts
@@ -29,5 +29,3 @@ export function compare() {
       findDifferences(oldPath, neoPath, options.logOnlyKeyChanges)
     });
 }
-
-compare().parse()

--- a/packages/integration-sdk-cli/src/commands/compare.ts
+++ b/packages/integration-sdk-cli/src/commands/compare.ts
@@ -1,0 +1,33 @@
+import { createCommand } from 'commander';
+import * as log from '../log';
+import { findDifferences } from '../utils/diff';
+
+export function compare() {
+  return createCommand('compare')
+    .storeOptionsAsProperties()
+    .arguments('<oldPath> <neoPath>')
+    .description('Compare the differences between two datasets that were downloaded from JupiterOne via the query: \n\n' +
+
+    '\t find * as e that RELATES TO as r * return e.*, r.*\n\n' +
+
+    'Example Dataset: \n\n' +
+
+    JSON.stringify(require('../utils/exampleDataset.json'), null, 4)
+    
+    , {
+      oldPath: 'relitive path to the dataset to compare against',
+      neoPath: 'relitive path to the new dataset'
+    })
+    .option(
+      '-logkey, --log-only-key-changes',
+      'Only log entities and relationships that have _key values that are not in the other dataset.'
+    )
+    .action((oldPath, neoPath, options) => {
+      log.info(`oldPath: ${oldPath}`);
+      log.info(`neoPath: ${neoPath}`);
+      log.info(`logOnlyKeyChanges: ${options.logOnlyKeyChanges}`)
+      findDifferences(oldPath, neoPath, options.logOnlyKeyChanges)
+    });
+}
+
+compare().parse()

--- a/packages/integration-sdk-cli/src/commands/compare.ts
+++ b/packages/integration-sdk-cli/src/commands/compare.ts
@@ -15,12 +15,12 @@ export function compare() {
     JSON.stringify(require('../utils/exampleDataset.json'), null, 4)
     
     , {
-      oldPath: 'relitive path to the dataset to compare against',
-      neoPath: 'relitive path to the new dataset'
+      oldPath: 'relative path to the dataset to compare against',
+      neoPath: 'relative path to the new dataset'
     })
     .option(
-      '-logkey, --log-only-key-changes',
-      'Only log entities and relationships that have _key values that are not in the other dataset.'
+      '-ok, --log-only-key-changes',
+      'Only log entities and relationships if their _key is only in one dataset or the other, but not in both.'
     )
     .action((oldPath, neoPath, options) => {
       log.info(`oldPath: ${oldPath}`);

--- a/packages/integration-sdk-cli/src/commands/index.ts
+++ b/packages/integration-sdk-cli/src/commands/index.ts
@@ -1,4 +1,5 @@
 export * from './collect';
+export * from './compare';
 export * from './visualize';
 export * from './sync';
 export * from './run';

--- a/packages/integration-sdk-cli/src/utils/diff.ts
+++ b/packages/integration-sdk-cli/src/utils/diff.ts
@@ -1,0 +1,84 @@
+import fs from "fs";
+import { diff as diffJson } from 'json-diff'
+
+export function findDifferences(oldJsonDataPath, newJsonDataPath, logOnlyKeyChanges) {
+
+  const neo = JSON.parse(fs.readFileSync(newJsonDataPath, 'utf8'))
+  const old = JSON.parse(fs.readFileSync(oldJsonDataPath, 'utf8'))
+
+  /**
+   * These regexes are necessary due to the way we export the data from JupiterOne.
+   */
+  const GRAPH_OBJECT_KEY_PROPERTY = /^[er]\._key/;
+  const ENTITY_PROPERTY = /^e\./;
+  const RELATIONSHIP_PROPERTY = /^r\./;
+
+  const extractor = (acc, obj) => {
+
+    const entity: any = {};
+    const relationship: any = {};
+    for (const key in obj) {
+      if (ENTITY_PROPERTY.test(key)) {
+        entity[key.slice(2)] = obj[key];
+        if (GRAPH_OBJECT_KEY_PROPERTY.test(key)) {
+          acc[obj[key]] = entity;
+        }
+      } else if (RELATIONSHIP_PROPERTY.test(key)) {
+        relationship[key.slice(2)] = obj[key];
+        if (GRAPH_OBJECT_KEY_PROPERTY.test(key)) {
+          acc[getRelationshipKey(relationship)] = relationship;
+        }
+      }
+    }
+    return acc;
+  };
+
+  const oldByKey = (old as any).data.reduce(extractor, {});
+  const newByKey = (neo as any).data.reduce(extractor, {});
+
+  const oldKeys: string[] = [];
+  const newKeys: string[] = [];
+
+  const pairs: { [key: string]: { key: string; old: any; neo: any } } = {};
+  for (const [key, value] of Object.entries<any>(oldByKey)) {
+    oldKeys.push(key);
+    pairs[key] = { key, old: value, neo: newByKey[getRelationshipKey(value)]};
+  }
+  for (const [key, value] of Object.entries<any>(newByKey)) {
+    newKeys.push(key)
+    if (!pairs[key]) {
+      pairs[key] = { key, old: oldByKey[getRelationshipKey(value)], neo: value };
+    }
+  }
+
+  console.log({
+    oldKeys: oldKeys.length,
+    newKeys: newKeys.length,
+  });
+
+  const differences: any[] = [];
+  for (const [key, { old, neo }] of Object.entries(pairs)) {
+    if (!logOnlyKeyChanges || (!old || !neo)) {
+      const mappedRelationship =
+        'system-mapper' === (old?._source || neo?._source);
+
+      const diff = diffJson(old, neo);
+      differences.push({ key, mappedRelationship, diff });
+    }
+  }
+
+  console.log('differences: ', JSON.stringify(differences, null, 2));
+}
+
+
+/**
+ * In some integrations, _key values for relationships were made with JupiterOne
+ * database storage id, which will change when between sdk v1 and v2. These changes
+ * are fine, so in order to avoid catching these, we construct a better key based
+ * on the entity types and the relationship.
+ */
+function getRelationshipKey(relationship) {
+  return (relationship._fromEntityKey && relationship._toEntityKey && relationship._class) ?
+    '' + relationship._fromEntityKey + relationship._class + relationship._toEntityKey :
+    relationship._key
+}

--- a/packages/integration-sdk-cli/src/utils/exampleDataset.json
+++ b/packages/integration-sdk-cli/src/utils/exampleDataset.json
@@ -1,0 +1,11 @@
+{
+    "type": "table",
+    "data": [
+      {
+        "e._objectType": "entity",
+        "e._key": "12345",
+        "e.name": "Name"
+      }
+    ],
+    "totalCount": 1
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,6 +2697,13 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+cli-color@~0.1.6:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-0.1.7.tgz#adc3200fa471cc211b0da7f566b71e98b9d67347"
+  integrity sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=
+  dependencies:
+    es5-ext "0.8.x"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -3323,6 +3330,13 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+difflib@~0.2.1:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/difflib/-/difflib-0.2.4.tgz#b5e30361a6db023176d562892db85940a718f47e"
+  integrity sha1-teMDYabbAjF21WKJLbhZQKcY9H4=
+  dependencies:
+    heap ">= 0.2.0"
+
 dir-glob@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -3384,6 +3398,13 @@ dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
+dreamopt@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/dreamopt/-/dreamopt-0.6.0.tgz#d813ccdac8d39d8ad526775514a13dda664d6b4b"
+  integrity sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=
+  dependencies:
+    wordwrap ">=0.0.2"
 
 dtrace-provider@~0.8:
   version "0.8.8"
@@ -3513,6 +3534,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es5-ext@0.8.x:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.8.2.tgz#aba8d9e1943a895ac96837a62a39b3f55ecd94ab"
+  integrity sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=
 
 es6-promise@^4.0.3:
   version "4.2.8"
@@ -4530,6 +4556,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+"heap@>= 0.2.0":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
+  integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   version "2.8.8"
@@ -5686,6 +5717,15 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+json-diff@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/json-diff/-/json-diff-0.5.4.tgz#7bc8198c441756632aab66c7d9189d365a7a035a"
+  integrity sha512-q5Xmx9QXNOzOzIlMoYtLrLiu4Jl/Ce2bn0CNcv54PhyH89CI4GWlGVDye8ei2Ijt9R3U+vsWPsXpLUNob8bs8Q==
+  dependencies:
+    cli-color "~0.1.6"
+    difflib "~0.2.1"
+    dreamopt "~0.6.0"
 
 json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1:
   version "1.0.2"
@@ -9225,7 +9265,7 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-wordwrap@^1.0.0:
+wordwrap@>=0.0.2, wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=


### PR DESCRIPTION
Usage:

This is used when migrating integrations from the old sdk to the new sdk to ensure there are no unintended changes.

Helper text:

```
Usage: compare [options] <oldPath> <neoPath>

Compare the differences between two datasets that were downloaded from JupiterOne via the query: 

         find * as e that RELATES TO as r * return e.*, r.*

Example Dataset: 

{
    "type": "table",
    "data": [
        {
            "e._objectType": "entity",
            "e._key": "12345",
            "e.name": "Name"
        }
    ],
    "totalCount": 1
}

Arguments:

  oldPath                          relitive path to the dataset to compare against
  neoPath                          relitive path to the new dataset

Options:
  -logkey, --log-only-key-changes  Only log entities and relationships that have _key values that are not in the other dataset.
  -h, --help                       display help for command
```

Output:
```
oldPath: ./.old.json
neoPath: ./.neo.json
logOnlyKeyChanges: undefined
{ oldKeys: 1, newKeys: 1 }
differences:  [
  {
    "key": "jupiterone/token-service/pull-requests/14",
    "mappedRelationship": false,
    "diff": {
      "name": {
        "__old": "Name 2",
        "__new": "Name 1"
      }
    }
  }
]
```

This could be a lot better, but it is useful enough for us to get through the few remaining integrations we still need to port to the new sdk.