### PR TITLE
Change job log name from 'step_failure' to 'error_step_failure' so jobs marked as 'errorsOccurred: true'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Changed step failure job log name from `step_failure` to `error_step_failure`,
+  which will force the job to be marked as `errorsOccurred: true`
+
 ## [7.0.0] - 2021-10-05
 
 ### Changed

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -323,7 +323,7 @@ describe('step event publishing', () => {
       description: 'Completed step "Mochi".',
     });
     expect(onEmitEvent).toHaveBeenNthCalledWith(3, {
-      name: 'step_failure',
+      name: 'error_step_failure',
       description: expect.stringMatching(
         new RegExp(
           `Step "Mochi" failed to complete due to error. \\(errorCode="${error.code}", errorId="(.*)"\\)$`,
@@ -377,7 +377,7 @@ describe('provider auth error details', () => {
       logger.stepFailure(step, error);
 
       expect(onEmitEvent).toHaveBeenCalledWith({
-        name: 'step_failure',
+        name: 'error_step_failure',
         description: expect.stringMatching(
           new RegExp(
             '^Step "Mochi" failed to complete due to error.' +
@@ -703,7 +703,7 @@ describe('#handleFailure', () => {
     logger.handleFailure({
       err: new Error(),
       errorId: 'SOME_ERROR_ID',
-      eventName: 'step_failure',
+      eventName: 'error_step_failure',
       description: 'an error :(',
     });
 
@@ -726,7 +726,7 @@ describe('#handleFailure', () => {
     logger.handleFailure({
       err: new Error(),
       errorId: 'SOME_ERROR_ID',
-      eventName: 'step_failure',
+      eventName: 'error_step_failure',
       description: 'an error :(',
     });
 
@@ -750,7 +750,7 @@ describe('#handleFailure', () => {
     logger.handleFailure({
       err: new IntegrationValidationError(''),
       errorId: 'SOME_ERROR_ID',
-      eventName: 'step_failure',
+      eventName: 'error_step_failure',
       description: 'an error :(',
     });
 

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -47,8 +47,7 @@ interface CreateLoggerInput<
 
 interface CreateIntegrationLoggerInput<
   TIntegrationConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
->
-  extends CreateLoggerInput<
+> extends CreateLoggerInput<
     IntegrationExecutionContext<TIntegrationConfig>,
     IntegrationStepExecutionContext<TIntegrationConfig>
   > {
@@ -169,7 +168,8 @@ interface IntegrationLoggerInput {
   onFailure?: OnFailureFunction;
 }
 
-export class IntegrationLogger extends EventEmitter
+export class IntegrationLogger
+  extends EventEmitter
   implements IntegrationLoggerType {
   private _logger: Logger;
   private _errorSet: Set<Error>;
@@ -283,7 +283,7 @@ export class IntegrationLogger extends EventEmitter
   }
 
   stepFailure(step: StepMetadata, err: Error) {
-    const eventName = 'step_failure';
+    const eventName = 'error_step_failure';
     const { errorId, description } = createErrorEventDescription(
       err,
       `Step "${step.name}" failed to complete due to error.`,
@@ -325,7 +325,7 @@ export class IntegrationLogger extends EventEmitter
   }
 
   private handleFailure(options: {
-    eventName: 'validation_failure' | 'step_failure';
+    eventName: 'validation_failure' | 'error_step_failure';
     errorId: string;
     err: Error;
     description: string;


### PR DESCRIPTION
Just a proposal. This would cause the integrations to set `errorsOccurred: true` when a step fails, hence setting the job status chip to yellow rather than green.

