### PR TITLE
Allow `findEntity()` to accept `string | undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
   ]);
   ```
 
+### Changed
+
+- Expanded the interface of `findEntity` to accept `string | undefined`.
+
 ### Fixed
 
 - Fix missing CLI `compare` sub command.

--- a/packages/integration-sdk-core/src/types/storage.ts
+++ b/packages/integration-sdk-core/src/types/storage.ts
@@ -26,7 +26,7 @@ export interface GraphObjectStore {
     onRelationshipsFlushed?: (relationships: Relationship[]) => Promise<void>,
   ): Promise<void>;
 
-  findEntity(_key: string): Promise<Entity | undefined>;
+  findEntity(_key: string | undefined): Promise<Entity | undefined>;
 
   iterateEntities<T extends Entity = Entity>(
     filter: GraphObjectFilter,

--- a/packages/integration-sdk-private-test-utils/src/graphObjectStore.ts
+++ b/packages/integration-sdk-private-test-utils/src/graphObjectStore.ts
@@ -34,8 +34,8 @@ export class InMemoryGraphObjectStore implements GraphObjectStore {
     return Promise.resolve();
   }
 
-  async findEntity(_key: string): Promise<Entity | undefined> {
-    const entity = this.entityMap.get(_key);
+  async findEntity(_key: string | undefined): Promise<Entity | undefined> {
+    const entity = _key ? this.entityMap.get(_key) : undefined;
 
     return Promise.resolve(entity);
   }

--- a/packages/integration-sdk-runtime/src/storage/memory.ts
+++ b/packages/integration-sdk-runtime/src/storage/memory.ts
@@ -113,8 +113,11 @@ export class InMemoryGraphObjectStore implements GraphObjectStore {
     return Promise.resolve();
   }
 
-  findEntity(_key: string): Promise<Entity | undefined> {
-    return Promise.resolve(this.entityKeyToEntityMap.get(_key)?.entity);
+  findEntity(_key: string | undefined): Promise<Entity | undefined> {
+    const entity = _key
+      ? this.entityKeyToEntityMap.get(_key)?.entity
+      : undefined;
+    return Promise.resolve(entity);
   }
 
   /**


### PR DESCRIPTION
Very often I find myself using the non-null assertion operator on properties I'm passing into the `jobState.findEntity()` method. Using non-null assertion is an antipattern in typescript IMO and this method should _explicitly_ handle the `undefined` case for safety's sake.