### PR TITLE
Adding SDK_API_CLIENT_MAX_TIMEOUT environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to
 
 ### Added
 
-- New `SDK_API_CLIENT_MAX_TIMEOUT` variable added to configure `maxTimeout` for
-  the sdk's `ApiClient`.
+- `retryOptions` parameter to `createApiClient` to allow configuration of the
+  retry behavior for `Alpha`
 
 ## [8.6.1] - 2022-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## Unreleased
 
+## [8.6.2] - 2022-03-17
+
+### Added
+
+- New `SDK_API_CLIENT_MAX_TIMEOUT` variable added to configure `maxTimeout` for
+  the sdk's `ApiClient`.
+
 ## [8.6.1] - 2022-03-14
 
 ### Fixed

--- a/packages/integration-sdk-runtime/src/api/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/api/__tests__/index.test.ts
@@ -7,7 +7,6 @@ import {
   createApiClient,
   getAccountFromEnvironment,
 } from '../index';
-import { IntegrationMaxTimeoutBadValueError } from '../error';
 
 jest.mock('@lifeomic/alpha');
 
@@ -91,6 +90,9 @@ describe('createApiClient', () => {
       apiBaseUrl,
       account: 'test-account',
       accessToken: 'test-key',
+      retryOptions: {
+        maxTimeout: 20000,
+      },
     });
 
     expect(client).toBeInstanceOf(AlphaMock);
@@ -107,22 +109,5 @@ describe('createApiClient', () => {
         maxTimeout: 20000,
       },
     });
-  });
-
-  test('bad SDK_API_CLIENT_MAX_TIMEOUT throws error', () => {
-    process.env.SDK_API_CLIENT_MAX_TIMEOUT = '10000x';
-    const apiBaseUrl = getApiBaseUrl();
-    try {
-      createApiClient({
-        apiBaseUrl,
-        account: 'test-account',
-        accessToken: 'test-key',
-      });
-    } catch (err) {
-      expect(err).toBeInstanceOf(IntegrationMaxTimeoutBadValueError);
-      expect(err.message).toBe(
-        'The SDK_API_CLIENT_MAX_TIMEOUT environment variable is not a number',
-      );
-    }
   });
 });

--- a/packages/integration-sdk-runtime/src/api/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/api/__tests__/index.test.ts
@@ -77,10 +77,6 @@ describe('getApiKeyFromEnvironment', () => {
 });
 
 describe('createApiClient', () => {
-  afterEach(() => {
-    delete process.env.SDK_API_CLIENT_MAX_TIMEOUT;
-  });
-
   test('successfully creates apiClient', () => {
     process.env.SDK_API_CLIENT_MAX_TIMEOUT = '20000';
 

--- a/packages/integration-sdk-runtime/src/api/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/api/__tests__/index.test.ts
@@ -78,8 +78,6 @@ describe('getApiKeyFromEnvironment', () => {
 
 describe('createApiClient', () => {
   test('successfully creates apiClient', () => {
-    process.env.SDK_API_CLIENT_MAX_TIMEOUT = '20000';
-
     const apiBaseUrl = getApiBaseUrl();
 
     const client = createApiClient({

--- a/packages/integration-sdk-runtime/src/api/error.ts
+++ b/packages/integration-sdk-runtime/src/api/error.ts
@@ -17,3 +17,13 @@ export class IntegrationAccountRequiredError extends IntegrationError {
     });
   }
 }
+
+export class IntegrationMaxTimeoutBadValueError extends IntegrationError {
+  constructor() {
+    super({
+      code: 'SDK_API_CLIENT_MAX_TIMEOUT_BAD_VALUE',
+      message:
+        'The SDK_API_CLIENT_MAX_TIMEOUT environment variable is not a number',
+    });
+  }
+}

--- a/packages/integration-sdk-runtime/src/api/error.ts
+++ b/packages/integration-sdk-runtime/src/api/error.ts
@@ -17,13 +17,3 @@ export class IntegrationAccountRequiredError extends IntegrationError {
     });
   }
 }
-
-export class IntegrationMaxTimeoutBadValueError extends IntegrationError {
-  constructor() {
-    super({
-      code: 'SDK_API_CLIENT_MAX_TIMEOUT_BAD_VALUE',
-      message:
-        'The SDK_API_CLIENT_MAX_TIMEOUT environment variable is not a number',
-    });
-  }
-}

--- a/packages/integration-sdk-runtime/src/api/index.ts
+++ b/packages/integration-sdk-runtime/src/api/index.ts
@@ -8,6 +8,7 @@ import dotenvExpand from 'dotenv-expand';
 import {
   IntegrationApiKeyRequiredError,
   IntegrationAccountRequiredError,
+  IntegrationMaxTimeoutBadValueError,
 } from './error';
 
 export type ApiClient = AxiosInstance;
@@ -41,9 +42,19 @@ export function createApiClient({
     headers.Authorization = `Bearer ${accessToken}`;
   }
 
+  const maxTimeout = process.env.SDK_API_CLIENT_MAX_TIMEOUT
+    ? Number(process.env.SDK_API_CLIENT_MAX_TIMEOUT)
+    : 10000;
+  if (isNaN(maxTimeout)) {
+    throw new IntegrationMaxTimeoutBadValueError();
+  }
+
   return new Alpha({
     baseURL: apiBaseUrl,
     headers,
+    retry: {
+      maxTimeout: maxTimeout,
+    },
   }) as ApiClient;
 }
 


### PR DESCRIPTION
# Description

This PR adds a new environment variable, `SDK_API_CLIENT_MAX_TIMEOUT`, to configure the `maxTimeout` for the SDK's `ApiClient`.

## Summary

The new `SDK_API_CLIENT_MAX_TIMEOUT` is an environment variable used to control the `retry.maxTimeout` property on the `Alpha` client the SDK uses to make calls to our public API routes. If no value is given for `SDK_API_CLIENT_MAX_TIMEOUT`, a default value of 10000 ms will be used. This is the same value the `Alpha` uses internally by default. `Alpha` also has other internal default values for `retry`. I have confirmed that if these other properties are `undefined` on the `retry` object we pass, `Alpha` will use its own defaults.

If the `SDK_API_CLIENT_MAX_TIMEOUT` is set but is not a number, then a new `IntegrationMaxTimeoutBadValue` error will be thrown. I would love feedback on this choice. I also thought about falling back to the default and logging a warning but felt being more explicit would be helpful. I would love to know what others think.