### PR TITLE
share data store between all graphs in an integration run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to
 
 ### Changed
 
-- Used default J1 colors for `yarn j1-integration visualize-types` command
+- A single DataStore is now used for all dependency graphs executed in an
+  integration run.
+- Used default J1 colors for `yarn j1-integration visualize-types` command.
 
 ## 6.11.0 - 20201-07-14
 

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -29,7 +29,7 @@ import {
   executeStepDependencyGraph,
 } from '../dependencyGraph';
 import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
-import { DuplicateKeyTracker } from '../jobState';
+import { DuplicateKeyTracker, MemoryDataStore } from '../jobState';
 import { getDefaultStepStartStates } from '../step';
 import {
   CreateStepGraphObjectDataUploaderFunction,
@@ -148,6 +148,7 @@ describe('executeStepDependencyGraph', () => {
       stepStartStates,
       duplicateKeyTracker: new DuplicateKeyTracker(),
       graphObjectStore,
+      dataStore: new MemoryDataStore(),
       createStepGraphObjectDataUploader,
     });
   }

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -76,6 +76,7 @@ export function executeStepDependencyGraph<
   stepStartStates,
   duplicateKeyTracker,
   graphObjectStore,
+  dataStore,
   createStepGraphObjectDataUploader,
   beforeAddEntity,
 }: {
@@ -84,6 +85,7 @@ export function executeStepDependencyGraph<
   stepStartStates: StepStartStates;
   duplicateKeyTracker: DuplicateKeyTracker;
   graphObjectStore: GraphObjectStore;
+  dataStore: MemoryDataStore;
   createStepGraphObjectDataUploader?: CreateStepGraphObjectDataUploaderFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
 }): Promise<IntegrationStepResult[]> {
@@ -99,7 +101,6 @@ export function executeStepDependencyGraph<
   const promiseQueue = new PromiseQueue();
 
   const stepResultsMap = buildStepResultsMap(inputGraph, stepStartStates);
-  const dataStore = new MemoryDataStore();
 
   function isStepEnabled(stepId: string) {
     return stepStartStates[stepId].disabled === false;

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -27,7 +27,7 @@ import {
 import { timeOperation } from '../metrics';
 import { FileSystemGraphObjectStore, GraphObjectStore } from '../storage';
 import { createIntegrationInstanceForLocalExecution } from './instance';
-import { DuplicateKeyTracker } from './jobState';
+import { DuplicateKeyTracker, MemoryDataStore } from './jobState';
 import {
   determinePartialDatasetsFromStepExecutionResults,
   executeSteps,
@@ -222,6 +222,7 @@ export async function executeWithContext<
         config.normalizeGraphObjectKey,
       ),
       graphObjectStore,
+      dataStore: new MemoryDataStore(),
       createStepGraphObjectDataUploader,
       beforeAddEntity: config.beforeAddEntity,
       dependencyGraphOrder: config.dependencyGraphOrder

--- a/packages/integration-sdk-runtime/src/execution/step.ts
+++ b/packages/integration-sdk-runtime/src/execution/step.ts
@@ -18,7 +18,7 @@ import {
   buildStepDependencyGraph,
   executeStepDependencyGraph,
 } from './dependencyGraph';
-import { DuplicateKeyTracker } from './jobState';
+import { DuplicateKeyTracker, MemoryDataStore } from './jobState';
 import { CreateStepGraphObjectDataUploaderFunction } from './uploader';
 import {
   DEFAULT_DEPENDENCY_GRAPH_IDENTIFIER,
@@ -34,6 +34,7 @@ export async function executeSteps<
   stepStartStates,
   duplicateKeyTracker,
   graphObjectStore,
+  dataStore,
   createStepGraphObjectDataUploader,
   beforeAddEntity,
   dependencyGraphOrder,
@@ -43,6 +44,7 @@ export async function executeSteps<
   stepStartStates: StepStartStates;
   duplicateKeyTracker: DuplicateKeyTracker;
   graphObjectStore: GraphObjectStore;
+  dataStore: MemoryDataStore;
   createStepGraphObjectDataUploader?: CreateStepGraphObjectDataUploaderFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
   dependencyGraphOrder?: string[];
@@ -72,6 +74,7 @@ export async function executeSteps<
         stepStartStates: pick(stepStartStates, stepIds),
         duplicateKeyTracker,
         graphObjectStore,
+        dataStore,
         createStepGraphObjectDataUploader,
         beforeAddEntity,
       }),


### PR DESCRIPTION
Right now data stored using the `setData` command is not shared between dependency graphs which is a real bummer for the graph-google-cloud project. This fixes that.

I pulled out the DataStore to where all the other shared stores are initialized.