### PR TITLE
Add support for empty string values to assignTags

### DIFF
--- a/packages/integration-sdk-core/src/data/__tests__/tagging.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/tagging.test.ts
@@ -202,4 +202,18 @@ describe('assignTags', () => {
       displayName: 'The Special',
     });
   });
+
+  test('tags with empty string values provided are assigned as empty strings', () => {
+    assignTags(entity, [{ key: 'empty', value: '' }]);
+    expect(entity).toMatchObject({
+      'tag.empty': '',
+    });
+  });
+
+  test('tags with " " string values provided are assigned as " " strings', () => {
+    assignTags(entity, [{ key: 'empty', value: ' ' }]);
+    expect(entity).toMatchObject({
+      'tag.empty': ' ',
+    });
+  });
 });

--- a/packages/integration-sdk-core/src/data/converters.ts
+++ b/packages/integration-sdk-core/src/data/converters.ts
@@ -9,7 +9,7 @@ const FLOAT_NUMBER_REGEX = /^\d+\.\d+$/;
 export function parseStringPropertyValue(
   value: string | undefined | null,
 ): string | boolean | number | undefined {
-  if (!value) {
+  if (value == null) {
     return undefined;
   }
   if (TRUE_REGEX.test(value)) {

--- a/packages/integration-sdk-core/src/data/tagging.ts
+++ b/packages/integration-sdk-core/src/data/tagging.ts
@@ -87,7 +87,7 @@ export function assignTags<T extends object>(
           (m: ResourceTagMap, t) => {
             const k = t.Key || t.key;
             const v = t.Value || t.value;
-            if (k && v) {
+            if (k && v != null) {
               m[k] = v;
             }
             return m;
@@ -114,7 +114,7 @@ function assignTagMap(
 
   for (const key of Object.keys(tagMap)) {
     const value = tagMap[key];
-    if (value) {
+    if (value != null) {
       if (TRUE_BOOLEAN_REGEX.test(value)) {
         tags.push(key);
       }


### PR DESCRIPTION
References #646

Probably a few different ways of handling this one, this approach uses JS coercion to let only string values that aren't `undefined` nor `null` pass through (our empty string lives there). What do you think of this? @austinkelleher 