### PR TITLE
Document command now documents mapped relationships from step metadata

### DIFF
--- a/packages/integration-sdk-cli/src/__tests__/__snapshots__/cli.test.ts.snap
+++ b/packages/integration-sdk-cli/src/__tests__/__snapshots__/cli.test.ts.snap
@@ -296,6 +296,53 @@ END OF GENERATED DOCUMENTATION AFTER BELOW MARKER
 <!-- {J1_DOCUMENTATION_MARKER_END} -->"
 `;
 
+exports[`document loads the integration with entity and mapped relationship and writes documentation results 1`] = `
+"# Integration with JupiterOne
+
+## Setup
+
+In this section, please provide details about how to set up the integration with
+JupiterOne. This may require provisioning some resources on the provider's side
+(perhaps a role, app, or api key) and passing information over to JupiterOne.
+
+
+<!-- {J1_DOCUMENTATION_MARKER_START} -->
+<!--
+********************************************************************************
+NOTE: ALL OF THE FOLLOWING DOCUMENTATION IS GENERATED USING THE
+\\"j1-integration document\\" COMMAND. DO NOT EDIT BY HAND! PLEASE SEE THE DEVELOPER
+DOCUMENTATION FOR USAGE INFORMATION:
+
+https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
+********************************************************************************
+-->
+
+## Data Model
+
+### Entities
+
+The following entities are created:
+
+| Resources | Entity \`_type\` | Entity \`_class\` |
+| --------- | -------------- | --------------- |
+| The Group | \`my_group\`     | \`Group\`         |
+
+### Mapped Relationships
+
+The following mapped relationships are created:
+
+| Source Entity \`_type\` | Relationship \`_class\` | Target Entity \`_type\` | Direction |
+| --------------------- | --------------------- | --------------------- | --------- |
+| \`my_group\`            | **HAS**               | \`*your_user*\`         | FORWARD   |
+
+<!--
+********************************************************************************
+END OF GENERATED DOCUMENTATION AFTER BELOW MARKER
+********************************************************************************
+-->
+<!-- {J1_DOCUMENTATION_MARKER_END} -->"
+`;
+
 exports[`document loads the integration without entities and writes documentation results 1`] = `
 "# Integration with JupiterOne
 

--- a/packages/integration-sdk-cli/src/__tests__/cli.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli.test.ts
@@ -441,6 +441,10 @@ describe('document', () => {
     await documentCommandSnapshotTest('docsInstanceRelationshipsAlphabetize');
   });
 
+  test('loads the integration with entity and mapped relationship and writes documentation results', async () => {
+    await documentCommandSnapshotTest('docsInstanceWithMappedRelationships');
+  });
+
   test('should allow passing a file path for the generated documentation', async () => {
     loadProjectStructure('docsInstanceCustomDocLoc');
 

--- a/packages/integration-sdk-cli/src/commands/document.ts
+++ b/packages/integration-sdk-cli/src/commands/document.ts
@@ -5,6 +5,7 @@ import {
   StepGraphObjectMetadataProperties,
   StepEntityMetadata,
   StepRelationshipMetadata,
+  StepMappedRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 import { promises as fs } from 'fs';
 import {
@@ -146,11 +147,33 @@ function generateRelationshipTableFromAllStepEntityMetadata(
   return generated;
 }
 
+function generateMappedRelationshipTableFromAllStepEntityMetadata(
+  metadata: StepMappedRelationshipMetadata[],
+): string {
+  const generated = table([
+    [
+      'Source Entity `_type`',
+      'Relationship `_class`',
+      'Target Entity `_type`',
+      'Direction',
+    ],
+    ...metadata.map((v) => [
+      `\`${v.sourceType}\``,
+      `**${v._class}**`,
+      `\`*${v.targetType}*\``,
+      `${v.direction}`,
+    ]),
+  ]);
+
+  return generated;
+}
+
 function generateGraphObjectDocumentationFromStepsMetadata(
   metadata: StepGraphObjectMetadataProperties,
 ): string {
   let entitySection = '';
   let relationshipSection = '';
+  let mappedRelationshipSection = '';
 
   if (metadata.entities.length) {
     const generatedEntityTable = generateEntityTableFromAllStepEntityMetadata(
@@ -180,6 +203,20 @@ The following relationships are created/mapped:
 ${generatedRelationshipTable}`;
   }
 
+  if (metadata.mappedRelationships?.length) {
+    const generatedMappedRelationshipTable = generateMappedRelationshipTableFromAllStepEntityMetadata(
+      metadata.mappedRelationships,
+    );
+
+    mappedRelationshipSection += `
+
+### Mapped Relationships
+
+The following mapped relationships are created:
+
+${generatedMappedRelationshipTable}`;
+  }
+
   return `${J1_DOCUMENTATION_MARKER_START}
 <!--
 ********************************************************************************
@@ -191,7 +228,7 @@ https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 ********************************************************************************
 -->
 
-## Data Model${entitySection}${relationshipSection}
+## Data Model${entitySection}${relationshipSection}${mappedRelationshipSection}
 
 <!--
 ********************************************************************************

--- a/packages/integration-sdk-private-test-utils/__fixtures__/docsInstanceWithMappedRelationships/.gitignore
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/docsInstanceWithMappedRelationships/.gitignore
@@ -1,0 +1,1 @@
+.j1-integration

--- a/packages/integration-sdk-private-test-utils/__fixtures__/docsInstanceWithMappedRelationships/docs/jupiterone.md
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/docsInstanceWithMappedRelationships/docs/jupiterone.md
@@ -1,0 +1,7 @@
+# Integration with JupiterOne
+
+## Setup
+
+In this section, please provide details about how to set up the integration with
+JupiterOne. This may require provisioning some resources on the provider's side
+(perhaps a role, app, or api key) and passing information over to JupiterOne.

--- a/packages/integration-sdk-private-test-utils/__fixtures__/docsInstanceWithMappedRelationships/src/index.ts
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/docsInstanceWithMappedRelationships/src/index.ts
@@ -1,0 +1,6 @@
+import fetchGroups from './steps/fetchGroups';
+
+export const invocationConfig = {
+  instanceConfigFields: {},
+  integrationSteps: [fetchGroups],
+};

--- a/packages/integration-sdk-private-test-utils/__fixtures__/docsInstanceWithMappedRelationships/src/steps/fetchGroups.ts
+++ b/packages/integration-sdk-private-test-utils/__fixtures__/docsInstanceWithMappedRelationships/src/steps/fetchGroups.ts
@@ -1,0 +1,32 @@
+import noop from 'lodash/noop';
+import {
+  StepExecutionContext,
+  Step,
+  RelationshipDirection,
+} from '@jupiterone/integration-sdk-core';
+import { RelationshipClass } from '@jupiterone/data-model';
+
+const fetchGroupsStep: Step<StepExecutionContext> = {
+  id: 'fetch-groups',
+  name: 'Fetch Groups',
+  entities: [
+    {
+      resourceName: 'The Group',
+      _type: 'my_group',
+      _class: 'Group',
+    },
+  ],
+  relationships: [],
+  mappedRelationships: [
+    {
+      _type: 'my_group_has_user',
+      sourceType: 'my_group',
+      _class: RelationshipClass.HAS,
+      targetType: 'your_user', // this is the target ("placeholder") entity
+      direction: RelationshipDirection.FORWARD,
+    },
+  ],
+  executionHandler: noop,
+};
+
+export default fetchGroupsStep;


### PR DESCRIPTION
Now that we have the ability to declare mapped relationships in the step meta data, this PR makes the document command generate docs for these mapped relationships

Example Output:

# Integration with JupiterOne

## Setup

In this section, please provide details about how to set up the integration with
JupiterOne. This may require provisioning some resources on the provider's side
(perhaps a role, app, or api key) and passing information over to JupiterOne.


<!-- {J1_DOCUMENTATION_MARKER_START} -->
<!--
********************************************************************************
NOTE: ALL OF THE FOLLOWING DOCUMENTATION IS GENERATED USING THE
\\"j1-integration document\\" COMMAND. DO NOT EDIT BY HAND! PLEASE SEE THE DEVELOPER
DOCUMENTATION FOR USAGE INFORMATION:

https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
********************************************************************************
-->

## Data Model

### Entities

The following entities are created:

| Resources | Entity \`_type\` | Entity \`_class\` |
| --------- | -------------- | --------------- |
| The Group | \`my_group\`     | \`Group\`         |

### Mapped Relationships

The following mapped relationships are created:

| Source Entity \`_type\` | Relationship \`_class\` | Target Entity \`_type\` | Direction |
| --------------------- | --------------------- | --------------------- | --------- |
| \`my_group\`            | **HAS**               | \`*your_user*\`         | FORWARD   |

<!--
********************************************************************************
END OF GENERATED DOCUMENTATION AFTER BELOW MARKER
********************************************************************************
-->
<!-- {J1_DOCUMENTATION_MARKER_END} -->