### PR TITLE
Support executeStepWithDependencies for steps with no dependencyGraphId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Support `executeStepWithDependencies` for steps with no `dependencyGraphId`,
+  even if `invocationConfig.dependencyGraphOrder` is present
+
 ## [8.6.4] - 2022-03-23
 
 ### Changed

--- a/packages/integration-sdk-testing/src/__tests__/executeStepWithDependencies.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/executeStepWithDependencies.test.ts
@@ -65,17 +65,22 @@ describe('executeStepWithDependencies', () => {
   });
 
   describe('invalid invocationConfig', () => {
-    test('should fail if invocationConfig `dependencyGraphOrder` property is present', async () => {
+    test('should fail if `step.dependencyGraphId` property is present', async () => {
       await expect(
         executeStepWithDependencies({
           stepId: 'step-1',
           invocationConfig: getMockInvocationConfig({
-            dependencyGraphOrder: [],
+            integrationSteps: [
+              getMockIntegrationStep({
+                id: 'step-1',
+                dependencyGraphId: 'last',
+              }),
+            ],
           }),
           instanceConfig: getMockInstanceConfig(),
         }),
       ).rejects.toThrow(
-        'executeStepWithDependencies does not currently support dependencyGraphOrder',
+        'executeStepWithDependencies does not currently support steps with a dependencyGraphId',
       );
     });
 

--- a/packages/integration-sdk-testing/src/executeStepWithDependencies.ts
+++ b/packages/integration-sdk-testing/src/executeStepWithDependencies.ts
@@ -9,15 +9,16 @@ import {
 export async function executeStepWithDependencies(params: StepTestConfig) {
   const { stepId, invocationConfig, instanceConfig } = params;
 
-  if (invocationConfig.dependencyGraphOrder) {
-    throw new Error(
-      'executeStepWithDependencies does not currently support dependencyGraphOrder',
-    );
-  }
-
   const stepDependencyGraph = buildStepDependencyGraph(
     invocationConfig.integrationSteps,
   );
+
+  const step = stepDependencyGraph.getNodeData(stepId);
+  if (step.dependencyGraphId) {
+    throw new Error(
+      'executeStepWithDependencies does not currently support steps with a dependencyGraphId',
+    );
+  }
 
   const dependencyStepIds = stepDependencyGraph.dependenciesOf(stepId);
 
@@ -48,8 +49,7 @@ export async function executeStepWithDependencies(params: StepTestConfig) {
     executionConfig,
   };
 
-  const { executionHandler } = stepDependencyGraph.getNodeData(stepId);
-  await executionHandler(context);
+  await step.executionHandler(context);
 
   return {
     collectedEntities: context.jobState.collectedEntities,


### PR DESCRIPTION
### Changed

- Support `executeStepWithDependencies` for steps with no `dependencyGraphId`, even if `invocationConfig.dependencyGraphOrder` is present
