### PR TITLE
Explicitly require a _key property when using createIntegrationEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- **\*BREAKING\*** Explicitly require a `_key` property when using
+  `createIntegrationEntity()`. Previously, the `createIntegrationEntity()`
+  function allowed the `_key` property to be _optional_, and when not present,
+  the function automatically uses either `id` or `providerId` as the entity
+  `_key`.
+
+  This caused (entirely preventable) runtime errors if the given `source` data
+  did not have an `id` or `providerId` property available.
+
 ## [7.4.0] - 2021-11-03
 
 ### Changed

--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
@@ -18,7 +18,7 @@ const networkSourceData = {
 };
 
 const networkResourceEntity = {
-  _key: 'natural-identifier',
+  _key: 'azure_vpc_key',
   _class: ['Network'],
   _type: 'azure_vpc',
   _rawData: [{ name: 'default', rawData: networkSourceData }],
@@ -34,6 +34,7 @@ const networkResourceEntity = {
 const networkAssigns = {
   _class: 'Network',
   _type: 'azure_vpc',
+  _key: 'azure_vpc_key',
   public: false,
   internal: true,
 };
@@ -93,40 +94,6 @@ describe('createIntegrationEntity', () => {
     });
     expect(entity).toHaveProperty('active', true);
   });
-
-  test.each(['id', 'providerId'])(
-    'requires _key when %s is not a single string value',
-    (prop) => {
-      expect(() =>
-        createIntegrationEntity({
-          entityData: {
-            assign: networkAssigns,
-            source: {
-              ...networkSourceData,
-              [prop]: ['yodog', 1234],
-            },
-          },
-        }),
-      ).toThrow(/as type string/);
-
-      const entity = createIntegrationEntity({
-        entityData: {
-          assign: {
-            ...networkAssigns,
-            _key: 'assigned-because-id-isnt-usable',
-          },
-          source: {
-            ...networkSourceData,
-            [prop]: ['yodog', 'numbers'],
-          },
-        },
-      });
-
-      expect(entity).toMatchObject({
-        _key: 'assigned-because-id-isnt-usable',
-      });
-    },
-  );
 
   test('should assign createdOn timestamp from creationDate', () => {
     const entity = createIntegrationEntity({

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -219,6 +219,7 @@ describe('addEntities', () => {
     const networkAssigns = {
       _class: 'Network',
       _type: 'azure_vpc',
+      _key: 'azure_vpc_key',
       public: false,
       internal: true,
     };
@@ -269,6 +270,7 @@ describe('addRelationships', () => {
     const networkAssigns = {
       _class: 'Network',
       _type: 'azure_vpc',
+      _key: 'azure_vpc_key',
       public: false,
       internal: true,
     };


### PR DESCRIPTION
This is a quality-of-life improvement that was triggered by a recent failure in the `graph-azure` project, which could have been prevented if `_key` were a required property.

This is a breaking change because integrations that do not already pass a `_key` property will need to explicitly set one now.

```
### Changed

- **\*BREAKING\*** Explicitly require a `_key` property when using
  `createIntegrationEntity()`. Previously, the `createIntegrationEntity()`
  function allowed the `_key` property to be _optional_, and when not present,
  the function automatically uses either `id` or `providerId` as the entity
  `_key`.

  This caused (entirely preventable) runtime errors if the given `source` data
  did not have an `id` or `providerId` property available.
