### PR TITLE
Add step spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added `StepSpec` and `IntegrationSpecConfig` types in order to define
+  integration specifications
+
 ### Changed
 
 - Changed language for relationships created that document command produces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ### Added
 
+- Added `toImplementSpec` jest matcher
 - Added `StepSpec` and `IntegrationSpecConfig` types in order to define
   integration specifications
 

--- a/packages/integration-sdk-core/src/types/index.ts
+++ b/packages/integration-sdk-core/src/types/index.ts
@@ -4,6 +4,7 @@ export * from './instance';
 export * from './jobState';
 export * from './logger';
 export * from './partialDatasets';
+export * from './spec';
 export * from './step';
 export * from './validation';
 export * from './synchronization';

--- a/packages/integration-sdk-core/src/types/spec.ts
+++ b/packages/integration-sdk-core/src/types/spec.ts
@@ -1,0 +1,18 @@
+import { IntegrationInvocationConfig } from './config';
+import { IntegrationStepExecutionContext } from './context';
+import { IntegrationInstanceConfig } from './instance';
+import { Step } from './step';
+
+export interface StepSpec<TConfig extends IntegrationInstanceConfig>
+  extends Omit<
+    Step<IntegrationStepExecutionContext<TConfig>>,
+    'executionHandler'
+  > {
+  implemented: boolean;
+}
+
+export interface IntegrationSpecConfig<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> extends Omit<IntegrationInvocationConfig, 'integrationSteps'> {
+  integrationSteps: StepSpec<TConfig>[];
+}

--- a/packages/integration-sdk-testing/src/__tests__/jest.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jest.test.ts
@@ -3,6 +3,8 @@ import {
   createMappedRelationship,
   Entity,
   ExplicitRelationship,
+  IntegrationInvocationConfig,
+  IntegrationSpecConfig,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import {
@@ -11,6 +13,7 @@ import {
   toTargetEntities,
   GraphObjectSchema,
   registerMatchers,
+  toImplementSpec,
 } from '../jest';
 import { v4 as uuid } from 'uuid';
 
@@ -750,6 +753,188 @@ describe('#toTargetEntities', () => {
   });
 });
 
+describe('#toImplementSpec', () => {
+  const executionHandler = () => {
+    undefined;
+  };
+
+  test('should pass if integration matches implemented spec', () => {
+    const implementation: IntegrationInvocationConfig = {
+      integrationSteps: [
+        {
+          id: 'step-1',
+          name: 'Step 1',
+          entities: [
+            {
+              resourceName: 'resource-1',
+              _type: 'resource_1',
+              _class: 'Record',
+            },
+          ],
+          relationships: [],
+          dependsOn: [],
+          executionHandler,
+        },
+        {
+          id: 'step-2',
+          name: 'Step 2',
+          entities: [
+            {
+              resourceName: 'resource-2',
+              _type: 'resource_2',
+              _class: 'Record',
+            },
+          ],
+          relationships: [
+            {
+              _type: 'resource_1_has_resource_2',
+              sourceType: 'resource_1',
+              _class: RelationshipClass.HAS,
+              targetType: 'resource_2',
+            },
+          ],
+          dependsOn: ['step-1'],
+          executionHandler,
+        },
+      ],
+    };
+
+    const spec: IntegrationSpecConfig = {
+      integrationSteps: [
+        {
+          id: 'step-1',
+          name: 'Step 1',
+          entities: [
+            {
+              resourceName: 'resource-1',
+              _type: 'resource_1',
+              _class: 'Record',
+            },
+          ],
+          relationships: [],
+          dependsOn: [],
+          implemented: true,
+        },
+        {
+          id: 'step-2',
+          name: 'Step 2',
+          entities: [
+            {
+              resourceName: 'RESOURCE-3',
+              _type: 'resource_3',
+              _class: 'Record',
+            },
+          ],
+          relationships: [
+            {
+              _type: 'resource_1_has_resource_3',
+              sourceType: 'resource_1',
+              _class: RelationshipClass.HAS,
+              targetType: 'resource_3',
+            },
+          ],
+          dependsOn: ['step-1'],
+          implemented: false,
+        },
+      ],
+    };
+    const result = toImplementSpec(implementation, spec);
+
+    expect(result).toEqual({
+      message: expect.any(Function),
+      pass: true,
+    });
+  });
+
+  test('should fail if integration does not match implemented spec', () => {
+    const implementation: IntegrationInvocationConfig = {
+      integrationSteps: [
+        {
+          id: 'step-1',
+          name: 'Step 1',
+          entities: [
+            {
+              resourceName: 'resource-1',
+              _type: 'resource_1',
+              _class: 'Record',
+            },
+          ],
+          relationships: [],
+          dependsOn: [],
+          executionHandler,
+        },
+        {
+          id: 'step-2',
+          name: 'Step 2',
+          entities: [
+            {
+              resourceName: 'resource-2',
+              _type: 'resource_2',
+              _class: 'Record',
+            },
+          ],
+          relationships: [
+            {
+              _type: 'resource_1_has_resource_2',
+              sourceType: 'resource_1',
+              _class: RelationshipClass.HAS,
+              targetType: 'resource_2',
+            },
+          ],
+          dependsOn: ['step-1'],
+          executionHandler,
+        },
+      ],
+    };
+
+    const spec: IntegrationSpecConfig = {
+      integrationSteps: [
+        {
+          id: 'step-1',
+          name: 'Step 1',
+          entities: [
+            {
+              resourceName: 'resource-1',
+              _type: 'resource_1',
+              _class: 'Record',
+            },
+          ],
+          relationships: [],
+          dependsOn: [],
+          implemented: true,
+        },
+        {
+          id: 'step-2',
+          name: 'Step 2',
+          entities: [
+            {
+              resourceName: 'RESOURCE-3',
+              _type: 'resource_3',
+              _class: 'Record',
+            },
+          ],
+          relationships: [
+            {
+              _type: 'resource_1_has_resource_3',
+              sourceType: 'resource_1',
+              _class: RelationshipClass.HAS,
+              targetType: 'resource_3',
+            },
+          ],
+          dependsOn: ['step-1'],
+          implemented: true,
+        },
+      ],
+    };
+    const result = toImplementSpec(implementation, spec);
+
+    expect(result).toEqual({
+      message: expect.any(Function),
+      pass: false,
+    });
+  });
+});
+
 describe('#registerMatchers', () => {
   test('should register all test matchers', () => {
     const mockJestExtendFn = jest.fn();
@@ -764,6 +949,7 @@ describe('#registerMatchers', () => {
       toMatchGraphObjectSchema,
       toMatchDirectRelationshipSchema,
       toTargetEntities,
+      toImplementSpec,
     });
   });
 });


### PR DESCRIPTION
This was formerly implemented in `graph-tenable`, see https://github.com/JupiterOne/graph-tenable-cloud/pull/117/files#diff-6fa1efb441a5cfd956cd83b787050f7ad1d9f17f3bfaf5b955d2357483ba057bR1

---

```
### Added

- Added `toImplementSpec` jest matcher
- Added `StepSpec` and `IntegrationSpecConfig` types in order to define
  integration specifications