### PR TITLE
Add optional `schema` property to graph object metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to
 
 ### Added
 
+- Added optional `schema` property to `StepGraphObjectMetadata`. This allows
+  developers to provide the property schema to expect on entities,
+  relationships, and mapped relationships. This serves two uses:
+  1. Schemas can be used at runtime or test-time to verify that an entity has
+     the correct properties
+  2. The `j1-integration document` command could automatically produce consumer
+     documentation about the properties that an entity / relationship is
+     expected to have
 - Added `executeStepWithDependencies` utility to
   `@jupiterone/integration-sdk-testing` package. This allows developers to test
   specific integration steps in isolation, while assuring that all of its

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -95,7 +95,14 @@ export interface StepGraphObjectMetadata {
   _type: string;
 
   /**
-   * The schema used to describe the properties assigned to this entity
+   * An optional extension to the JSON schemas defined by the `_class` of this entity
+   * in the @jupiterone/data-model.
+   *
+   * Extensions defined by this schema are in addition to the schemas referenced by the
+   * `_class` values of the entity. These should be considered unique properties for
+   * this integration. Ask yourself, should a property here be considered for promotion
+   * to the @jupiterone/data-model to benefit normalization of all integrations producing
+   * this class of entity?
    */
   schema?: GraphObjectSchema;
 

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -1,4 +1,7 @@
-import { RelationshipClass } from '@jupiterone/data-model';
+import {
+  RelationshipClass,
+  IntegrationEntitySchema,
+} from '@jupiterone/data-model';
 
 import {
   ExecutionContext,
@@ -81,8 +84,20 @@ export interface GraphObjectIndexMetadata {
   enabled: boolean;
 }
 
+export interface GraphObjectSchema extends IntegrationEntitySchema {
+  $schema?: string;
+  $id?: string;
+  description?: string;
+  additionalProperties?: boolean;
+}
+
 export interface StepGraphObjectMetadata {
   _type: string;
+
+  /**
+   * The schema used to describe the properties assigned to this entity
+   */
+  schema?: GraphObjectSchema;
 
   /**
    * Indicates the set of data represented by this `_type` should always be

--- a/packages/integration-sdk-testing/src/__tests__/jest.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jest.test.ts
@@ -3,6 +3,7 @@ import {
   createMappedRelationship,
   Entity,
   ExplicitRelationship,
+  GraphObjectSchema,
   IntegrationInvocationConfig,
   IntegrationSpecConfig,
   RelationshipClass,
@@ -11,7 +12,6 @@ import {
   toMatchGraphObjectSchema,
   toMatchDirectRelationshipSchema,
   toTargetEntities,
-  GraphObjectSchema,
   registerMatchers,
   toImplementSpec,
 } from '../jest';

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -3,6 +3,7 @@ import * as deepmerge from 'deepmerge';
 import {
   Entity,
   ExplicitRelationship,
+  GraphObjectSchema,
   IntegrationInstanceConfig,
   IntegrationInvocationConfig,
   IntegrationSpecConfig,
@@ -220,13 +221,6 @@ function generateGraphObjectSchemaFromDataModelSchemas(
 
 function graphObjectClassToSchemaRef(_class: string) {
   return `#${_class}`;
-}
-
-export interface GraphObjectSchema extends dataModel.IntegrationEntitySchema {
-  $schema?: string;
-  $id?: string;
-  description?: string;
-  additionalProperties?: boolean;
 }
 
 export interface ToMatchGraphObjectSchemaParams {


### PR DESCRIPTION
### Added

- Added optional `schema` property to `StepGraphObjectMetadata`. This allows
  developers to provide the property schema to expect on entities,
  relationships, and mapped relationships. This serves two uses:
  1. Schemas can be used at runtime or test-time to verify that an entity has
     the correct properties
  2. The `j1-integration document` command could automatically produce consumer
     documentation about the properties that an entity / relationship is
     expected to have