### PR TITLE
Add cause.stack to IntegrationError stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- When an `IntegrationError` receives a `cause` property, append `cause.stack`
+  to the error's stack trace
+
 ## [6.22.0] - 2021-09-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## Unreleased
 
+## [6.22.1] - 2021-10-04
+
 ### Changed
 
 - When an `IntegrationError` receives a `cause` property, append `cause.stack`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "6.22.0",
+  "version": "6.22.1",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.22.0",
-    "@jupiterone/integration-sdk-runtime": "^6.22.0",
+    "@jupiterone/integration-sdk-core": "^6.22.1",
+    "@jupiterone/integration-sdk-runtime": "^6.22.1",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "6.22.0",
+  "version": "6.22.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^6.22.0",
+    "@jupiterone/integration-sdk-runtime": "^6.22.1",
     "commander": "^5.0.0",
     "globby": "^11.0.0",
     "js-yaml": "^4.1.0",
@@ -34,7 +34,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.22.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.22.1",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "6.22.0",
+  "version": "6.22.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-core/src/errors.test.ts
+++ b/packages/integration-sdk-core/src/errors.test.ts
@@ -1,0 +1,14 @@
+import { IntegrationError } from '.';
+
+test('should append cause stack trace to current stack trace', () => {
+  const cause = new Error('GENERIC_ERROR');
+
+  const integrationError = new IntegrationError({
+    message: 'SPECIAL_INTEGRATION_ERROR',
+    code: 'code',
+    cause,
+  });
+  expect(integrationError.stack).toMatch('Error: SPECIAL_INTEGRATION_ERROR');
+  expect(integrationError.stack).toMatch('Error: GENERIC_ERROR');
+  expect(integrationError.stack?.endsWith(cause.stack!)).toBe(true);
+});

--- a/packages/integration-sdk-core/src/errors.ts
+++ b/packages/integration-sdk-core/src/errors.ts
@@ -84,7 +84,7 @@ export class IntegrationError extends Error {
     this.fatal = options.fatal;
     this._cause = options.cause;
     if (options.cause?.stack) {
-      this.stack = this.stack + '\n' + options.cause.stack;
+      this.stack += '\nCaused By: ' + options.cause.stack;
     }
   }
 

--- a/packages/integration-sdk-core/src/errors.ts
+++ b/packages/integration-sdk-core/src/errors.ts
@@ -83,6 +83,9 @@ export class IntegrationError extends Error {
     this.code = options.code;
     this.fatal = options.fatal;
     this._cause = options.cause;
+    if (options.cause?.stack) {
+      this.stack = this.stack + '\n' + options.cause.stack;
+    }
   }
 
   /**

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "6.22.0",
+  "version": "6.22.1",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^6.22.0",
-    "@jupiterone/integration-sdk-testing": "^6.22.0",
+    "@jupiterone/integration-sdk-cli": "^6.22.1",
+    "@jupiterone/integration-sdk-testing": "^6.22.1",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "6.22.0",
+  "version": "6.22.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.22.0",
+    "@jupiterone/integration-sdk-core": "^6.22.1",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "6.22.0",
+  "version": "6.22.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.22.0",
+    "@jupiterone/integration-sdk-core": "^6.22.1",
     "@lifeomic/alpha": "^1.4.0",
     "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.22.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.22.1",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "6.22.0",
+  "version": "6.22.1",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.22.0",
-    "@jupiterone/integration-sdk-runtime": "^6.22.0",
+    "@jupiterone/integration-sdk-core": "^6.22.1",
+    "@jupiterone/integration-sdk-runtime": "^6.22.1",
     "@pollyjs/adapter-node-http": "^4.0.4",
     "@pollyjs/core": "^4.0.4",
     "@pollyjs/persister-fs": "^4.0.4",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^6.22.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^6.22.1",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
In the azure integration, the way that we're making client API calls is causing almost every provider error, from every distinct step, to be grouped using the following trace:

```
at request (/opt/jupiterone/app/node_modules/@jupiterone/graph-azure/dist/azure/resource-manager/client.js:180:23)
at runMicrotasks (<anonymous>)
at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

This change should help to fingerprint every unique error in sentry or other similar services.