### PR TITLE
Add loadExecutionConfig hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added the `loadExecutionConfig` lifecycle method to the `InvocationConfig`
+  interface. `loadExecutionConfig` loads shared configuration assets, such as
+  shared API credentials. Example:
+
+  ```ts
+  import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
+
+  /**
+   * The AWS integration uses shared `fromTemporaryCredentials` across all of
+   * its clients.
+   */
+  export function loadExecutionConfig({
+    config: { roleArn: string, externalId: string },
+  }) {
+    return {
+      credentials: fromTemporaryCredentials({
+        params: {
+          RoleArn: config.roleArn,
+          ExternalId: config.externalId,
+          RoleSessionName: `juptierone-${uuid()}`,
+        },
+      }),
+    };
+  }
+  ```
+
 ## [8.1.2] - 2022-01-04
 
 ### Changed

--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -71,7 +71,6 @@ any of these contexts as `context.executionConfig`.
 Example:
 
 ```typescript
-// src/loadExecutionConfig.ts
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { v4 as uuid } from 'uuid';
 
@@ -88,9 +87,13 @@ export function loadExecutionConfig({
     }),
   };
 }
+```
 
+Calling functions may use the loaded `executionConfig` like so:
+
+```ts
 // -----------------------------------------------------------------------------
-// src/steps/ec2/client.ts
+// client.ts
 import { EC2Client, DescribeVpcsCommand, Vpc } from '@aws-sdk/client-ec2';
 
 export class J1Ec2Client {
@@ -113,7 +116,7 @@ export class J1Ec2Client {
 }
 
 // -----------------------------------------------------------------------------
-// src/steps/ec2/index.ts
+// index.ts
 import { J1Ec2Client } from './client';
 import { createVpcEntity } from './converters';
 import { Ec2Entities } from './constants';

--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -58,6 +58,88 @@ Example:
 }
 ```
 
