### PR TITLE
Trim properties from placeholder entities created from j1-integration visualize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Changed how `j1-integration visualize` displays placeholder entities. Now only
+  properties present in `targetFilterKeys` are displayed in the graph, making
+  target entities smaller.
+
 ## 6.13.0 - 2021-07-28
 
 ### Added

--- a/packages/integration-sdk-cli/src/visualization/createMappedRelationshipNodesAndEdges.ts
+++ b/packages/integration-sdk-cli/src/visualization/createMappedRelationshipNodesAndEdges.ts
@@ -96,7 +96,14 @@ function findOrCreatePlaceholderEntity(
 ): NodeEntity | NewPlaceholderEntity {
   const targetEntity = findTargetEntity(nodeEntities, _mapping);
   if (targetEntity === undefined) {
-    return _mapping.targetEntity;
+    const newPlaceholderEntity = {};
+    for (const filterKey of _mapping.targetFilterKeys) {
+      const keys = Array.isArray(filterKey) ? filterKey : [filterKey];
+      for (const key of keys) {
+        newPlaceholderEntity[key] = _mapping.targetEntity[key];
+      }
+    }
+    return newPlaceholderEntity;
   } else {
     return targetEntity;
   }


### PR DESCRIPTION
Previously, the "placeholder entities" generated from j1-integration visualize included all of the properties in `targetEntity`, but in reality, target entities are unique only in their `targetFilterKeys`. 

Previous: 
<img width="845" alt="Screen Shot 2021-08-02 at 4 34 32 PM" src="https://user-images.githubusercontent.com/15333061/127921020-096833b8-0008-4aba-b6c1-ea36af6ea0e1.png">

Now: 
<img width="845" alt="Screen Shot 2021-08-02 at 4 29 22 PM" src="https://user-images.githubusercontent.com/15333061/127921047-4bd04262-4e67-4837-9996-e571bbce105a.png">
