### PR TITLE
Support jobState.addMappedRelationship method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added support for `jobState.addMappedRelationship` and
+  `jobState.addMappedRelationships` methods. Previously, mapped relationships
+  were added to the job state using `jobState.addRelationships` and sent to the
+  `/persister/synchronization/jobs/{jobId}/relationships` synchronization
+  endpoint. They are now uploaded to
+  `/persister/synchronization/jobs/{jobId}/mapped-relationships`, which enables
+  some mapped relationships to be handled in an isolated fashion.
+
 ## [6.19.0] - 2021-09-09
 
 ### Added

--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -316,9 +316,9 @@ provides utilities for collecting and validating graph data.
 
 ##### `jobState`
 
-The `jobState` object is used for collecting entities and relationships that
-have been created throughout the integration run via the `addEntities` and
-`addRelationships` functions.
+The `jobState` object is used for collecting entities, relationships, and mapped
+relationships that have been created throughout the integration run via the
+`addEntities`, `addRelationships`, and `addMappedRelationships` functions.
 
 Previously collected integration data can be collected via the `iterateEntities`
 and `iterateRelationships` function. These functions will initially allow for
@@ -715,13 +715,14 @@ When the integration is run with context about an integration instance (via the
 
 The `executionContext` that is provided in the `executionHandler` step exposes a
 `jobState` utility that can be used to collect entity and relationship data via
-`addEntities` and `addRelationships` functions. The `jobState` utility will
-automatically flush the data to disk as a certain threshold of entities and
-relationships is met. The data flushed to disk are grouped in folders that are
-based on the step that was run. Entities and relationships will also be grouped
-by the `_type` and linked into separate directories to provide faster look ups.
-These directories will be used by the `findEntity`, `iterateEntities`, and
-`iterateRelationships` functions to provide faster lookups.
+`addEntities`, `addRelationships`, and `addMappedRelationships` functions. The
+`jobState` utility will automatically flush the data to disk as a certain
+threshold of entities and relationships is met. The data flushed to disk are
+grouped in folders that are based on the step that was run. Entities and
+relationships will also be grouped by the `_type` and linked into separate
+directories to provide faster look ups. These directories will be used by the
+`findEntity`, `iterateEntities`, and `iterateRelationships` functions to provide
+faster lookups.
 
 From our experience, integrations most commonly query collected data from
 previous steps the `_type` property for constructing relationships, so the

--- a/docs/integrations/testing.md
+++ b/docs/integrations/testing.md
@@ -208,8 +208,9 @@ collected via the `jobState` in memory.
 
 For convenience, the `jobState` created by the mocked context exposes a slightly
 different interface than the regular `jobState` object and allows for data
-collected via the `addEntities` and `addRelationships` functions to be accessed
-via `collectedEntities` and `collectedRelationships` properties.
+collected via the `addEntities`, `addRelationships`, and
+`addMappedRelationships` functions to be accessed via `collectedEntities` and
+`collectedRelationships` properties.
 
 Example usage in a test:
 

--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -1,3 +1,4 @@
+import { MappedRelationship } from '..';
 import { Entity, Relationship } from '../types';
 
 export interface GraphObjectFilter {
@@ -70,6 +71,22 @@ export interface JobState {
    * to add a single relationship to the collection.
    */
   addRelationships: (relationships: Relationship[]) => Promise<void>;
+
+  /**
+   * Adds a mapped relationship to the job's collection. `addMappedRelationships` can be used
+   * to add a batch of relationships to the collection.
+   */
+  addMappedRelationship: (
+    mappedRelationship: MappedRelationship,
+  ) => Promise<void>;
+
+  /**
+   * Adds a batch of mapped relationships to the job's collection. `addMappedRelationship` can be used
+   * to add a single relationship to the collection.
+   */
+  addMappedRelationships: (
+    mappedRelationships: MappedRelationship[],
+  ) => Promise<void>;
 
   /**
    * Finds an entity by `_key` and returns `null` if the entity does not exist.

--- a/packages/integration-sdk-core/src/types/storage.ts
+++ b/packages/integration-sdk-core/src/types/storage.ts
@@ -1,16 +1,21 @@
 import { Entity } from './entity';
 import { GraphObjectFilter, GraphObjectIteratee } from './jobState';
-import { Relationship } from './relationship';
+import { MappedRelationship, Relationship } from './relationship';
 import { GraphObjectIndexMetadata } from '../types/step';
+
+export type CollectionType =
+  | 'entities'
+  | 'relationships'
+  | 'mapped-relationships';
 
 export interface GetIndexMetadataForGraphObjectTypeParams {
   stepId: string;
   _type: string;
-  graphObjectCollectionType: 'entities' | 'relationships';
+  graphObjectCollectionType: CollectionType;
 }
 
 /**
- * Persists entities and relationships to a durable medium for the duration of
+ * Persists entities, relationships, and mapped relationships to a durable medium for the duration of
  * integration execution.
  */
 export interface GraphObjectStore {
@@ -26,6 +31,14 @@ export interface GraphObjectStore {
     onRelationshipsFlushed?: (relationships: Relationship[]) => Promise<void>,
   ): Promise<void>;
 
+  addMappedRelationships(
+    stepId: string,
+    newMappedRelationships: MappedRelationship[],
+    onRelationshipsFlushed?: (
+      mappedRelationships: MappedRelationship[],
+    ) => Promise<void>,
+  ): Promise<void>;
+
   findEntity(_key: string | undefined): Promise<Entity | undefined>;
 
   iterateEntities<T extends Entity = Entity>(
@@ -38,9 +51,14 @@ export interface GraphObjectStore {
     iteratee: GraphObjectIteratee<T>,
   ): Promise<void>;
 
+  // TODO iterateMappedRelationships()
+
   flush(
     onEntitiesFlushed?: (entities: Entity[]) => Promise<void>,
     onRelationshipsFlushed?: (relationships: Relationship[]) => Promise<void>,
+    onMappedRelationshipsFlushed?: (
+      mappedRelationships: MappedRelationship[],
+    ) => Promise<void>,
   ): Promise<void>;
 
   getIndexMetadataForGraphObjectType?: (

--- a/packages/integration-sdk-private-test-utils/src/graphObjectStore.ts
+++ b/packages/integration-sdk-private-test-utils/src/graphObjectStore.ts
@@ -4,16 +4,21 @@ import {
   GraphObjectIteratee,
   Relationship,
   GraphObjectStore,
+  MappedRelationship,
 } from '@jupiterone/integration-sdk-core';
 
 /**
- * Custom implementation of GraphObjectStore that stores all entities and
- * relationships in memory. This should never be used in production and is
+ * Custom implementation of GraphObjectStore that stores all entities,
+ * relationships, and mapped relationships in memory. This should never be used in production and is
  * currently only used for testing purposes.
  */
 export class InMemoryGraphObjectStore implements GraphObjectStore {
   private readonly entityMap = new Map<string, Entity>();
   private readonly relationshipMap = new Map<string, Relationship>();
+  private readonly mappedRelationshipMap = new Map<
+    string,
+    MappedRelationship
+  >();
 
   async addEntities(stepId: string, newEntities: Entity[]): Promise<void> {
     for (const entity of newEntities) {
@@ -29,6 +34,20 @@ export class InMemoryGraphObjectStore implements GraphObjectStore {
   ): Promise<void> {
     for (const relationship of newRelationships) {
       this.relationshipMap.set(relationship._key, relationship);
+    }
+
+    return Promise.resolve();
+  }
+
+  async addMappedRelationships(
+    stepId: string,
+    newMappedRelationships: MappedRelationship[],
+  ): Promise<void> {
+    for (const mappedRelationship of newMappedRelationships) {
+      this.mappedRelationshipMap.set(
+        mappedRelationship._key,
+        mappedRelationship,
+      );
     }
 
     return Promise.resolve();

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -735,10 +735,12 @@ describe('executeStepDependencyGraph', () => {
       {
         entities: [eA],
         relationships: [],
+        mappedRelationships: [],
       },
       {
         entities: [eC],
         relationships: [],
+        mappedRelationships: [],
       },
     ];
 

--- a/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
@@ -194,6 +194,7 @@ describe('upload callbacks', () => {
       {
         entities: [e1, e2],
         relationships: [],
+        mappedRelationships: [],
       },
     ];
 
@@ -219,6 +220,7 @@ describe('upload callbacks', () => {
       {
         entities: [],
         relationships: [r1, r2],
+        mappedRelationships: [],
       },
     ];
 
@@ -247,10 +249,12 @@ describe('upload callbacks', () => {
       {
         entities: [e1],
         relationships: [],
+        mappedRelationships: [],
       },
       {
         entities: [],
         relationships: [r1],
+        mappedRelationships: [],
       },
     ];
 
@@ -296,6 +300,7 @@ describe('upload callbacks', () => {
       {
         entities: [e1, e2],
         relationships: [],
+        mappedRelationships: [],
       },
     ];
 

--- a/packages/integration-sdk-runtime/src/execution/uploader.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.test.ts
@@ -20,6 +20,7 @@ function createFlushedGraphObjectData(): FlushedGraphObjectData {
   return {
     entities: [createTestEntity(), createTestEntity()],
     relationships: [createTestRelationship(), createTestRelationship()],
+    mappedRelationships: [],
   };
 }
 

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -37,6 +37,7 @@ async function getStorageDirectoryDataForStep(
   const accumulatedWrittenStepData: FlushedGraphObjectData = {
     entities: [],
     relationships: [],
+    mappedRelationships: [],
   };
 
   for (const collectionType of ['entities', 'relationships']) {

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/flushDataToDisk.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/flushDataToDisk.ts
@@ -2,15 +2,15 @@ import pMap from 'p-map';
 import { v4 as uuid } from 'uuid';
 import groupBy from 'lodash/groupBy';
 
-import { Entity, Relationship } from '@jupiterone/integration-sdk-core';
+import {
+  CollectionType,
+  Entity,
+  Relationship,
+} from '@jupiterone/integration-sdk-core';
 
 import { writeJsonToPath, symlink } from '../../fileSystem';
 
-import {
-  CollectionType,
-  buildIndexFilePath,
-  buildObjectCollectionFilePath,
-} from './path';
+import { buildIndexFilePath, buildObjectCollectionFilePath } from './path';
 
 interface FlushDataToDiskInput<TGraphObject = Entity | Relationship> {
   storageDirectoryPath: string;

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/path.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/path.ts
@@ -1,6 +1,5 @@
+import { CollectionType } from '@jupiterone/integration-sdk-core';
 import path from 'path';
-
-export type CollectionType = 'entities' | 'relationships';
 
 interface BuildObjectCollectionFilePathInput {
   storageDirectoryPath: string;

--- a/packages/integration-sdk-runtime/src/storage/types.ts
+++ b/packages/integration-sdk-runtime/src/storage/types.ts
@@ -1,4 +1,8 @@
-import { Entity, Relationship } from '@jupiterone/integration-sdk-core';
+import {
+  Entity,
+  MappedRelationship,
+  Relationship,
+} from '@jupiterone/integration-sdk-core';
 
 export interface FlushedEntityData {
   entities: Entity[];
@@ -8,5 +12,10 @@ export interface FlushedRelationshipData {
   relationships: Relationship[];
 }
 
+export interface FlushedMappedRelationshipData {
+  mappedRelationships: MappedRelationship[];
+}
+
 export type FlushedGraphObjectData = FlushedEntityData &
-  FlushedRelationshipData;
+  FlushedRelationshipData &
+  FlushedMappedRelationshipData;

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -7,6 +7,7 @@ import {
   Entity,
   Relationship,
   SynchronizationJob,
+  MappedRelationship,
 } from '@jupiterone/integration-sdk-core';
 
 import { IntegrationLogger } from '../logger';
@@ -193,7 +194,7 @@ export async function uploadGraphObjectData(
         graphObjectData.entities,
         uploadBatchSize,
       );
-      
+
       synchronizationJobContext.logger.info(
         {
           entities: graphObjectData.entities.length,
@@ -225,6 +226,32 @@ export async function uploadGraphObjectData(
           relationships: graphObjectData.relationships.length,
         },
         'Successfully uploaded relationships',
+      );
+    }
+
+    if (
+      Array.isArray(graphObjectData.mappedRelationships) &&
+      graphObjectData.mappedRelationships.length != 0
+    ) {
+      synchronizationJobContext.logger.info(
+        {
+          mappedRelationships: graphObjectData.mappedRelationships.length,
+        },
+        'Preparing batches of mapped relationships for upload',
+      );
+
+      await uploadData(
+        synchronizationJobContext,
+        'mapped-relationships',
+        graphObjectData.mappedRelationships,
+        uploadBatchSize,
+      );
+
+      synchronizationJobContext.logger.info(
+        {
+          mappedRelationships: graphObjectData.mappedRelationships.length,
+        },
+        'Successfully uploaded mapped relationships',
       );
     }
   } catch (err) {
@@ -261,6 +288,7 @@ export async function uploadCollectedData(context: SynchronizationJobContext) {
 interface UploadDataLookup {
   entities: Entity;
   relationships: Relationship;
+  'mapped-relationships': MappedRelationship;
 }
 
 interface UploadDataChunkParams<T extends UploadDataLookup, K extends keyof T> {


### PR DESCRIPTION
```
### Added

- Added support for `jobState.addMappedRelationship` and
  `jobState.addMappedRelationships` methods. Previously, mapped relationships
  were added to the job state using `jobState.addRelationships` and sent to the
  `/persister/synchronization/jobs/{jobId}/relationships` synchronization
  endpoint. They are now uploaded to
  `/persister/synchronization/jobs/{jobId}/mapped-relationships`, which enables
  some mapped relationships to be handled in an isolated fashion.
```