+#### `loadExecutionConfig`
+
+The `loadExecutionConfig` method loads any config assets that should be used
+across multiple steps. This method is most often used to create shared
+credentials for API clients.
+
+The `loadExecutionConfig` method runs before `validateInvocation`,
+`getStepStartStates`, and `integrationSteps`. The loaded config is accessable in
+any of these contexts as `context.executionConfig`.
+
+Example:
+
+```typescript
+// src/loadExecutionConfig.ts
+import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
+import { v4 as uuid } from 'uuid';
+
+export function loadExecutionConfig({
+  config: { roleArn: string, externalId: string },
+}) {
+  return {
+    credentials: fromTemporaryCredentials({
+      params: {
+        RoleArn: config.roleArn,
+        ExternalId: config.externalId,
+        RoleSessionName: `juptierone-${uuid()}`,
+      },
+    }),
+  };
+}
+
+// -----------------------------------------------------------------------------
+// src/steps/ec2/client.ts
+import { EC2Client, DescribeVpcsCommand, Vpc } from '@aws-sdk/client-ec2';
+
+export class J1Ec2Client {
+  private ec2: Ec2Client;
+  constructor(credentials: ProviderCredentials) {
+    this.ec2 = new Ec2Client({ credentials });
+  }
+
+  public async iterateVpcs(iteratee: (vpc: Vpc) => Promise<void>) {
+    do {
+      const response = await this.ec2.send(new DescribeVpcsCommand({}));
+      if (response.Vpcs) {
+        for (const vpc of response.Vpcs) {
+          await iteratee(vpc);
+        }
+      }
+      nextToken = response.NextToken;
+    } while (nextToken);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// src/steps/ec2/index.ts
+import { J1Ec2Client } from './client';
+import { createVpcEntity } from './converters';
+import { Ec2Entities } from './constants';
+
+function fetchVpcs({
+  jobState,
+  executionConfig,
+}: IntegrationStepExecutionContext<IntegrationConfig>) {
+  const { credentials } = executionConfig;
+  const client = new J1Ec2Client(credentials);
+  await client.iterateVpcs(async (vpc) =>
+    jobState.addEntity(createVpcEntity(vpc)),
+  );
+}
+
+export const ec2Steps = [
+  {
+    id: 'fetch-vpcs',
+    name: 'Fetch EC2 VPCs',
+    entities: [Ec2Entities.VPC],
+    relationships: [],
+    executionHandler: fetchVpcs,
+  },
+];
+```
+
 #### `validateInvocation`
 
 The `validateInvocation` field is a validation function that is required for

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -1,7 +1,4 @@
-import {
-  IntegrationInstanceConfig,
-  IntegrationExecutionConfig,
-} from './instance';
+import { IntegrationInstanceConfig } from './instance';
 import { GetStepStartStatesFunction, Step } from './step';
 import { InvocationValidationFunction } from './validation';
 import {
@@ -9,6 +6,7 @@ import {
   IntegrationExecutionContext,
   StepExecutionContext,
   IntegrationStepExecutionContext,
+  IntegrationExecutionConfig,
 } from './context';
 import { Entity } from './entity';
 

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -1,4 +1,7 @@
-import { IntegrationInstanceConfig } from './instance';
+import {
+  IntegrationInstanceConfig,
+  IntegrationExecutionConfig,
+} from './instance';
 import { GetStepStartStatesFunction, Step } from './step';
 import { InvocationValidationFunction } from './validation';
 import {
@@ -24,6 +27,11 @@ export type BeforeAddEntityHookFunction<
   TExecutionContext extends ExecutionContext
 > = (context: TExecutionContext, entity: Entity) => Entity;
 
+export type LoadExecutionConfigFunction<
+  TInstanceConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,
+  TExecutionConfig extends IntegrationExecutionConfig = IntegrationExecutionConfig
+> = (options: { config: TInstanceConfig }) => TExecutionConfig;
+
 export interface InvocationConfig<
   TExecutionContext extends ExecutionContext,
   TStepExecutionContext extends StepExecutionContext
@@ -33,11 +41,12 @@ export interface InvocationConfig<
   integrationSteps: Step<TStepExecutionContext>[];
   normalizeGraphObjectKey?: KeyNormalizationFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
+  loadExecutionConfig?: LoadExecutionConfigFunction;
   /**
    * An optional array of identifiers used to execute dependency
    * graphs in a specific order. These values should match the
    * StepMetadata `dependencyGraphId` prpoperties.
-   * 
+   *
    * If this is not provided, all steps will be evalueted in
    * the same dependency graph.
    */
@@ -46,8 +55,7 @@ export interface InvocationConfig<
 
 export interface IntegrationInvocationConfig<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
->
-  extends InvocationConfig<
+> extends InvocationConfig<
     IntegrationExecutionContext<TConfig>,
     IntegrationStepExecutionContext<TConfig>
   > {

--- a/packages/integration-sdk-core/src/types/context.ts
+++ b/packages/integration-sdk-core/src/types/context.ts
@@ -1,4 +1,8 @@
-import { IntegrationInstance, IntegrationInstanceConfig } from './instance';
+import {
+  IntegrationInstance,
+  IntegrationInstanceConfig,
+  IntegrationExecutionConfig,
+} from './instance';
 import { JobState } from './jobState';
 import { IntegrationLogger } from './logger';
 
@@ -22,10 +26,17 @@ export interface ExecutionContext {
  * @param TConfig the integration specific type of the `instance.config`
  * property
  */
-export type IntegrationExecutionContext<
-  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+export type IntegrationLoadExecutionConfigContext<
+  TConfig extends IntegrationInstanceConfig
 > = ExecutionContext & {
   instance: IntegrationInstance<TConfig>;
+};
+
+export type IntegrationExecutionContext<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,
+  TExecutionConfig extends IntegrationExecutionConfig = IntegrationExecutionConfig,
+> = IntegrationLoadExecutionConfigContext<TConfig> & {
+  executionConfig: TExecutionConfig;
 };
 
 export type StepExecutionContext = ExecutionContext & {
@@ -37,5 +48,7 @@ export type StepExecutionContext = ExecutionContext & {
  * property
  */
 export interface IntegrationStepExecutionContext<
-  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> extends IntegrationExecutionContext<TConfig>, StepExecutionContext {}
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,
+  TExecutionConfig extends IntegrationExecutionConfig = IntegrationExecutionConfig
+> extends IntegrationExecutionContext<TConfig, TExecutionConfig>,
+    StepExecutionContext {}

--- a/packages/integration-sdk-core/src/types/context.ts
+++ b/packages/integration-sdk-core/src/types/context.ts
@@ -1,8 +1,4 @@
-import {
-  IntegrationInstance,
-  IntegrationInstanceConfig,
-  IntegrationExecutionConfig,
-} from './instance';
+import { IntegrationInstance, IntegrationInstanceConfig } from './instance';
 import { JobState } from './jobState';
 import { IntegrationLogger } from './logger';
 
@@ -23,6 +19,14 @@ export interface ExecutionContext {
 }
 
 /**
+ * A configuration object constructed by an integration just before the
+ * integration is executed. This is distinct from the
+ * `IntegrationInstanceConfig`, containing dynamic values perhaps calculated
+ * based on the instance config.
+ */
+export type IntegrationExecutionConfig = Record<string, any>;
+
+/**
  * @param TConfig the integration specific type of the `instance.config`
  * property
  */
@@ -32,9 +36,15 @@ export type IntegrationLoadExecutionConfigContext<
   instance: IntegrationInstance<TConfig>;
 };
 
+/**
+ * @param TConfig the integration specific type of the `instance.config`
+ * property
+ * @param TExecutionConfig the configuration type produced by the
+ * integration's optional `loadExecutionConfig` function
+ */
 export type IntegrationExecutionContext<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,
-  TExecutionConfig extends IntegrationExecutionConfig = IntegrationExecutionConfig,
+  TExecutionConfig extends IntegrationExecutionConfig = IntegrationExecutionConfig
 > = IntegrationLoadExecutionConfigContext<TConfig> & {
   executionConfig: TExecutionConfig;
 };
@@ -46,6 +56,8 @@ export type StepExecutionContext = ExecutionContext & {
 /**
  * @param TConfig the integration specific type of the `instance.config`
  * property
+ * @param TExecutionConfig the configuration type produced by the
+ * integration's optional `loadExecutionConfig` function
  */
 export interface IntegrationStepExecutionContext<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,

--- a/packages/integration-sdk-core/src/types/context.ts
+++ b/packages/integration-sdk-core/src/types/context.ts
@@ -24,7 +24,7 @@ export interface ExecutionContext {
  * `IntegrationInstanceConfig`, containing dynamic values perhaps calculated
  * based on the instance config.
  */
-export type IntegrationExecutionConfig = Record<string, any>;
+export type IntegrationExecutionConfig = object;
 
 /**
  * @param TConfig the integration specific type of the `instance.config`

--- a/packages/integration-sdk-core/src/types/instance.ts
+++ b/packages/integration-sdk-core/src/types/instance.ts
@@ -1,7 +1,5 @@
 export type IntegrationInstanceConfig = Record<string, any>;
 
-export type IntegrationExecutionConfig = Record<string, any>;
-
 /**
  * A stored user configuration for executing the integration defined by
  * the associated `integrationDefinitionId`.

--- a/packages/integration-sdk-core/src/types/instance.ts
+++ b/packages/integration-sdk-core/src/types/instance.ts
@@ -1,5 +1,7 @@
 export type IntegrationInstanceConfig = Record<string, any>;
 
+export type IntegrationExecutionConfig = Record<string, any>;
+
 /**
  * A stored user configuration for executing the integration defined by
  * the associated `integrationDefinitionId`.

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -50,6 +50,7 @@ const executionContext: IntegrationExecutionContext = {
     },
   }),
   instance: LOCAL_INTEGRATION_INSTANCE,
+  executionConfig: {},
   executionHistory: {
     current: {
       startedOn: Date.now(),

--- a/packages/integration-sdk-runtime/src/execution/__tests__/executeIntegration.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/executeIntegration.test.ts
@@ -45,9 +45,7 @@ function sleep(ms: number) {
 export interface InstanceConfigurationData<
   TIntegrationConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
 > {
-  validateInvocation: IntegrationInvocationValidationFunction<
-    TIntegrationConfig
-  >;
+  validateInvocation: IntegrationInvocationValidationFunction<TIntegrationConfig>;
   instance: IntegrationInstance<TIntegrationConfig>;
   invocationConfig: IntegrationInvocationConfig<TIntegrationConfig>;
   logger: IntegrationLogger;
@@ -99,9 +97,35 @@ describe('executeIntegrationInstance', () => {
           startedOn: executionStartedOn,
         },
       },
+      executionConfig: {},
     };
 
     expect(config.validateInvocation).toHaveBeenCalledWith(expectedContext);
+  });
+
+  test('should load executionConfig if loadExecutionConfig provided in config', async () => {
+    const config = createInstanceConfiguration({
+      invocationConfig: {
+        integrationSteps: [],
+        loadExecutionConfig: ({ config: instanceConfig }) => ({
+          sharedCredentials: { instanceConfig },
+        }),
+      },
+    });
+
+    const loadExecutionConfigSpy = jest.spyOn(
+      config.invocationConfig,
+      'loadExecutionConfig',
+    );
+
+    await executeIntegrationInstanceWithConfig(config);
+
+    expect(loadExecutionConfigSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ config: config.instance.config }),
+    );
+    expect(loadExecutionConfigSpy).toHaveReturnedWith({
+      sharedCredentials: { instanceConfig: config.instance.config },
+    });
   });
 
   test('logs validation error if validation fails', async () => {
@@ -195,11 +219,10 @@ describe('executeIntegrationInstance', () => {
   });
 
   test('runs multiple dependency graphs in order and returns integration step results and metadata about partial datasets', async () => {
-
-    const firstStepExecutionHandler = jest.fn()
-    const secondStepExecutionHandler = jest.fn()
-    const thirdStepExecutionHandler = jest.fn()
-    const fourthStepExecutionHandler = jest.fn()
+    const firstStepExecutionHandler = jest.fn();
+    const secondStepExecutionHandler = jest.fn();
+    const thirdStepExecutionHandler = jest.fn();
+    const fourthStepExecutionHandler = jest.fn();
 
     const config = createInstanceConfiguration({
       invocationConfig: {
@@ -230,7 +253,7 @@ describe('executeIntegrationInstance', () => {
             ],
             relationships: [],
             executionHandler: firstStepExecutionHandler,
-            dependencyGraphId: undefined // defaults to going first
+            dependencyGraphId: undefined, // defaults to going first
           },
           {
             id: 'my-second-step',
@@ -244,7 +267,7 @@ describe('executeIntegrationInstance', () => {
             ],
             relationships: [],
             executionHandler: secondStepExecutionHandler,
-            dependencyGraphId: '1'
+            dependencyGraphId: '1',
           },
           {
             id: 'depends-on-second-step',
@@ -258,11 +281,11 @@ describe('executeIntegrationInstance', () => {
             ],
             relationships: [],
             executionHandler: thirdStepExecutionHandler,
-            dependsOn: ['my-second-step'], 
-            dependencyGraphId: '1'
+            dependsOn: ['my-second-step'],
+            dependencyGraphId: '1',
           },
         ],
-        dependencyGraphOrder: ['1', '2']
+        dependencyGraphOrder: ['1', '2'],
       },
     });
 
@@ -311,9 +334,15 @@ describe('executeIntegrationInstance', () => {
       },
     );
 
-    expect(firstStepExecutionHandler).toHaveBeenCalledBefore(secondStepExecutionHandler)
-    expect(secondStepExecutionHandler).toHaveBeenCalledBefore(thirdStepExecutionHandler)
-    expect(thirdStepExecutionHandler).toHaveBeenCalledBefore(fourthStepExecutionHandler)
+    expect(firstStepExecutionHandler).toHaveBeenCalledBefore(
+      secondStepExecutionHandler,
+    );
+    expect(secondStepExecutionHandler).toHaveBeenCalledBefore(
+      thirdStepExecutionHandler,
+    );
+    expect(thirdStepExecutionHandler).toHaveBeenCalledBefore(
+      fourthStepExecutionHandler,
+    );
   });
 
   test('compresses files when INTEGRATION_FILE_COMPRESSION_ENABLED is set', async () => {
@@ -1090,9 +1119,7 @@ describe('executeIntegrationInstance', () => {
       expectedResults,
     );
 
-    const writtenSummary = await integrationFileSystem.readJsonFromPath<
-      ExecuteIntegrationResult
-    >(
+    const writtenSummary = await integrationFileSystem.readJsonFromPath<ExecuteIntegrationResult>(
       path.resolve(
         integrationFileSystem.getRootStorageDirectory(),
         'summary.json',
@@ -1186,9 +1213,7 @@ describe('executeIntegrationInstance', () => {
       expectedResults,
     );
 
-    const writtenSummary = await integrationFileSystem.readJsonFromPath<
-      ExecuteIntegrationResult
-    >(
+    const writtenSummary = await integrationFileSystem.readJsonFromPath<ExecuteIntegrationResult>(
       path.resolve(
         integrationFileSystem.getRootStorageDirectory(),
         'summary.json',
@@ -1471,6 +1496,7 @@ describe('executeIntegrationLocally', () => {
           startedOn: executionStartedOn,
         },
       },
+      executionConfig: {},
     };
 
     expect(validateInvocation).toHaveBeenCalledWith(expectedContext);

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -107,6 +107,10 @@ export async function executeIntegrationInstance<
   if (options.enableSchemaValidation === true) {
     process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION = 'true';
   }
+  const instanceWithTrimmedConfig = trimStringValues(
+    instance,
+    getMaskedFields(config),
+  );
 
   return timeOperation({
     logger,
@@ -114,9 +118,11 @@ export async function executeIntegrationInstance<
     operation: () =>
       executeWithContext(
         {
-          instance: trimStringValues(instance, getMaskedFields(config)),
+          instance: instanceWithTrimmedConfig,
           logger,
           executionHistory,
+          executionConfig:
+            config.loadExecutionConfig?.(instanceWithTrimmedConfig) || {},
         },
         config,
         options,
@@ -225,7 +231,7 @@ export async function executeWithContext<
       dataStore: new MemoryDataStore(),
       createStepGraphObjectDataUploader,
       beforeAddEntity: config.beforeAddEntity,
-      dependencyGraphOrder: config.dependencyGraphOrder
+      dependencyGraphOrder: config.dependencyGraphOrder,
     });
 
     const partialDatasets = determinePartialDatasetsFromStepExecutionResults(

--- a/packages/integration-sdk-testing/src/context.ts
+++ b/packages/integration-sdk-testing/src/context.ts
@@ -82,6 +82,7 @@ export function createMockExecutionContext<
   return {
     logger,
     instance,
+    executionConfig: {},
     executionHistory: options.executionHistory || {
       current: {
         startedOn: Date.now(),


### PR DESCRIPTION
### Added

- Added the `loadExecutionConfig` lifecycle method to the `InvocationConfig`
  interface. `loadExecutionConfig` loads shared configuration assets, such as
  shared API credentials. Example:

  ```ts
  import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';

  /**
   * The AWS integration uses shared `fromTemporaryCredentials` across all of
   * its clients.
   */
  export function loadExecutionConfig({
    config: { roleArn: string, externalId: string },
  }) {
    return {
      credentials: fromTemporaryCredentials({
        params: {
          RoleArn: config.roleArn,
          ExternalId: config.externalId,
          RoleSessionName: `juptierone-${uuid()}`,
        },
      }),
    };
  }
  ```

---

See `docs/integrations.md` for more on using `loadExecutionConfig`: https://github.com/JupiterOne/sdk/blob/add-execution-config/docs/integrations/development.md#loadexecutionconfig