### PR TITLE
Allow undefined values in jobState.findEntity and jobState.hasKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to
 
 ## Unreleased
 
+- Updated the interfaces for `jobState.findEntity` and `jobState.hasKey` to
+  allow `undefined`. Oftentimes, we use optional chaining with
+  `jobState.findEntity` or `jobState.hasKey`, so having the ability to pass
+  `undefined` into these methods can make our code easier to read.
+
+  ```ts
+  // without allowing `undefined`, we often need to assert values as `string`
+  const virtualMachineId = await jobState.findEntity(
+    nic.virtualMachine?.id as string,
+  );
+
+  // by allowing `undefined`, we can more safely use these methods without type assertions
+  const virtualMachineId = await jobState.findEntity(nic.virtualMachine?.id);
+  ```
+
 ## [7.4.0] - 2021-11-03
 
 ### Changed

--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -81,7 +81,7 @@ export interface JobState {
    * the same `_key` value. Note however, there are mechanisms in place to
    * prevent storing duplicates.
    */
-  findEntity: (_key: string) => Promise<Entity | null>;
+  findEntity: (_key: string | undefined) => Promise<Entity | null>;
 
   /**
    * Answers `true` when an entity OR relationship having `_key` has been added.
@@ -89,7 +89,7 @@ export interface JobState {
    * @see findEntity when the entity, if present, is needed (there is no need to
    * use `hasKey` before `findEntity`).
    */
-  hasKey: (_key: string) => boolean | Promise<boolean>;
+  hasKey: (_key: string | undefined) => boolean | Promise<boolean>;
 
   /**
    * Allows a step to iterate all entities collected into the job state, limited

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -252,7 +252,8 @@ export function createStepJobState({
     },
     addRelationships,
 
-    findEntity: async (_key: string) => {
+    findEntity: async (_key: string | undefined) => {
+      if (!_key) return null;
       const graphObjectMetadata = duplicateKeyTracker.getGraphObjectMetadata(
         _key,
       );
@@ -266,7 +267,8 @@ export function createStepJobState({
       );
     },
 
-    hasKey: (_key: string) => {
+    hasKey: (_key: string | undefined) => {
+      if (!_key) return false;
       return duplicateKeyTracker.hasKey(_key);
     },
 

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -177,7 +177,8 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
    * in the InMemoryGraphObjectStore. If not, it then checks to see if it is
    * located on disk.
    */
-  async findEntity(_key: string): Promise<Entity | undefined> {
+  async findEntity(_key: string | undefined): Promise<Entity | undefined> {
+    if (!_key) return;
     const bufferedEntity = await this.localGraphObjectStore.findEntity(_key);
     if (bufferedEntity) {
       return bufferedEntity;

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -164,7 +164,8 @@ export function createMockJobState({
     },
     addRelationships,
 
-    findEntity: async (_key: string) => {
+    findEntity: async (_key: string | undefined) => {
+      if (!_key) return null;
       const graphObjectMetadata = duplicateKeyTracker.getGraphObjectMetadata(
         _key,
       );
@@ -180,7 +181,8 @@ export function createMockJobState({
       );
     },
 
-    hasKey: (_key: string) => {
+    hasKey: (_key: string | undefined) => {
+      if (!_key) return false;
       return duplicateKeyTracker.hasKey(_key);
     },
 


### PR DESCRIPTION
### Added

- Updated the interfaces for `jobState.findEntity` and `jobState.hasKey` to allow `undefined`. Oftentimes, we use optional chaining with `jobState.findEntity` or `jobState.hasKey`, so having the ability to pass `undefined` into these methods can make our code easier to read.

  ```ts
  // without allowing `undefined`, we often need to assert values as `string`
  const virtualMachineId = await jobState.findEntity(
    nic.virtualMachine?.id as string,
  );

  // by allowing `undefined`, we can more safely use these methods without type assertions
  const virtualMachineId = await jobState.findEntity(nic.virtualMachine?.id);
  ```
