### PR TITLE
Add executeStepWithDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ and this project adheres to
 
 ### Added
 
+- Added `executeStepWithDependencies` utility to
+  `@jupiterone/integration-sdk-testing` package. This allows developers to test
+  specific integration steps in isolation, while assuring that all of its
+  dependencies have indeed executed. Usage:
+
+  ```ts
+  const {
+    collectedEntities,
+    collectedRelationships,
+    collectedData,
+  } = await executeStepWithDependencies({
+    stepId: Steps.FETCH_USERS.id,
+    invocationConfig,
+    instanceConfig,
+  });
+
+  expect(collectedEntities.length).toBeGreaterThan(0);
+  expect(collectedEnities).toMatchGraphObjectSchema({
+    _class: Entities.USER._class,
+    schema: Entities.USER.schema,
+  });
+  // ... additional expectations
+  ```
+
 - Added `MockJobState.collectedData` to capture data that has been collected in
   the job state. Usage:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added `MockJobState.collectedData` to capture data that has been collected in
+  the job state. Usage:
+
+  ```ts
+  const jobState = createMockJobState({
+    setData: { existingKey: 'existing-value' },
+  });
+  await executeStepThatAddsAccountEntity();
+
+  expect(jobState.collectedData).toEqual({
+    ACCOUNT_ENTITY: {
+      _type: 'account',
+      _class: 'Account',
+      _key: 'account1',
+    },
+  });
+  expect(jobState.collectedData.existingKey).toBeUndefined();
+  ```
+
 ## [8.3.2] - 2022-02-09
 
 ### Added

