### PR TITLE
Fixing an error where undefined retryOptions would not adopt defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- Fixed an error where if `retryOptions` was `undefined` default options would
+  not be adopted
+
 ## [8.6.2] - 2022-03-17
 
 ### Added

--- a/packages/integration-sdk-runtime/src/api/index.ts
+++ b/packages/integration-sdk-runtime/src/api/index.ts
@@ -52,7 +52,7 @@ export function createApiClient({
   return new Alpha({
     baseURL: apiBaseUrl,
     headers,
-    retry: retryOptions,
+    retry: retryOptions ?? {},
   }) as ApiClient;
 }
 


### PR DESCRIPTION
# Description

This PR fixes an error where if `retryOptions` is `undefined`, there would be no default retry behavior.