### PR TITLE
Fix #629 - Neo4j store create relationships using `_class` as the label

### DIFF
--- a/packages/integration-sdk-cli/src/neo4j/neo4jGraphStore.ts
+++ b/packages/integration-sdk-cli/src/neo4j/neo4jGraphStore.ts
@@ -121,7 +121,7 @@ export class Neo4jGraphStore {
       const buildCommand = `
       MERGE (start {_key: $startEntityKey, _integrationInstanceID: $integrationInstanceID})
       MERGE (end {_key: $endEntityKey, _integrationInstanceID: $integrationInstanceID})
-      MERGE (start)-[${relationshipAlias}:${relationship._type}]->(end)
+      MERGE (start)-[${relationshipAlias}:${relationship._class}]->(end)
       SET ${relationshipAlias} += $propertyParameters;`;
       await this.runCypherCommand(buildCommand, {
         propertyParameters: propertyParameters,


### PR DESCRIPTION
## Example

> Which GitHub repositories are accessible to outside collaborators?

Old query:

```cy
MATCH (n:github_repo)-[r:github_repo_allows_user]->(u:github_user{role:"OUTSIDE"})
RETURN n, u
```

![Screen Shot 2022-02-19 at 9 44 35 AM](https://user-images.githubusercontent.com/3771924/154808136-f2813157-8071-4c1f-868d-6c30a352f7ea.png)

New query:

```cy
MATCH (n:github_repo)-[ALLOWS]->(u:github_user{role:"OUTSIDE"})
RETURN n, u
```

![Screen Shot 2022-02-19 at 9 44 17 AM](https://user-images.githubusercontent.com/3771924/154808140-683cd79c-55f3-48b6-a07f-c045f55b0332.png)