--- a/packages/integration-sdk-testing/src/__tests__/executeStepWithDependencies.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/executeStepWithDependencies.test.ts
@@ -1,0 +1,233 @@
+import {
+  createDirectRelationship,
+  Entity,
+  IntegrationInstanceConfig,
+  IntegrationInvocationConfig,
+  IntegrationStep,
+  Relationship,
+  RelationshipClass,
+} from '@jupiterone/integration-sdk-core';
+import { v4 as uuid } from 'uuid';
+import { executeStepWithDependencies } from '../executeStepWithDependencies';
+
+function getMockInvocationConfig(
+  config?: Partial<IntegrationInvocationConfig>,
+): IntegrationInvocationConfig {
+  return {
+    integrationSteps: [],
+    ...config,
+  };
+}
+
+function getMockIntegrationStep(
+  config?: Partial<IntegrationStep>,
+): IntegrationStep {
+  return {
+    id: 'id',
+    name: 'name',
+    entities: [],
+    relationships: [],
+    executionHandler: () => undefined,
+    ...config,
+  };
+}
+
+function getMockInstanceConfig(
+  config?: Partial<IntegrationInstanceConfig>,
+): IntegrationInstanceConfig {
+  return {
+    ...config,
+  };
+}
+
+function getMockEntity(e?: Partial<Entity>): Entity {
+  return {
+    _class: 'Record',
+    _type: 'entity-type',
+    _key: uuid(),
+    ...e,
+  };
+}
+
+describe('executeStepWithDependencies', () => {
+  describe('invalid step', () => {
+    test('should fail if step `id` property does not exist in dependency graph', async () => {
+      await expect(
+        executeStepWithDependencies({
+          stepId: 'invalid-id',
+          invocationConfig: getMockInvocationConfig({
+            integrationSteps: [getMockIntegrationStep({ id: 'valid-id' })],
+          }),
+          instanceConfig: getMockInstanceConfig(),
+        }),
+      ).rejects.toThrow('Node does not exist: invalid-id');
+    });
+  });
+
+  describe('invalid invocationConfig', () => {
+    test('should fail if invocationConfig `dependencyGraphOrder` property is present', async () => {
+      await expect(
+        executeStepWithDependencies({
+          stepId: 'step-1',
+          invocationConfig: getMockInvocationConfig({
+            dependencyGraphOrder: [],
+          }),
+          instanceConfig: getMockInstanceConfig(),
+        }),
+      ).rejects.toThrow(
+        'executeStepWithDependencies does not currently support dependencyGraphOrder',
+      );
+    });
+
+    test('should fail if invocationConfig contains circular dependency', async () => {
+      await expect(
+        executeStepWithDependencies({
+          stepId: 'step-1',
+          invocationConfig: getMockInvocationConfig({
+            integrationSteps: [
+              getMockIntegrationStep({ id: 'step-1', dependsOn: ['step-2'] }),
+              getMockIntegrationStep({ id: 'step-2', dependsOn: ['step-1'] }),
+            ],
+          }),
+          instanceConfig: getMockInstanceConfig(),
+        }),
+      ).rejects.toThrow('Dependency Cycle Found: step-1 -> step-2 -> step-1');
+    });
+  });
+
+  describe('success', () => {
+    test('should return entities, relationships, and data', async () => {
+      const e1 = getMockEntity();
+      const e2 = getMockEntity();
+
+      const r1 = createDirectRelationship({
+        from: e1,
+        _class: RelationshipClass.HAS,
+        to: e2,
+      });
+
+      const d1 = { key: 'value' };
+
+      const stepOne = getMockIntegrationStep({
+        id: 'step-1',
+        executionHandler: async ({ jobState }) => {
+          await jobState.addEntity(e1);
+          await jobState.addEntity(e2);
+          await jobState.addRelationship(r1);
+          await jobState.setData(Object.keys(d1)[0], Object.values(d1)[0]);
+        },
+      });
+
+      await expect(
+        executeStepWithDependencies({
+          stepId: stepOne.id,
+          invocationConfig: getMockInvocationConfig({
+            integrationSteps: [stepOne],
+          }),
+          instanceConfig: getMockInstanceConfig(),
+        }),
+      ).resolves.toMatchObject({
+        collectedEntities: [e1, e2],
+        collectedRelationships: [r1],
+        collectedData: d1,
+      });
+    });
+
+    test('should not expose entities or relationships from previous steps', async () => {
+      const entityType = 'entity-type';
+      const e1 = getMockEntity({ _type: entityType });
+      const e2 = getMockEntity({ _type: entityType });
+
+      const relationshipType = 'relationship-type';
+      const r1 = createDirectRelationship({
+        from: e1,
+        _class: RelationshipClass.HAS,
+        to: e2,
+        properties: { _type: relationshipType },
+      });
+
+      const stepOne = getMockIntegrationStep({
+        id: 'step-1',
+        executionHandler: async ({ jobState }) => {
+          await jobState.addEntity(e1);
+          await jobState.addEntity(e2);
+          await jobState.addRelationship(r1);
+        },
+      });
+
+      let stepTwoExecutionHandlerDidExecute = false;
+      const stepTwo = getMockIntegrationStep({
+        id: 'step-2',
+        dependsOn: ['step-1'],
+        executionHandler: async ({ jobState }) => {
+          const entities: Entity[] = [];
+          await jobState.iterateEntities({ _type: entityType }, (e) => {
+            entities.push(e);
+          });
+          expect(entities).toMatchObject([e1, e2]);
+          const relationships: Relationship[] = [];
+          await jobState.iterateRelationships(
+            { _type: relationshipType },
+            (r) => {
+              relationships.push(r);
+            },
+          );
+          expect(relationships).toMatchObject([r1]);
+          stepTwoExecutionHandlerDidExecute = true;
+        },
+      });
+
+      await expect(
+        executeStepWithDependencies({
+          stepId: stepTwo.id,
+          invocationConfig: getMockInvocationConfig({
+            integrationSteps: [stepOne, stepTwo],
+          }),
+          instanceConfig: getMockInstanceConfig(),
+        }),
+      ).resolves.toMatchObject({
+        collectedEntities: [],
+        collectedRelationships: [],
+      });
+
+      expect(stepTwoExecutionHandlerDidExecute).toBe(true);
+    });
+
+    test('should allow step to access data from previous step', async () => {
+      const setDataKey = 'set-data-key';
+      const setDataValue = 'set-data-value';
+      const stepOne = getMockIntegrationStep({
+        id: 'step-1',
+        executionHandler: async ({ jobState }) => {
+          await jobState.setData(setDataKey, setDataValue);
+        },
+      });
+
+      let stepTwoExecutionHandlerDidExecute = false;
+      const stepTwo = getMockIntegrationStep({
+        id: 'step-2',
+        dependsOn: ['step-1'],
+        executionHandler: async ({ jobState }) => {
+          const getDataValue = await jobState.getData(setDataKey);
+          expect(getDataValue).toBe(setDataValue);
+          stepTwoExecutionHandlerDidExecute = true;
+        },
+      });
+
+      await expect(
+        executeStepWithDependencies({
+          stepId: stepTwo.id,
+          invocationConfig: getMockInvocationConfig({
+            integrationSteps: [stepOne, stepTwo],
+          }),
+          instanceConfig: getMockInstanceConfig(),
+        }),
+      ).resolves.toMatchObject({
+        collectedEntities: [],
+        collectedRelationships: [],
+      });
+
+      expect(stepTwoExecutionHandlerDidExecute).toBe(true);
+    });
+  });
+});

