### PR TITLE
Add support to publish job log events at levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added support to publish job log events at level `info`, `warn`, and `error`.
+
+  Usage:
+
+  ```ts
+  logger.publishInfoEvent({
+    name: IntegrationErrorEventName.Stats,
+    description: 'fetched 100000 records',
+  });
+  logger.publishWarnEvent({
+    name: IntegrationErrorEventName.MissingPermission,
+    description: 'Missing permission users.read',
+  });
+  logger.publishErrorEvent({
+    name: IntegrationErrorEventName.MissingPermission,
+    description: 'Missing permission users.read',
+  });
+  ```
+
 ## [7.0.0] - 2021-10-05
 
 ### Changed

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
@@ -1,4 +1,7 @@
-import { SynchronizationJob } from '@jupiterone/integration-sdk-core';
+import {
+  PublishEventLevel,
+  SynchronizationJob,
+} from '@jupiterone/integration-sdk-core';
 import { createIntegrationLogger } from '../../logger';
 import { createApiClient } from '../../api';
 
@@ -9,11 +12,13 @@ test('publishes events added to the queue in the order they were enqueued', asyn
   const eventA = {
     name: 'a',
     description: 'Event A',
+    level: PublishEventLevel.Info,
   };
 
   const eventB = {
     name: 'b',
     description: 'Event B',
+    level: PublishEventLevel.Info,
   };
 
   const { apiClient, job, queue } = createContext();
@@ -45,6 +50,7 @@ test('logs an error if publish fails', async () => {
   const event = {
     name: 'a',
     description: 'Event A',
+    level: PublishEventLevel.Info,
   };
 
   const { apiClient, logger, queue } = createContext();

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
@@ -34,14 +34,28 @@ test('publishes events added to the queue in the order they were enqueued', asyn
   expect(postSpy).toHaveBeenNthCalledWith(
     1,
     `/persister/synchronization/jobs/${job.id}/events`,
-    { events: [eventA] },
+    {
+      events: [
+        {
+          name: eventA.name,
+          description: eventA.description,
+        },
+      ],
+    },
     { headers: { 'managed-integration': 'some-integration' } },
   );
 
   expect(postSpy).toHaveBeenNthCalledWith(
     2,
     `/persister/synchronization/jobs/${job.id}/events`,
-    { events: [eventB] },
+    {
+      events: [
+        {
+          name: eventB.name,
+          description: eventB.description,
+        },
+      ],
+    },
     { headers: { 'managed-integration': 'some-integration' } },
   );
 });

--- a/packages/integration-sdk-runtime/src/synchronization/events.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/events.ts
@@ -17,7 +17,13 @@ export const createEventPublishingQueue = (
           await apiClient.post(
             `/persister/synchronization/jobs/${job.id}/events`,
             {
-              events: [event],
+              events: [
+                {
+                  name: event.name,
+                  description: event.description,
+                  // level: event.level, // TODO enable the `level` property in synchronization API
+                },
+              ],
             },
             config,
           );


### PR DESCRIPTION
See changelog below:

---

### Added

- Added support to publish job log events at level `info`, `warn`, and `error`.

  Usage:

  ```ts
  logger.publishInfoEvent({
    name: IntegrationErrorEventName.Stats,
    description: 'fetched 100000 records',
  });
  logger.publishWarnEvent({
    name: IntegrationErrorEventName.MissingPermission,
    description: 'Missing permission users.read',
  });
  logger.publishErrorEvent({
    name: IntegrationErrorEventName.MissingPermission,
    description: 'Missing permission users.read',
  });
  ```

---

This change encourages stricter event names for info-, warn-, and error-level logs that should be shown to the user. The deprecated `publishEvent` method is still available to grant developers flexibility with job log events.

This also passes a level with the job log (`info`, `warn`, and `error`) that can be consumed by the job log in order to emphasize certain events for users.

