### PR TITLE
Add j1-integration diff command for colorized diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
     entity3,
   ]);
   ```
+- Added `j1-integration diff` command to ouptut colorized diffs of old/new
+  integrations.
 
 ### Changed
 

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -36,6 +36,7 @@
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
+    "@types/json-diff": "^0.5.1",
     "@types/lodash": "^4.14.158",
     "@types/pollyjs__adapter-node-http": "^2.0.0",
     "@types/pollyjs__core": "^4.0.0",

--- a/packages/integration-sdk-cli/src/commands/diff.ts
+++ b/packages/integration-sdk-cli/src/commands/diff.ts
@@ -1,0 +1,197 @@
+import { createCommand } from 'commander';
+import fs from 'fs';
+import { diffString } from 'json-diff';
+
+declare module 'json-diff' {
+  /**
+   * The exported types from @types/json-diff exclude an optional fourth parameter, `diffOptions`,
+   * that allows the user to pass the `keysOnly` flag. Sadly, based on testing, it seems that
+   * `keysOnly` does not work under certain circumstances, particularly with diffed arrays.
+   *
+   * Method signature as exported from @types/json-diff:
+   *   function diffString(obj1: unknown, obj2: unknown, colorizeOptions?: ColorizeOptions): string;
+   */
+  function diffString(
+    obj1: unknown,
+    obj2: unknown,
+    colorizeOptions?: { color?: boolean },
+    diffOptions?: { keysOnly?: boolean },
+  ): string;
+}
+
+export function diff() {
+  return createCommand('diff')
+    .storeOptionsAsProperties()
+    .arguments('<oldExportPath> <newExportPath>')
+    .description(
+      'Compare two datasets downloaded from JupiterOne using: \n\n' +
+        '\t find * with _integrationInstanceId="abc-123" that RELATES TO * return tree\n\n',
+    )
+    .option('-k, --keys-only', 'Only diff _key properties.')
+    .action((oldExportPath, newExportPath, options) => {
+      findDifferences(oldExportPath, newExportPath, options.keysOnly);
+      console.log(options.keysOnly);
+    });
+}
+
+interface JupiterOneTreeExport {
+  type: 'tree';
+  data: {
+    vertices: VertexExport[];
+    edges: EdgeExport[];
+  };
+}
+
+type EntityAdditionalProperty =
+  | string
+  | string[]
+  | number
+  | number[]
+  | boolean
+  | boolean[];
+
+interface EntityAdditionalProperties {
+  [k: string]: EntityAdditionalProperty;
+}
+
+interface VertexExport {
+  id: string;
+  entity: {
+    _key: string;
+    _type: string | string[];
+    _class: string | string[];
+    _source: string;
+    displayName: string | undefined;
+  };
+  properties: EntityAdditionalProperties;
+}
+
+type RelationshipAdditionalProperty = string | number | boolean;
+
+interface RelationshipAdditionalProperties {
+  [k: string]: RelationshipAdditionalProperty;
+}
+
+interface EdgeExport {
+  id: string;
+  toVertexId: string;
+  fromVertexId: string;
+  relationship: {
+    _key: string;
+    _type: string | string[];
+    _class: string | string[];
+    _source: string;
+    displayName: string | undefined;
+    _fromEntityKey: string;
+    _toEntityKey: string;
+  };
+  properties: RelationshipAdditionalProperties;
+}
+
+export function findDifferences(
+  oldJsonDataPath: string,
+  newJsonDataPath: string,
+  keysOnly?: boolean,
+) {
+  const oldExport: JupiterOneTreeExport = JSON.parse(
+    fs.readFileSync(oldJsonDataPath, 'utf8'),
+  );
+  const newExport: JupiterOneTreeExport = JSON.parse(
+    fs.readFileSync(newJsonDataPath, 'utf8'),
+  );
+
+  diffVertices(oldExport.data.vertices, newExport.data.vertices, keysOnly);
+  diffEdges(oldExport.data.edges, newExport.data.edges, keysOnly);
+}
+
+interface DiffableEntity {
+  _type: string | string[];
+  _class: string | string[];
+  _source: string;
+  displayName: string | undefined;
+  properties: EntityAdditionalProperties;
+}
+
+interface DiffableEntities {
+  [_key: string]: DiffableEntity;
+}
+
+function diffVertices(
+  oldVertices: VertexExport[],
+  newVertices: VertexExport[],
+  keysOnly?: boolean,
+) {
+  const oldEntities: DiffableEntities = {};
+  for (const vertex of oldVertices) {
+    oldEntities[vertex.entity._key] = {
+      _type: vertex.entity._type,
+      _class: vertex.entity._class,
+      _source: vertex.entity._source,
+      displayName: vertex.entity.displayName,
+      properties: vertex.properties,
+    };
+  }
+
+  const newEntities: DiffableEntities = {};
+  for (const vertex of newVertices) {
+    newEntities[vertex.entity._key] = {
+      _type: vertex.entity._type,
+      _class: vertex.entity._class,
+      _source: vertex.entity._source,
+      displayName: vertex.entity.displayName,
+      properties: vertex.properties,
+    };
+  }
+
+  console.log(diffString(oldEntities, newEntities, undefined, { keysOnly }));
+}
+
+interface DiffableRelationship {
+  _type: string | string[];
+  _class: string | string[];
+  _source: string;
+  displayName: string | undefined;
+  _fromEntityKey: string;
+  _toEntityKey: string;
+  properties: RelationshipAdditionalProperties;
+}
+
+interface DiffableRelationships {
+  [_key: string]: DiffableRelationship;
+}
+
+function diffEdges(
+  oldEdges: EdgeExport[],
+  newEdges: EdgeExport[],
+  keysOnly?: boolean,
+) {
+  const oldRelationships: DiffableRelationships = {};
+  for (const edge of oldEdges) {
+    oldRelationships[edge.relationship._key] = {
+      _type: edge.relationship._type,
+      _class: edge.relationship._class,
+      _source: edge.relationship._source,
+      displayName: edge.relationship.displayName,
+      _fromEntityKey: edge.relationship._fromEntityKey,
+      _toEntityKey: edge.relationship._toEntityKey,
+      properties: edge.properties,
+    };
+  }
+
+  const newRelationships: DiffableRelationships = {};
+  for (const edge of newEdges) {
+    newRelationships[edge.relationship._key] = {
+      _type: edge.relationship._type,
+      _class: edge.relationship._class,
+      _source: edge.relationship._source,
+      displayName: edge.relationship.displayName,
+      _fromEntityKey: edge.relationship._fromEntityKey,
+      _toEntityKey: edge.relationship._toEntityKey,
+      properties: edge.properties,
+    };
+  }
+
+  console.log(
+    diffString(oldRelationships, newRelationships, undefined, { keysOnly }),
+  );
+}

--- a/packages/integration-sdk-cli/src/commands/index.ts
+++ b/packages/integration-sdk-cli/src/commands/index.ts
@@ -1,5 +1,6 @@
 export * from './collect';
 export * from './compare';
+export * from './diff';
 export * from './visualize';
 export * from './sync';
 export * from './run';

--- a/packages/integration-sdk-cli/src/index.ts
+++ b/packages/integration-sdk-cli/src/index.ts
@@ -3,6 +3,7 @@ import { createCommand } from 'commander';
 import {
   collect,
   compare,
+  diff,
   visualize,
   sync,
   run,
@@ -14,6 +15,7 @@ export function createCli() {
   return createCommand()
     .addCommand(collect())
     .addCommand(compare())
+    .addCommand(diff())
     .addCommand(visualize())
     .addCommand(sync())
     .addCommand(run())

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/json-diff@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@types/json-diff/-/json-diff-0.5.1.tgz#fcbff418cef55b324a8598f67bfd4e52949f2164"
+  integrity sha512-/XJ7OPKk+fJCJF93CCA1l2EojXd+dNysFNJN42igT96Xur0tmGQx6U+tm5boDVvgwU7M8ADaWaRuJZx98v2a9g==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"


### PR DESCRIPTION
This builds on top of `j1-integration compare` but uses the exported `diffString()` function from `json-diff`, which gives pretty colorized diffs

```diff

 {
   tenable_user_2232707: {
     properties: {
-      id: 2232707
+      id: "2232707"
     }
   }
   tenable_scan_19: {
     properties: {
-      id: 19
+      id: "19"
     }
   }
   tenable_scan_13: {
     properties: {
-      id: 13
+      id: "13"
     }
   }
   tenable_scan_17: {
     properties: {
-      id: 17
+      id: "17"
     }
   }
   tenable_scan_15: {
     properties: {
-      id: 15
+      id: "15"
     }
   }
...
```