### PR TITLE
Fix #638 - Support Neo4j entity ingestion with `false` property values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to
 
 ## Unreleased
 
+## [8.4.4] - 2022-02-22
+
+Fix #638 - The Neo4j ingestion tool was ignoring properties with the value
+`false`.
+
+With this fix, the following query is supported:
+
+```cy
+MATCH (user:User {
+  mfaEnabled: false
+}) RETURN user
+```
+
 ## [8.4.3] - 2022-02-22
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.4.3",
-    "@jupiterone/integration-sdk-runtime": "^8.4.3",
+    "@jupiterone/integration-sdk-core": "^8.4.4",
+    "@jupiterone/integration-sdk-runtime": "^8.4.4",
     "@lifeomic/attempt": "^3.0.0",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "node ./src/index.js"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.4.3",
-    "@jupiterone/integration-sdk-runtime": "^8.4.3",
+    "@jupiterone/integration-sdk-core": "^8.4.4",
+    "@jupiterone/integration-sdk-runtime": "^8.4.4",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^8.4.3",
+    "@jupiterone/integration-sdk-runtime": "^8.4.4",
     "chalk": "^4",
     "commander": "^5.0.0",
     "fs-extra": "^10.0.0",
@@ -37,7 +37,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.4.3",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.4.4",
     "@pollyjs/adapter-node-http": "^5.1.1",
     "@pollyjs/core": "^5.1.1",
     "@pollyjs/persister-fs": "^5.1.1",

--- a/packages/integration-sdk-cli/src/neo4j/__tests__/neo4jUtilities.test.ts
+++ b/packages/integration-sdk-cli/src/neo4j/__tests__/neo4jUtilities.test.ts
@@ -60,7 +60,7 @@ describe('#buildPropertyParameters', () => {
     expect(
       buildPropertyParameters({
         test: '123',
-        ignore: undefined,
+        ignore: null,
       }),
     ).toEqual({
       test: '123',

--- a/packages/integration-sdk-cli/src/neo4j/__tests__/neo4jUtilities.test.ts
+++ b/packages/integration-sdk-cli/src/neo4j/__tests__/neo4jUtilities.test.ts
@@ -30,14 +30,52 @@ describe('#neo4jUtilities', () => {
       '1a!b@c#d$e%f^g&h*i(j)k-l=m+n\\o|p\'q\\"r;s:t/u?v.w,x>y<z`1~2\t3\n4[5]6{7}8 90',
     );
   });
+});
+
+describe('#buildPropertyParameters', () => {
   test('should build property string correctly including sanitization', () => {
-    const testPropResults: Object = buildPropertyParameters({
-      test: '123',
-      '1sanitize1hi&$abc d': '1h"i&$abc d',
-    });
-    expect(testPropResults).toEqual({
+    expect(
+      buildPropertyParameters({
+        test: '123',
+        '1sanitize1hi&$abc d': '1h"i&$abc d',
+      }),
+    ).toEqual({
       test: '123',
       n1sanitize1hi__abc_d: '1h\\"i&$abc d',
+    });
+  });
+
+  test('should ignore properties with the value "undefined"', () => {
+    expect(
+      buildPropertyParameters({
+        test: '123',
+        ignore: undefined,
+      }),
+    ).toEqual({
+      test: '123',
+    });
+  });
+
+  test('should ignore properties with the value "null"', () => {
+    expect(
+      buildPropertyParameters({
+        test: '123',
+        ignore: undefined,
+      }),
+    ).toEqual({
+      test: '123',
+    });
+  });
+
+  test('should not ignore "false" property values', () => {
+    expect(
+      buildPropertyParameters({
+        test: '123',
+        include: false,
+      }),
+    ).toEqual({
+      test: '123',
+      include: false,
     });
   });
 });

--- a/packages/integration-sdk-cli/src/neo4j/neo4jUtilities.ts
+++ b/packages/integration-sdk-cli/src/neo4j/neo4jUtilities.ts
@@ -21,28 +21,29 @@ export function sanitizeValue(value: string): string {
 
 export function buildPropertyParameters(propList: Object) {
   const propertyParameters = {};
+
   for (const key in propList) {
+    const propVal = propList[key];
+
     if (key === '_rawData') {
-      //stringify JSON in rawData so we can store it.
-      propertyParameters[key] = `"${JSON.stringify(propList[key])}"`;
+      // stringify JSON in rawData so we can store it.
+      propertyParameters[key] = `"${JSON.stringify(propVal)}"`;
     } else {
       // Sanitize out characters that aren't allowed in property names
       const propertyName = sanitizePropertyName(key);
 
-      //If we're dealing with a number or boolean, leave alone, otherwise
-      //wrap in single quotes to convert to a string and escape all
-      //other single quotes so they don't terminate strings prematurely.
-      if (propList[key]) {
-        if (
-          typeof propList[key] == 'number' ||
-          typeof propList[key] == 'boolean'
-        ) {
-          propertyParameters[propertyName] = propList[key];
-        } else {
-          propertyParameters[propertyName] = sanitizeValue(
-            propList[key].toString(),
-          );
-        }
+      if (typeof propVal === 'undefined' || propVal === null) {
+        // Ignore properties that have the value `undefined` or `null`.
+        continue;
+      }
+
+      // If we're dealing with a number or boolean, leave alone, otherwise
+      // wrap in single quotes to convert to a string and escape all
+      // other single quotes so they don't terminate strings prematurely.
+      if (typeof propVal == 'number' || typeof propVal == 'boolean') {
+        propertyParameters[propertyName] = propVal;
+      } else {
+        propertyParameters[propertyName] = sanitizeValue(propVal.toString());
       }
     }
   }

--- a/packages/integration-sdk-cli/src/neo4j/neo4jUtilities.ts
+++ b/packages/integration-sdk-cli/src/neo4j/neo4jUtilities.ts
@@ -32,7 +32,7 @@ export function buildPropertyParameters(propList: Object) {
       // Sanitize out characters that aren't allowed in property names
       const propertyName = sanitizePropertyName(key);
 
-      if (typeof propVal === 'undefined' || propVal === null) {
+      if (propVal === undefined || propVal === null) {
         // Ignore properties that have the value `undefined` or `null`.
         continue;
       }

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^8.4.3",
-    "@jupiterone/integration-sdk-testing": "^8.4.3",
+    "@jupiterone/integration-sdk-cli": "^8.4.4",
+    "@jupiterone/integration-sdk-testing": "^8.4.4",
     "@types/jest": "^27.1.0",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "8.4.3",
+  "version": "8.4.4",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.4.3",
+    "@jupiterone/integration-sdk-core": "^8.4.4",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.4.3",
+    "@jupiterone/integration-sdk-core": "^8.4.4",
     "@lifeomic/alpha": "^1.4.0",
     "@lifeomic/attempt": "^3.0.0",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.4.3",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.4.4",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.4.3",
-    "@jupiterone/integration-sdk-runtime": "^8.4.3",
+    "@jupiterone/integration-sdk-core": "^8.4.4",
+    "@jupiterone/integration-sdk-runtime": "^8.4.4",
     "@pollyjs/adapter-node-http": "^5.1.1",
     "@pollyjs/core": "^5.1.1",
     "@pollyjs/persister-fs": "^5.1.1",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.4.3",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.4.4",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
Fixes #638. The Neo4j ingestion tool was ignoring properties with the value `false`.

With this fix, the following query is supported:

```cy
MATCH (user:User {
  mfaEnabled: false
}) RETURN user
```