--- a/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
@@ -32,6 +32,21 @@ describe('data', () => {
     await jobState.deleteData('my-key');
     await expect(jobState.getData('my-key')).resolves.toEqual(undefined);
   });
+
+  describe('collectedData', () => {
+    test('should return collectedData', async () => {
+      const jobState = createMockJobState();
+      await jobState.setData('my-key', 'whatever');
+      expect(jobState.collectedData).toEqual({ 'my-key': 'whatever' });
+    });
+
+    test('should not include pre-existing relationships in collectedData', () => {
+      const jobState = createMockJobState({
+        setData: { 'my-key': 'whatever' },
+      });
+      expect(jobState.collectedData).toEqual({});
+    });
+  });
 });
 
 describe('entities', () => {

--- a/packages/integration-sdk-testing/src/executeStepWithDependencies.ts
+++ b/packages/integration-sdk-testing/src/executeStepWithDependencies.ts
@@ -1,0 +1,70 @@
+import {
+  IntegrationExecutionConfig,
+  IntegrationInstanceConfig,
+  IntegrationInvocationConfig,
+} from '@jupiterone/integration-sdk-core';
+import { buildStepDependencyGraph } from '@jupiterone/integration-sdk-runtime';
+import {
+  createMockStepExecutionContext,
+  MockIntegrationStepExecutionContext,
+} from './context';
+
+export async function executeStepWithDependencies(params: {
+  stepId: string;
+  invocationConfig: Pick<
+    IntegrationInvocationConfig,
+    'integrationSteps' | 'loadExecutionConfig' | 'dependencyGraphOrder'
+  >;
+  instanceConfig: IntegrationInstanceConfig;
+}) {
+  const { stepId, invocationConfig, instanceConfig } = params;
+
+  if (invocationConfig.dependencyGraphOrder) {
+    throw new Error(
+      'executeStepWithDependencies does not currently support dependencyGraphOrder',
+    );
+  }
+
+  const stepDependencyGraph = buildStepDependencyGraph(
+    invocationConfig.integrationSteps,
+  );
+
+  const dependencyStepIds = stepDependencyGraph.dependenciesOf(stepId);
+
+  const executionConfig = invocationConfig.loadExecutionConfig
+    ? invocationConfig.loadExecutionConfig({ config: instanceConfig })
+    : {};
+  const preContext: MockIntegrationStepExecutionContext & {
+    executionConfig: IntegrationExecutionConfig;
+  } = {
+    ...createMockStepExecutionContext({ instanceConfig }),
+    executionConfig,
+  };
+
+  for (const dependencyStepId of dependencyStepIds) {
+    const dependencyStep = stepDependencyGraph.getNodeData(dependencyStepId);
+    await dependencyStep.executionHandler(preContext);
+  }
+
+  const context: MockIntegrationStepExecutionContext & {
+    executionConfig: IntegrationExecutionConfig;
+  } = {
+    ...createMockStepExecutionContext({
+      instanceConfig,
+      entities: preContext.jobState.collectedEntities,
+      relationships: preContext.jobState.collectedRelationships,
+      setData: preContext.jobState.collectedData,
+    }),
+    executionConfig,
+  };
+
+  const { executionHandler } = stepDependencyGraph.getNodeData(stepId);
+  await executionHandler(context);
+
+  return {
+    collectedEntities: context.jobState.collectedEntities,
+    collectedRelationships: context.jobState.collectedRelationships,
+    collectedData: context.jobState.collectedData,
+    encounteredTypes: context.jobState.encounteredTypes,
+  };
+}

--- a/packages/integration-sdk-testing/src/index.ts
+++ b/packages/integration-sdk-testing/src/index.ts
@@ -1,4 +1,5 @@
 export * from './context';
+export * from './executeStepWithDependencies';
 export * from './logger';
 export * from './recording';
 export * from './jobState';

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -25,6 +25,7 @@ export interface CreateMockJobStateOptions {
 export interface MockJobState extends JobState {
   collectedEntities: Entity[];
   collectedRelationships: Relationship[];
+  collectedData: { [key: string]: any };
   encounteredTypes: string[];
 }
 
@@ -44,6 +45,7 @@ export function createMockJobState({
 }: CreateMockJobStateOptions = {}): MockJobState {
   let collectedEntities: Entity[] = [];
   let collectedRelationships: Relationship[] = [];
+  const collectedData: { [key: string]: any } = {};
 
   const duplicateKeyTracker = new DuplicateKeyTracker(normalizeGraphObjectKey);
   const typeTracker = new TypeTracker();
@@ -135,12 +137,17 @@ export function createMockJobState({
       return collectedRelationships;
     },
 
+    get collectedData() {
+      return collectedData;
+    },
+
     get encounteredTypes() {
       return typeTracker.getAllEncounteredTypes();
     },
 
     setData: async <T>(key: string, data: T): Promise<void> => {
       dataStore.set(key, data);
+      collectedData[key] = data;
       return Promise.resolve();
     },
 


### PR DESCRIPTION
Bringing this functionality in from `graph-aws`.

See usage in `graph-aws`: https://github.com/JupiterOne/graph-aws/blob/main/src/steps/services/ec2/executionHandlers/ec2Service.test.ts#L10

```ts

import { integrationConfig } from '../../../../../test/config';
import { EC2Relationships, EC2Entities, EC2Steps } from '../constants';
import { invocationConfig } from '../../../..';
import { executeStepWithDependencies } from '../../../../../test/executeStepWithDependencies';

test('createEc2Service exec handler', async () => {
  const {
    collectedEntities,
    collectedRelationships,
  } = await executeStepWithDependencies({
    stepId: EC2Steps.CREATE_EC2_SERVICE.id,
    invocationConfig: invocationConfig as any,
    instanceConfig: integrationConfig,
  });

  expect(collectedEntities.length).toEqual(1);
  expect(collectedEntities).toMatchGraphObjectSchema(
    EC2Entities.AWS_EC2_SERVICE,
  );

  expect(collectedRelationships.length).toEqual(1);
  expect(collectedRelationships).toMatchDirectRelationshipSchema({
    schema: {
      properties: {
        _type: {
          const: EC2Relationships.AWS_ACCOUNT_HAS_EC2_SERVICE._type,
        },
      },
    },
  });
});
```