### PR TITLE
Release 6.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to
 
 ## Unreleased
 
+## 6.11.0 - 20201-07-14
+
+### Added
+
+- a `dependencyGraphOrder` property to the InvocationConfig and a
+  `dependencyGraphId` property to the StepMetadata which togeather can be used
+  to create multiple ordered dependency graphs per execution.
+
 ## 6.10.0 - 2021-07-09
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0",
-    "@jupiterone/integration-sdk-runtime": "^6.10.0",
+    "@jupiterone/integration-sdk-core": "^6.11.0",
+    "@jupiterone/integration-sdk-runtime": "^6.11.0",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^6.10.0",
+    "@jupiterone/integration-sdk-runtime": "^6.11.0",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "json-diff": "^0.5.4",
@@ -32,7 +32,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.10.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.11.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -33,6 +33,15 @@ export interface InvocationConfig<
   integrationSteps: Step<TStepExecutionContext>[];
   normalizeGraphObjectKey?: KeyNormalizationFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
+  /**
+   * An optional array of identifiers used to execute dependency
+   * graphs in a specific order. These values should match the
+   * StepMetadata `dependencyGraphId` prpoperties.
+   * 
+   * If this is not provided, all steps will be evalueted in
+   * the same dependency graph.
+   */
+  dependencyGraphOrder?: string[];
 }
 
 export interface IntegrationInvocationConfig<

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -151,4 +151,20 @@ export type StepMetadata = StepGraphObjectMetadataProperties & {
    * before the current step can.
    */
   dependsOn?: string[];
+
+  /**
+   * An optional array of identifiers used to execute dependency
+   * graphs in a specific order. These values should match the
+   * IntegrationInvocationConfig `dependencyGraphOrder`
+   * prpoperty.
+   * 
+   * Steps that do not have a `dependencyGraphId` will be added to
+   * the default dependency graph which is executed first.
+   * 
+   * NOTE: If your step `dependsOn` a step that is not in the same
+   * dependencyGraphId, you will get a `Node does not exist` error.
+   * These dependencies will need to be accounted for by the
+   * the `dependencyGraphOrder` in the IntegrationInvocationConfig
+   */
+  dependencyGraphId?: string;
 };

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^6.10.0",
-    "@jupiterone/integration-sdk-testing": "^6.10.0",
+    "@jupiterone/integration-sdk-cli": "^6.11.0",
+    "@jupiterone/integration-sdk-testing": "^6.11.0",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0",
+    "@jupiterone/integration-sdk-core": "^6.11.0",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0",
+    "@jupiterone/integration-sdk-core": "^6.11.0",
     "@lifeomic/alpha": "^1.4.0",
     "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.10.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.11.0",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -224,6 +224,7 @@ export async function executeWithContext<
       graphObjectStore,
       createStepGraphObjectDataUploader,
       beforeAddEntity: config.beforeAddEntity,
+      dependencyGraphOrder: config.dependencyGraphOrder
     });
 
     const partialDatasets = determinePartialDatasetsFromStepExecutionResults(

--- a/packages/integration-sdk-runtime/src/execution/utils/seperateStepsByDependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/utils/seperateStepsByDependencyGraph.ts
@@ -1,0 +1,16 @@
+import { Step } from "@jupiterone/integration-sdk-core";
+
+export const DEFAULT_DEPENDENCY_GRAPH_IDENTIFIER = '__defaultDependencyGraph';
+
+export function seperateStepsByDependencyGraph<T extends Step<any>[]>(
+  integrationSteps: T,
+): { [k: string]: T } {
+  return integrationSteps.reduce((stepsByGraphId, step) => {
+    const graphId =
+      step.dependencyGraphId ?? DEFAULT_DEPENDENCY_GRAPH_IDENTIFIER;
+    stepsByGraphId[graphId]?.push
+      ? stepsByGraphId[graphId].push(step)
+      : (stepsByGraphId[graphId] = [step]);
+    return stepsByGraphId;
+  }, {});
+}

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0",
-    "@jupiterone/integration-sdk-runtime": "^6.10.0",
+    "@jupiterone/integration-sdk-core": "^6.11.0",
+    "@jupiterone/integration-sdk-runtime": "^6.11.0",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.10.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.11.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
This change adds the ability to, in the integrationConfig, specify multiple dependency graphs that each step can be assigned to. These graphs will then be executed in the order specified.

This maintains backwards compatibility with existing integrations while allowing us to specify an integration step as needing to be last for the google-cloud role binding steps.

NOTE: I didn't need to change anything for local execution because of one side-effect of this change. If your step definition `dependsOn` a step that is no longer in your dependency graph, you will get a "Node does not exist" error. I thought this was a good way to handle this case so I left it as is, but if we want that to change and instead log a warning, then I would add back my changes to `prepareLocalStepCollection` that I removed after noticing they didn't do anything because of this behavior 🙃 