### PR TITLE
Fix #660 - Trigger fatal error when system responds with `JOB_NOT_AWAITING_UPLOADS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Log error `code` when an integration logs an error
+- Throw an `IntegrationError` with code `INTEGRATION_UPLOAD_FAILED` when the
+  JupiterOne system responds with `RequestEntityTooLargeException`
+
+### Fixed
+
+- [#660] - Trigger fatal error when JupiterOne system responds with
+  `JOB_NOT_AWAITING_UPLOADS`
+
 ## [8.6.3] - 2022-03-17
 
 ### Fixed

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -812,7 +812,7 @@ describe('executeStepDependencyGraph', () => {
 
     expect(errorLogSpy).toHaveBeenCalledTimes(1);
     expect(errorLogSpy).toHaveBeenCalledWith(
-      { err: error, errorId: expect.any(String) },
+      { err: error, errorId: expect.any(String), code: 'ABC-123' },
       expect.stringMatching(
         new RegExp(
           `Step "a" failed to complete due to error. \\(errorCode="ABC-123", errorId="(.*)"\\)$`,

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -282,6 +282,7 @@ describe('step event publishing', () => {
       1,
       {
         err: error,
+        code: 'LOCAL_CONFIG_FIELD_MISSING',
         errorId: expect.any(String),
       },
       expect.stringContaining(
@@ -502,7 +503,11 @@ describe('validation failure logging', () => {
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      { errorId: expect.any(String), err: error },
+      {
+        errorId: expect.any(String),
+        err: error,
+        code: 'CONFIG_VALIDATION_ERROR',
+      },
       expect.stringMatching(expectedDescriptionRegex),
     );
   });

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -335,11 +335,17 @@ export class IntegrationLogger
     description: string;
   }) {
     const { eventName, errorId, err, description } = options;
+
+    // If there is a `code` property on the `Error`, we should include this
+    // in our log. This is helpful for when we receive an HTTP response error
+    // and the service includes specific codes (e.g. the JupiterOne system).
+    const code = (err as any).code;
+
     if (shouldReportErrorToOperator(err)) {
-      this.error({ errorId, err }, description);
+      this.error({ errorId, err, code }, description);
       this.onFailure({ err });
     } else {
-      this.warn({ errorId, err }, description);
+      this.warn({ errorId, err, code }, description);
     }
 
     this.publishEvent({

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/index.test.ts
@@ -430,9 +430,15 @@ describe('uploadDataChunk', () => {
     const context = createTestContext();
     const job = generateSynchronizationJob();
 
-    const jobNotAwaitingUploadsError = new Error('Job is not awaiting uploads');
-    jobNotAwaitingUploadsError.name = 'JOB_NOT_AWAITING_UPLOADS';
-    jobNotAwaitingUploadsError['code'] = 'JOB_NOT_AWAITING_UPLOADS';
+    const jobNotAwaitingUploadsError = new Error('400 bad request');
+    (jobNotAwaitingUploadsError as any).response = {
+      data: {
+        error: {
+          code: 'JOB_NOT_AWAITING_UPLOADS',
+          message: 'JOB_NOT_AWAITING_UPLOADS',
+        },
+      },
+    };
 
     const type = 'entities';
     const batch = [];


### PR DESCRIPTION
- Log error `code` when an integration logs an error
- Throw an `IntegrationError` with code `INTEGRATION_UPLOAD_FAILED` when the
  JupiterOne system responds with `RequestEntityTooLargeException`
- [#660] - Trigger fatal error when JupiterOne system responds with
  `JOB_NOT_AWAITING_UPLOADS`