### PR TITLE
Release 6.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to
 
 ## Unreleased
 
+## 6.8.0 - 2021-06-29
+
+### Added
+
+- Added `j1-integration diff` command to ouptut colorized diffs of old/new
+  integrations.
+- Allow overriding integration instance properties when running integrations
+  locally.
+
 ## 6.7.1 - 2021-06-29
 
 ### Fixed
@@ -33,8 +42,6 @@ and this project adheres to
     entity3,
   ]);
   ```
-- Added `j1-integration diff` command to ouptut colorized diffs of old/new
-  integrations.
 
 ### Changed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.7.1",
-    "@jupiterone/integration-sdk-runtime": "^6.7.1",
+    "@jupiterone/integration-sdk-core": "^6.8.0",
+    "@jupiterone/integration-sdk-runtime": "^6.8.0",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^6.7.1",
+    "@jupiterone/integration-sdk-runtime": "^6.8.0",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "json-diff": "^0.5.4",
@@ -32,7 +32,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.7.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.8.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^6.7.1",
-    "@jupiterone/integration-sdk-testing": "^6.7.1",
+    "@jupiterone/integration-sdk-cli": "^6.8.0",
+    "@jupiterone/integration-sdk-testing": "^6.8.0",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.7.1",
+    "@jupiterone/integration-sdk-core": "^6.8.0",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.7.1",
+    "@jupiterone/integration-sdk-core": "^6.8.0",
     "@lifeomic/alpha": "^1.4.0",
     "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.7.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.8.0",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.7.1",
-    "@jupiterone/integration-sdk-runtime": "^6.7.1",
+    "@jupiterone/integration-sdk-core": "^6.8.0",
+    "@jupiterone/integration-sdk-runtime": "^6.8.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.7.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.8.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
```
## 6.8.0 - 2021-06-29

### Added

- Added `j1-integration diff` command to ouptut colorized diffs of old/new
  integrations.
- Allow overriding integration instance properties when running integrations
  locally.
```