### PR TITLE
INT-1202 - Allow the specification of multiple dependency graphs

### DIFF
--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -33,6 +33,15 @@ export interface InvocationConfig<
   integrationSteps: Step<TStepExecutionContext>[];
   normalizeGraphObjectKey?: KeyNormalizationFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
+  /**
+   * An optional array of identifiers used to execute dependency
+   * graphs in a specific order. These values should match the
+   * StepMetadata `dependencyGraphId` prpoperties.
+   * 
+   * If this is not provided, all steps will be evalueted in
+   * the same dependency graph.
+   */
+  dependencyGraphOrder?: string[];
 }
 
 export interface IntegrationInvocationConfig<

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -151,4 +151,20 @@ export type StepMetadata = StepGraphObjectMetadataProperties & {
    * before the current step can.
    */
   dependsOn?: string[];
+
+  /**
+   * An optional array of identifiers used to execute dependency
+   * graphs in a specific order. These values should match the
+   * IntegrationInvocationConfig `dependencyGraphOrder`
+   * prpoperty.
+   * 
+   * Steps that do not have a `dependencyGraphId` will be added to
+   * the default dependency graph which is executed first.
+   * 
+   * NOTE: If your step `dependsOn` a step that is not in the same
+   * dependencyGraphId, you will get a `Node does not exist` error.
+   * These dependencies will need to be accounted for by the
+   * the `dependencyGraphOrder` in the IntegrationInvocationConfig
+   */
+  dependencyGraphId?: string;
 };

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -224,6 +224,7 @@ export async function executeWithContext<
       graphObjectStore,
       createStepGraphObjectDataUploader,
       beforeAddEntity: config.beforeAddEntity,
+      dependencyGraphOrder: config.dependencyGraphOrder
     });
 
     const partialDatasets = determinePartialDatasetsFromStepExecutionResults(

--- a/packages/integration-sdk-runtime/src/execution/utils/seperateStepsByDependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/seperateStepsByDependencyGraph.ts
@@ -1,0 +1,16 @@
+import { Step } from "@jupiterone/integration-sdk-core";
+
+export const DEFAULT_DEPENDENCY_GRAPH_IDENTIFIER = '__defaultDependencyGraph';
+
+export function seperateStepsByDependencyGraph<T extends Step<any>[]>(
+  integrationSteps: T,
+): { [k: string]: T } {
+  return integrationSteps.reduce((stepsByGraphId, step) => {
+    const graphId =
+      step.dependencyGraphId ?? DEFAULT_DEPENDENCY_GRAPH_IDENTIFIER;
+    stepsByGraphId[graphId]?.push
+      ? stepsByGraphId[graphId].push(step)
+      : (stepsByGraphId[graphId] = [step]);
+    return stepsByGraphId;
+  }, {});
+}


### PR DESCRIPTION
This change adds the ability to, in the integrationConfig, specify multiple dependency graphs that each step can be assigned to. These graphs will then be executed in the order specified.

This maintains backwards compatibility with existing integrations while allowing us to specify an integration step as needing to be last for the google-cloud role binding steps.

NOTE: I didn't need to change anything for local execution because of one side-effect of this change. If your step definition `dependsOn` a step that is no longer in your dependency graph, you will get a "Node does not exist" error. I thought this was a good way to handle this case so I left it as is, but if we want that to change and instead log a warning, then I would add back my changes to `prepareLocalStepCollection` that I removed after noticing they didn't do anything because of this behavior 🙃 