### PR TITLE
Add mapped relationship metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added optional `mappedRelationships` to step metadata
+
 ## 6.14.0 - 2021-08-04
 
 ### Changed

--- a/packages/integration-sdk-cli/src/commands/visualize-types.test.ts
+++ b/packages/integration-sdk-cli/src/commands/visualize-types.test.ts
@@ -1,11 +1,16 @@
 import {
   RelationshipClass,
+  RelationshipDirection,
   StepGraphObjectMetadataProperties,
 } from '@jupiterone/integration-sdk-core';
-import { getNodesAndEdgesFromStepMetadata } from './visualize-types';
+import {
+  getNodesAndEdgesFromStepMetadata,
+  MAPPED_RELATIONSHIP_OPTIONS,
+  PLACEHOLDER_ENTITY_OPTIONS,
+} from './visualize-types';
 
 describe('getNodesAndEdgesFromStepMetadata', () => {
-  test('should create node from step metadata', () => {
+  test('should create node from entity metadata', () => {
     const metadata: StepGraphObjectMetadataProperties = {
       entities: [
         {
@@ -28,7 +33,7 @@ describe('getNodesAndEdgesFromStepMetadata', () => {
     });
   });
 
-  test('should create edge from step metadata', () => {
+  test('should create edge from relationship metadata', () => {
     const metadata: StepGraphObjectMetadataProperties = {
       entities: [
         {
@@ -47,7 +52,7 @@ describe('getNodesAndEdgesFromStepMetadata', () => {
       ],
     };
 
-    expect(getNodesAndEdgesFromStepMetadata(metadata)).toMatchObject({
+    expect(getNodesAndEdgesFromStepMetadata(metadata)).toEqual({
       nodes: [
         {
           id: 'user_group',
@@ -59,6 +64,155 @@ describe('getNodesAndEdgesFromStepMetadata', () => {
           from: 'user_group',
           label: 'CONTAINS',
           to: 'user_group',
+        },
+      ],
+    });
+  });
+
+  test('should create mapped edge and placeholder node from mapped relationship metadata', () => {
+    const metadata: StepGraphObjectMetadataProperties = {
+      entities: [
+        {
+          resourceName: 'User Group',
+          _type: 'user_group',
+          _class: 'UserGroup',
+        },
+      ],
+      relationships: [],
+      mappedRelationships: [
+        {
+          _type: 'user_group_contains_google_user',
+          sourceType: 'user_group',
+          _class: RelationshipClass.CONTAINS,
+          targetType: 'google_user',
+          direction: RelationshipDirection.FORWARD,
+        },
+      ],
+    };
+
+    expect(getNodesAndEdgesFromStepMetadata(metadata)).toEqual({
+      nodes: [
+        {
+          id: 'user_group',
+          label: expect.any(String),
+        },
+        {
+          id: 'google_user',
+          label: expect.any(String),
+          ...PLACEHOLDER_ENTITY_OPTIONS,
+        },
+      ],
+      edges: [
+        {
+          from: 'user_group',
+          label: 'CONTAINS',
+          to: 'google_user',
+          ...MAPPED_RELATIONSHIP_OPTIONS,
+        },
+      ],
+    });
+  });
+
+  test('should create mapped edge and NO node from mapped relationship metadata when targetType already exists', () => {
+    const metadata: StepGraphObjectMetadataProperties = {
+      entities: [
+        {
+          resourceName: 'User Group',
+          _type: 'user_group',
+          _class: 'UserGroup',
+        },
+      ],
+      relationships: [],
+      mappedRelationships: [
+        {
+          _type: 'user_group_contains_user_group',
+          sourceType: 'user_group',
+          _class: RelationshipClass.CONTAINS,
+          targetType: 'user_group',
+          direction: RelationshipDirection.FORWARD,
+        },
+      ],
+    };
+
+    expect(getNodesAndEdgesFromStepMetadata(metadata)).toEqual({
+      nodes: [
+        {
+          id: 'user_group',
+          label: expect.any(String),
+        },
+      ],
+      edges: [
+        {
+          from: 'user_group',
+          label: 'CONTAINS',
+          to: 'user_group',
+          ...MAPPED_RELATIONSHIP_OPTIONS,
+        },
+      ],
+    });
+  });
+
+  test('should create just one placeholder node when multiple mapped relationships target same type', () => {
+    const metadata: StepGraphObjectMetadataProperties = {
+      entities: [
+        {
+          resourceName: 'User Group',
+          _type: 'user_group',
+          _class: 'UserGroup',
+        },
+        {
+          resourceName: 'User',
+          _type: 'user',
+          _class: 'User',
+        },
+      ],
+      relationships: [],
+      mappedRelationships: [
+        {
+          _type: 'user_group_contains_google_user',
+          sourceType: 'user_group',
+          _class: RelationshipClass.CONTAINS,
+          targetType: 'google_user',
+          direction: RelationshipDirection.FORWARD,
+        },
+        {
+          _type: 'user_is_google_user',
+          sourceType: 'user',
+          _class: RelationshipClass.IS,
+          targetType: 'google_user',
+          direction: RelationshipDirection.FORWARD,
+        },
+      ],
+    };
+
+    expect(getNodesAndEdgesFromStepMetadata(metadata)).toEqual({
+      nodes: [
+        {
+          id: 'user_group',
+          label: expect.any(String),
+        },
+        {
+          id: 'user',
+          label: expect.any(String),
+        },
+        {
+          id: 'google_user',
+          label: expect.any(String),
+          ...PLACEHOLDER_ENTITY_OPTIONS,
+        },
+      ],
+      edges: [
+        {
+          from: 'user_group',
+          label: 'CONTAINS',
+          to: 'google_user',
+          ...MAPPED_RELATIONSHIP_OPTIONS,
+        },
+        {
+          from: 'user',
+          label: 'IS',
+          to: 'google_user',
+          ...MAPPED_RELATIONSHIP_OPTIONS,
         },
       ],
     });

--- a/packages/integration-sdk-cli/src/commands/visualize-types.test.ts
+++ b/packages/integration-sdk-cli/src/commands/visualize-types.test.ts
@@ -1,0 +1,66 @@
+import {
+  RelationshipClass,
+  StepGraphObjectMetadataProperties,
+} from '@jupiterone/integration-sdk-core';
+import { getNodesAndEdgesFromStepMetadata } from './visualize-types';
+
+describe('getNodesAndEdgesFromStepMetadata', () => {
+  test('should create node from step metadata', () => {
+    const metadata: StepGraphObjectMetadataProperties = {
+      entities: [
+        {
+          resourceName: 'User Group',
+          _type: 'user_group',
+          _class: 'UserGroup',
+        },
+      ],
+      relationships: [],
+    };
+
+    expect(getNodesAndEdgesFromStepMetadata(metadata)).toMatchObject({
+      nodes: [
+        {
+          id: 'user_group',
+          label: expect.any(String),
+        },
+      ],
+      edges: [],
+    });
+  });
+
+  test('should create edge from step metadata', () => {
+    const metadata: StepGraphObjectMetadataProperties = {
+      entities: [
+        {
+          resourceName: 'User Group',
+          _type: 'user_group',
+          _class: 'UserGroup',
+        },
+      ],
+      relationships: [
+        {
+          _type: 'user_group_contains_group',
+          sourceType: 'user_group',
+          _class: RelationshipClass.CONTAINS,
+          targetType: 'user_group',
+        },
+      ],
+    };
+
+    expect(getNodesAndEdgesFromStepMetadata(metadata)).toMatchObject({
+      nodes: [
+        {
+          id: 'user_group',
+          label: expect.any(String),
+        },
+      ],
+      edges: [
+        {
+          from: 'user_group',
+          label: 'CONTAINS',
+          to: 'user_group',
+        },
+      ],
+    });
+  });
+});

--- a/packages/integration-sdk-cli/src/commands/visualize-types.ts
+++ b/packages/integration-sdk-cli/src/commands/visualize-types.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { createCommand } from 'commander';
 import {
   StepEntityMetadata,
+  StepGraphObjectMetadataProperties,
   StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 import { promises as fs } from 'fs';
@@ -43,7 +44,7 @@ export function visualizeTypes() {
     )
     .option(
       '-t, --type <string>',
-      'J1 type(s) to visualize, comma separated if multiple.',
+      'J1 entity type(s) to visualize, comma separated if multiple.',
       collector,
       [],
     )
@@ -104,6 +105,22 @@ function getDefaultTypesGraphFilePath(projectSourceDirectory: string): string {
     projectSourceDirectory,
     '.j1-integration/types-graph/index.html',
   );
+}
+
+export function getNodesAndEdgesFromStepMetadata(
+  metadata: StepGraphObjectMetadataProperties,
+  options?: {
+    types?: string[];
+  },
+): { nodes: Node[]; edges: Edge[] } {
+  const edges = getEdgesFromStepRelationshipMetadata(metadata.relationships, {
+    types: options?.types,
+  });
+  const nodes = getNodesFromStepEntityMetadata(metadata.entities, {
+    types: options?.types,
+    edges,
+  });
+  return { nodes, edges };
 }
 
 function getNodesFromStepEntityMetadata(

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -6,6 +6,7 @@ import {
   StepExecutionContext,
 } from './context';
 import { IntegrationInstanceConfig } from './instance';
+import { RelationshipDirection } from './relationship';
 
 export interface StepStartState {
   /**
@@ -120,6 +121,14 @@ export interface StepRelationshipMetadata extends StepGraphObjectMetadata {
   targetType: string;
 }
 
+export interface StepMappedRelationshipMetadata
+  extends StepGraphObjectMetadata {
+  sourceType: string;
+  _class: RelationshipClass;
+  targetType: string;
+  direction: RelationshipDirection;
+}
+
 export interface StepGraphObjectMetadataProperties {
   /**
    * Metadata about the entities ingested in this integration step. This is
@@ -132,6 +141,12 @@ export interface StepGraphObjectMetadataProperties {
    * used to generate documentation.
    */
   relationships: StepRelationshipMetadata[];
+
+  /**
+   * Metadata about any mapped relationships ingested in this integration step. This is
+   * used to generate documentation.
+   */
+  mappedRelationships?: StepMappedRelationshipMetadata[];
 }
 
 export type StepMetadata = StepGraphObjectMetadataProperties & {
@@ -157,10 +172,10 @@ export type StepMetadata = StepGraphObjectMetadataProperties & {
    * graphs in a specific order. These values should match the
    * IntegrationInvocationConfig `dependencyGraphOrder`
    * prpoperty.
-   * 
+   *
    * Steps that do not have a `dependencyGraphId` will be added to
    * the default dependency graph which is executed first.
-   * 
+   *
    * NOTE: If your step `dependsOn` a step that is not in the same
    * dependencyGraphId, you will get a `Node does not exist` error.
    * These dependencies will need to be accounted for by the

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.test.ts
@@ -1,0 +1,87 @@
+import {
+  RelationshipClass,
+  RelationshipDirection,
+} from '@jupiterone/integration-sdk-core';
+import { getDeclaredTypesInStep } from './dependencyGraph';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const executionHandler = () => {};
+
+describe('getDeclaredTypesInStep', () => {
+  test('should get entity types', () => {
+    expect(
+      getDeclaredTypesInStep({
+        id: 'id',
+        name: 'name',
+        entities: [
+          {
+            resourceName: 'entity',
+            _type: 'entity',
+            _class: 'Entity',
+          },
+        ],
+        relationships: [],
+        executionHandler,
+      }),
+    ).toEqual({ declaredTypes: ['entity'], partialTypes: [] });
+  });
+
+  test('should get relationship types', () => {
+    expect(
+      getDeclaredTypesInStep({
+        id: 'id',
+        name: 'name',
+        entities: [],
+        relationships: [
+          {
+            _type: 'relationship',
+            sourceType: 'source_type',
+            _class: RelationshipClass.HAS,
+            targetType: 'target_type',
+          },
+        ],
+        executionHandler,
+      }),
+    ).toEqual({ declaredTypes: ['relationship'], partialTypes: [] });
+  });
+
+  test('should get mapped relationship types', () => {
+    expect(
+      getDeclaredTypesInStep({
+        id: 'id',
+        name: 'name',
+        entities: [],
+        relationships: [],
+        mappedRelationships: [
+          {
+            _type: 'mapped_relationship',
+            sourceType: 'source_type',
+            _class: RelationshipClass.HAS,
+            targetType: 'target_type',
+            direction: RelationshipDirection.FORWARD,
+          },
+        ],
+        executionHandler,
+      }),
+    ).toEqual({ declaredTypes: ['mapped_relationship'], partialTypes: [] });
+  });
+
+  test('should get partial types', () => {
+    expect(
+      getDeclaredTypesInStep({
+        id: 'id',
+        name: 'name',
+        entities: [
+          {
+            resourceName: 'entity',
+            _type: 'entity',
+            _class: 'Entity',
+            partial: true,
+          },
+        ],
+        relationships: [],
+        executionHandler,
+      }),
+    ).toEqual({ declaredTypes: ['entity'], partialTypes: ['entity'] });
+  });
+});

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -442,7 +442,7 @@ function buildStepResultsMap<
   return new Map<string, IntegrationStepResult>(stepResultMapEntries);
 }
 
-function getDeclaredTypesInStep<
+export function getDeclaredTypesInStep<
   TStepExecutionContext extends StepExecutionContext
 >(
   step: Step<TStepExecutionContext>,
@@ -453,7 +453,11 @@ function getDeclaredTypesInStep<
   const declaredTypes: string[] = [];
   const partialTypes: string[] = [];
 
-  [...step.entities, ...step.relationships].map((e) => {
+  [
+    ...step.entities,
+    ...step.relationships,
+    ...(step.mappedRelationships || []),
+  ].map((e) => {
     declaredTypes.push(e._type);
     if (e.partial) {
       partialTypes.push(e._type);


### PR DESCRIPTION
This change allows developers to declare mapped relationships that are produced from a step. Users can specify mapped relationships like so:

```typescript
const step = {
  id: 'step-id',
  name: 'Step Name',
  entities: [],
  relationships: [],
  mappedRelationships: [{
    _type: 'mapped_relationship_type',
    sourceType: 'source_entity_type',
    _class: RelationshipClass.HAS,
    target_type: 'target_entity_type',  // this is the target ("placeholder") entity
    direction: RelationshipDirection.FORWARD,
  }],
  executionHandler,
}
```

This provides two main benefits:

1. Mapped relationships are recognized as **declared types**
2. Mapped relationships can be visualized in `yarn j1-integration visualize-types`

![Screen Shot 2021-08-11 at 3 01 57 PM](https://user-images.githubusercontent.com/15333061/129087686-cf77001a-9360-4fc9-9d19-fa0aca7c2255.png)

Check the test suites to verify behavior
