### PR TITLE
INT-1287 - Track summary of collected graph object `_type`'s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@ and this project adheres to
 
 ## Unreleased
 
-## 6.12.0 - 20201-07-27
+### Added
+
+- Track summary of collected graph object `_type`'s and the number of times that
+  each `_type` has been encountered
+
+## 6.12.0 - 2021-07-27
+
+### Changed
 
 - Bump `@jupiterone/data-model` to expose `Problem` entity schema.
 
-## 6.11.1 - 20201-07-23
+## 6.11.1 - 2021-07-23
 
 ### Changed
 
@@ -21,7 +28,7 @@ and this project adheres to
   integration run.
 - Used default J1 colors for `yarn j1-integration visualize-types` command.
 
-## 6.11.0 - 20201-07-14
+## 6.11.0 - 2021-07-14
 
 ### Added
 

--- a/packages/integration-sdk-runtime/src/execution/collection.ts
+++ b/packages/integration-sdk-runtime/src/execution/collection.ts
@@ -1,0 +1,19 @@
+export type GraphObjectTypeSummary = {
+  total: number;
+};
+
+export class IntegrationExecutionSummarizer {
+  readonly graphObjectTypeSummary = new Map<string, GraphObjectTypeSummary>();
+
+  incrGraphObjectType(_type: string, count: number) {
+    const existingSummary = this.graphObjectTypeSummary.get(_type);
+
+    if (existingSummary) {
+      existingSummary.total += count;
+    } else {
+      this.graphObjectTypeSummary.set(_type, {
+        total: count,
+      });
+    }
+  }
+}

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -9,6 +9,7 @@ import {
   MemoryDataStore,
   TypeTracker,
 } from '@jupiterone/integration-sdk-runtime';
+import { v4 as uuid } from 'uuid';
 
 export interface CreateMockJobStateOptions {
   entities?: Entity[];
@@ -47,20 +48,32 @@ export function createMockJobState({
   const duplicateKeyTracker = new DuplicateKeyTracker(normalizeGraphObjectKey);
   const typeTracker = new TypeTracker();
   const dataStore = new MemoryDataStore();
+  const mockStepId = `mock-step-${uuid()}`;
 
   inputEntities.forEach((e) => {
     duplicateKeyTracker.registerKey(e._key, {
       _type: e._type,
       _key: e._key,
     });
-    typeTracker.registerType(e._type);
+
+    typeTracker.addStepGraphObjectType({
+      stepId: mockStepId,
+      _type: e._type,
+      count: 1,
+    });
   });
+
   inputRelationships.forEach((r) => {
     duplicateKeyTracker.registerKey(r._key as string, {
       _type: r._type,
       _key: r._key,
     });
-    typeTracker.registerType(r._type as string);
+
+    typeTracker.addStepGraphObjectType({
+      stepId: mockStepId,
+      _type: r._type,
+      count: 1,
+    });
   });
 
   Object.keys(inputData).forEach((key) => dataStore.set(key, inputData[key]));
@@ -71,8 +84,14 @@ export function createMockJobState({
         _type: e._type,
         _key: e._key,
       });
-      typeTracker.registerType(e._type);
+
+      typeTracker.addStepGraphObjectType({
+        stepId: mockStepId,
+        _type: e._type,
+        count: 1,
+      });
     });
+
     collectedEntities = collectedEntities.concat(newEntities);
     return Promise.resolve(newEntities);
   };
@@ -83,8 +102,14 @@ export function createMockJobState({
         _type: r._type,
         _key: r._key,
       });
-      typeTracker.registerType(r._type as string);
+
+      typeTracker.addStepGraphObjectType({
+        stepId: mockStepId,
+        _type: r._type,
+        count: 1,
+      });
     });
+
     collectedRelationships = collectedRelationships.concat(newRelationships);
     return Promise.resolve();
   };
@@ -111,7 +136,7 @@ export function createMockJobState({
     },
 
     get encounteredTypes() {
-      return typeTracker.getEncounteredTypes();
+      return typeTracker.getAllEncounteredTypes();
     },
 
     setData: async <T>(key: string, data: T): Promise<void> => {


### PR DESCRIPTION
- Tracked `_type`'s by step ID
- Log summary after each step in success or failure cases

Example:

```
17:33:55.586Z  INFO Local: Step summary (stepId=fetch-binary-authorization-policy)
  summary: {"graphObjectTypeSummary":[{"_type":"google_binary_authorization_policy","total":1},{"_type":"google_cloud_project_has_binary_authorization_policy","total":1}]}
```