### PR TITLE
Add export to EntityCoreProperties

### DIFF
--- a/packages/integration-sdk-core/src/types/entity.ts
+++ b/packages/integration-sdk-core/src/types/entity.ts
@@ -44,7 +44,7 @@ export type Entity = EntityCoreProperties &
   RawDataTracking &
   EntityAdditionalProperties;
 
-interface EntityCoreProperties extends Omit<PersistedObject, '_class'> {
+export interface EntityCoreProperties extends Omit<PersistedObject, '_class'> {
   /**
    * Relationships are allowed a single `_class` value; entities are
    * allowed multiple values.


### PR DESCRIPTION
#why so that it could be successfully resolved in packages dependent on the sdk.