### PR TITLE
Use J1 colors in j1-integration visualize-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Used default J1 colors for `yarn j1-integration visualize-types` command
+
 ## 6.11.0 - 20201-07-14
 
 ### Added

--- a/packages/integration-sdk-cli/src/__tests__/cli/__snapshots__/visualize-types.test.ts.snap
+++ b/packages/integration-sdk-cli/src/__tests__/cli/__snapshots__/visualize-types.test.ts.snap
@@ -20,7 +20,7 @@ exports[`visualize integration metadata creates graph based on integration data 
           nodes: nodes,
           edges: edges
         };
-        var options = {\\"edges\\":{\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}},\\"physics\\":{\\"barnesHut\\":{\\"springLength\\":300,\\"centralGravity\\":0.03}}};
+        var options = {\\"edges\\":{\\"color\\":\\"#6647ff\\",\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}},\\"nodes\\":{\\"color\\":{\\"border\\":\\"#6647ff\\",\\"background\\":\\"#3ce3b5\\"}},\\"physics\\":{\\"barnesHut\\":{\\"springLength\\":300,\\"centralGravity\\":0.03}}};
         var network = new vis.Network(container, data, options);
       </script>
     </body>
@@ -47,7 +47,7 @@ exports[`visualize integration metadata creates graph filtered by --type flag 1`
           nodes: nodes,
           edges: edges
         };
-        var options = {\\"edges\\":{\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}},\\"physics\\":{\\"barnesHut\\":{\\"springLength\\":300,\\"centralGravity\\":0.03}}};
+        var options = {\\"edges\\":{\\"color\\":\\"#6647ff\\",\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}},\\"nodes\\":{\\"color\\":{\\"border\\":\\"#6647ff\\",\\"background\\":\\"#3ce3b5\\"}},\\"physics\\":{\\"barnesHut\\":{\\"springLength\\":300,\\"centralGravity\\":0.03}}};
         var network = new vis.Network(container, data, options);
       </script>
     </body>

--- a/packages/integration-sdk-cli/src/commands/visualize-types.ts
+++ b/packages/integration-sdk-cli/src/commands/visualize-types.ts
@@ -11,7 +11,12 @@ import {
   TypesCommandArgs,
 } from '../utils/getSortedJupiterOneTypes';
 import { generateVisHTML } from '../utils/generateVisHTML';
-import { Node, Edge } from 'vis';
+import { Node, Edge, Options } from 'vis';
+
+const COLORS = {
+  J1_PRIMARY_GREEN: '#3ce3b5',
+  J1_PRIMARY_PURPLE: '#6647ff',
+};
 
 interface VisualizeTypesCommandArgs extends TypesCommandArgs {
   outputFile: string;
@@ -74,8 +79,19 @@ async function executeVisualizeTypesAction(
     types,
     edges,
   });
+  const networkVisualizationOptions: Options = {
+    edges: {
+      color: COLORS.J1_PRIMARY_PURPLE,
+    },
+    nodes: {
+      color: {
+        border: COLORS.J1_PRIMARY_PURPLE,
+        background: COLORS.J1_PRIMARY_GREEN,
+      },
+    },
+  };
 
-  const visHtml = generateVisHTML(nodes, edges);
+  const visHtml = generateVisHTML(nodes, edges, networkVisualizationOptions);
 
   await fs.mkdir(path.dirname(graphFilePath), { recursive: true });
   await fs.writeFile(graphFilePath, visHtml, 'utf-8');

--- a/packages/integration-sdk-cli/src/utils/generateVisHTML.ts
+++ b/packages/integration-sdk-cli/src/utils/generateVisHTML.ts
@@ -1,6 +1,12 @@
+import { defaultsDeep } from 'lodash';
 import { Node, Edge, Options } from 'vis';
 
 export const nothingToDisplayMessage = 'There was no data found to visualize.';
+
+const defaultOptions: Options = {
+  edges: { arrows: { to: { enabled: true } } },
+  physics: { barnesHut: { springLength: 300, centralGravity: 0.03 } },
+};
 
 /**
  * Creates the html to display the vis graph
@@ -8,8 +14,9 @@ export const nothingToDisplayMessage = 'There was no data found to visualize.';
 export function generateVisHTML(
   nodeDataSets: Node[],
   edgeDataSets: Edge[],
-  options: Options = { edges: { arrows: { to: { enabled: true } } }, physics: { barnesHut: { springLength: 300, centralGravity: 0.03 } } },
+  options?: Options,
 ) {
+  options = defaultsDeep(options, defaultOptions);
   const displayVisualization =
     nodeDataSets.length > 0 || edgeDataSets.length > 0;
 

--- a/packages/integration-sdk-cli/src/visualization/__tests__/__snapshots__/generateVisHTML.test.ts.snap
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/__snapshots__/generateVisHTML.test.ts.snap
@@ -20,7 +20,7 @@ exports[`renders custom config when passed in 1`] = `
           nodes: nodes,
           edges: edges
         };
-        var options = {};
+        var options = {\\"edges\\":{\\"color\\":\\"#ffffff\\",\\"arrows\\":{\\"to\\":{\\"enabled\\":true}}},\\"physics\\":{\\"barnesHut\\":{\\"springLength\\":300,\\"centralGravity\\":0.03}}};
         var network = new vis.Network(container, data, options);
       </script>
     </body>

--- a/packages/integration-sdk-cli/src/visualization/__tests__/generateVisHTML.test.ts
+++ b/packages/integration-sdk-cli/src/visualization/__tests__/generateVisHTML.test.ts
@@ -1,4 +1,7 @@
-import { generateVisHTML, nothingToDisplayMessage } from '../../utils/generateVisHTML';
+import {
+  generateVisHTML,
+  nothingToDisplayMessage,
+} from '../../utils/generateVisHTML';
 import { Node, Edge } from 'vis';
 
 const nodeDataSets: Node[] = [
@@ -23,9 +26,11 @@ test('renders html with default config', () => {
 });
 
 test('renders custom config when passed in', () => {
-  const html = generateVisHTML(nodeDataSets, edgeDataSet, {});
+  const html = generateVisHTML(nodeDataSets, edgeDataSet, {
+    edges: { color: '#ffffff' },
+  });
 
-  expect(html).toContain('var options = {}');
+  expect(html).toContain('"color":"#ffffff"');
   expect(html).toMatchSnapshot();
 });
 


### PR DESCRIPTION
While working on a blog post, I noticed that the output of `j1-integration visualize-types` provides good content, but I didn't think screenshots would not look great in J1 marketing content because of the color scheme. Updated to use J1 primary colors.

<h2>Before</h2>
<img width="792" alt="Screen Shot 2021-07-16 at 10 09 39 AM" src="https://user-images.githubusercontent.com/15333061/125961158-04f05f96-af60-448d-a666-af82a72374a8.png">

<h2>After</h2>
<img width="792" alt="Screen Shot 2021-07-16 at 10 09 49 AM" src="https://user-images.githubusercontent.com/15333061/125961177-ef19d565-d351-4e4b-8fd6-fe42f6b72d86.png">
