### PR TITLE
Allow overriding local integration instance variables

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/instance.ts
+++ b/packages/integration-sdk-runtime/src/execution/instance.ts
@@ -17,15 +17,23 @@ export const LOCAL_INTEGRATION_INSTANCE: IntegrationInstance = {
 export function createIntegrationInstanceForLocalExecution(
   config: IntegrationInvocationConfig,
 ): IntegrationInstance {
-  const accountId =
-    process.env.JUPITERONE_LOCAL_INTEGRATION_INSTANCE_ACCOUNT_ID ||
-    LOCAL_INTEGRATION_INSTANCE.accountId;
-
   return {
-    ...LOCAL_INTEGRATION_INSTANCE,
+    id: process.env.INTEGRATION_INSTANCE_ID || LOCAL_INTEGRATION_INSTANCE.id,
+    name:
+      process.env.INTEGRATION_INSTANCE_NAME || LOCAL_INTEGRATION_INSTANCE.name,
+    integrationDefinitionId:
+      process.env.INTEGRATION_INSTANCE_INTEGRATION_DEFINITION_ID ||
+      LOCAL_INTEGRATION_INSTANCE.integrationDefinitionId,
+    description:
+      process.env.INTEGRATION_INSTANCE_DESCRIPTION ||
+      LOCAL_INTEGRATION_INSTANCE.description,
+
+    accountId:
+      process.env.INTEGRATION_INSTANCE_ACCOUNT_ID ||
+      process.env.JUPITERONE_LOCAL_INTEGRATION_INSTANCE_ACCOUNT_ID ||
+      LOCAL_INTEGRATION_INSTANCE.accountId,
     config: config.instanceConfigFields
       ? loadConfigFromEnvironmentVariables(config.instanceConfigFields)
       : {},
-    accountId,
   };
 }


### PR DESCRIPTION
Some `Account` entities use integration instance variables as properties / `_key`s (in Tenable, [for example](https://github.com/JupiterOne/graph-tenable-cloud/blob/master/src/steps/account/converters.ts#L9)). When converting to the new SDK and running diffing operations, it's important to pass the same instance variables so that a complete diff can be executed.

```diff
 {
-  tenable_account_e1f4b959-9907-48f8-80d3-76919a5eb545: {
-    _type: [
-      "tenable_account"
-    ]
-    _class: [
-      "Account"
-    ]
-    _source: "integration-managed"
-    displayName: "Tenable Nick Test"
-    properties: {
-      name: "Tenable Nick Test"
-      tag.AccountName: "Tenable Nick Test"
-    }
-  }
+  tenable_account_local-integration-instance: {
+    _type: [
+      "tenable_account"
+    ]
+    _class: [
+      "Account"
+    ]
+    _source: "integration-managed"
+    displayName: "Local Integration"
+    properties: {
+      name: "Local Integration"
+      tag.AccountName: "Tenable - New SDK"
+    }
+  }
...
```