### PR TITLE
[INT-3353] Updating and adding new benchmarks

### DIFF
--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "prebenchmark": "rm -rf .j1-integration",
-    "benchmark": "node ./src/index.js"
+    "benchmark": "for file in ./src/benchmarks/*; do yarn prebenchmark && node $file; done"
   },
   "dependencies": {
     "@jupiterone/integration-sdk-core": "^8.12.0",

--- a/packages/integration-sdk-benchmark/src/benchmarks/FileSystemGraphObjectStore.addEntities.js
+++ b/packages/integration-sdk-benchmark/src/benchmarks/FileSystemGraphObjectStore.addEntities.js
@@ -54,7 +54,7 @@ for (const size of inputSizes) {
 
   // Add the test function to the benchmark
   suite.add(
-    `FileSystemGraphObjectStore#addEntity ${size.toString()} Entities`,
+    `FileSystemGraphObjectStore#addEntities ${size.toString()} Entities`,
     fn,
   );
 }

--- a/packages/integration-sdk-benchmark/src/benchmarks/InMemoryGraphObjectStore.addEntities.js
+++ b/packages/integration-sdk-benchmark/src/benchmarks/InMemoryGraphObjectStore.addEntities.js
@@ -1,12 +1,12 @@
 const Benchmark = require('benchmark');
 const {
-  FileSystemGraphObjectStore,
+  InMemoryGraphObjectStore,
 } = require('@jupiterone/integration-sdk-runtime');
 const { createMockEntities } = require('../util/entity');
 const { createEventCollector } = require('../util/eventCollector');
 
-function createFileSystemGraphObjectStore(params) {
-  return new FileSystemGraphObjectStore(params);
+function createInMemoryGraphObjectStore(params) {
+  return new InMemoryGraphObjectStore(params);
 }
 
 function createBenchmarkContext(params = {}) {
@@ -20,9 +20,9 @@ function createBenchmarkContext(params = {}) {
   return {
     stepId,
     newEntities,
-    fileSystemGraphObjectStoreParams: { graphObjectBufferThreshold: 500 },
   };
 }
+
 const inputSizes = [100, 1000, 10000, 100000];
 
 const eventCollector = createEventCollector();
@@ -42,21 +42,15 @@ for (const size of inputSizes) {
 
   // ---- TEST FUNCTION -------------
   const fn = async function () {
-    const fileSystemGraphObjectStore = createFileSystemGraphObjectStore(
-      context.fileSystemGraphObjectStoreParams,
-    );
+    const inMemoryGraphObjectStore = createInMemoryGraphObjectStore();
 
-    await fileSystemGraphObjectStore.addEntities(
+    await inMemoryGraphObjectStore.addEntities(
       context.stepId,
       context.newEntities,
     );
   };
 
-  // Add the test function to the benchmark
-  suite.add(
-    `FileSystemGraphObjectStore#addEntity ${size.toString()} Entities`,
-    fn,
-  );
+  suite.add(`InMemoryGraphObjectStore#addEntity ${size.toString()}`, fn);
 }
 
 suite
@@ -66,4 +60,6 @@ suite
   .on('complete', function () {
     eventCollector.publishEvents();
   })
-  .run({ async: true });
+  .run({
+    async: true,
+  });

--- a/packages/integration-sdk-benchmark/src/benchmarks/InMemoryGraphObjectStore.addEntities.js
+++ b/packages/integration-sdk-benchmark/src/benchmarks/InMemoryGraphObjectStore.addEntities.js
@@ -50,7 +50,7 @@ for (const size of inputSizes) {
     );
   };
 
-  suite.add(`InMemoryGraphObjectStore#addEntity ${size.toString()}`, fn);
+  suite.add(`InMemoryGraphObjectStore#addEntities ${size.toString()}`, fn);
 }
 
 suite

--- a/packages/integration-sdk-benchmark/src/benchmarks/JobState.addEntities.js
+++ b/packages/integration-sdk-benchmark/src/benchmarks/JobState.addEntities.js
@@ -1,0 +1,68 @@
+const {
+  createStepJobState,
+  DuplicateKeyTracker,
+  TypeTracker,
+  MemoryDataStore,
+} = require('@jupiterone/integration-sdk-runtime/dist/src/execution/jobState');
+const {
+  FileSystemGraphObjectStore,
+} = require('@jupiterone/integration-sdk-runtime');
+const { createMockEntities } = require('../util/entity');
+const { createEventCollector } = require('../util/eventCollector');
+const Benchmark = require('benchmark');
+
+const eventCollector = createEventCollector();
+function createFileSystemGraphObjectStore(params) {
+  return new FileSystemGraphObjectStore(params);
+}
+
+function createBenchmarkContext(params = {}) {
+  const stepId = 'abc';
+  let newEntities = [];
+
+  if (params.numNewEntities) {
+    newEntities = createMockEntities(params.numNewEntities);
+  }
+
+  return {
+    stepId,
+    newEntities,
+  };
+}
+
+const inputSizes = [100, 1000, 10000, 100000];
+
+const suite = new Benchmark.Suite();
+
+for (const size of inputSizes) {
+  const context = createBenchmarkContext({
+    numNewEntities: size,
+  });
+  const fn = async function () {
+    const duplicateKeyTracker = new DuplicateKeyTracker();
+    const typeTracker = new TypeTracker();
+    const fsGraphObjectStore = createFileSystemGraphObjectStore({});
+    const memoryDataStore = new MemoryDataStore();
+
+    await createStepJobState({
+      stepId: 'step1',
+      duplicateKeyTracker: duplicateKeyTracker,
+      typeTracker: typeTracker,
+      graphObjectStore: fsGraphObjectStore,
+      dataStore: memoryDataStore,
+    }).addEntities(context.newEntities);
+  };
+
+  suite.add(`JobState#addEntities ${size.toString()}`, fn);
+}
+
+suite
+  .on('cycle', function (event) {
+    eventCollector.addEvent(event);
+  })
+  .on('complete', function () {
+    eventCollector.publishEvents();
+  })
+  .run({
+    async: true,
+  });

--- a/packages/integration-sdk-benchmark/src/index.js
+++ b/packages/integration-sdk-benchmark/src/index.js
@@ -1,1 +1,3 @@
 require('./benchmarks/FileSystemGraphObjectStore.addEntities');
+require('./benchmarks/InMemoryGraphObjectStore.addEntities');
+require('./benchmarks/JobState.addEntities');

--- a/packages/integration-sdk-benchmark/src/index.js
+++ b/packages/integration-sdk-benchmark/src/index.js
@@ -1,3 +1,0 @@
-require('./benchmarks/FileSystemGraphObjectStore.addEntities');
-require('./benchmarks/InMemoryGraphObjectStore.addEntities');
-require('./benchmarks/JobState.addEntities');

--- a/packages/integration-sdk-benchmark/src/util/eventCollector.js
+++ b/packages/integration-sdk-benchmark/src/util/eventCollector.js
@@ -1,0 +1,26 @@
+function createEventCollector() {
+  return {
+    events: [],
+    addEvent: function (event) {
+      this.events.push(event);
+    },
+    publishEvents: function () {
+      this.events.sort((a, b) => {
+        return a.target.name > b.target.name;
+      });
+
+      for (const event of this.events) {
+        console.log(
+          event.target.name,
+          '\t',
+          event.target.hz.toFixed(3),
+          'ops/sec',
+        );
+      }
+    },
+  };
+}
+
+module.exports = {
+  createEventCollector,
+};

--- a/packages/integration-sdk-benchmark/src/util/eventCollector.js
+++ b/packages/integration-sdk-benchmark/src/util/eventCollector.js
@@ -1,24 +1,39 @@
-function createEventCollector() {
-  return {
-    events: [],
-    addEvent: function (event) {
-      this.events.push(event);
-    },
-    publishEvents: function () {
-      this.events.sort((a, b) => {
-        return a.target.name > b.target.name;
-      });
+class EventCollector {
+  constructor() {
+    this.events = [];
+  }
 
-      for (const event of this.events) {
-        console.log(
-          event.target.name,
-          '\t',
-          event.target.hz.toFixed(3),
-          'ops/sec',
-        );
-      }
-    },
-  };
+  /**
+   * addEvent adds an event to the EventCollector
+   *
+   * @param event - The benchmark.js event to be recorded
+   */
+  addEvent(event) {
+    this.events.push(event);
+  }
+
+  /**
+   * publishEvents formats all the recorded events and output the results into
+   * a human readable format
+   */
+  publishEvents() {
+    this.events.sort((event1, event2) => {
+      return event1.target.name > event2.target.name;
+    });
+
+    for (const event of this.events) {
+      console.log(
+        event.target.name,
+        '\t',
+        event.target.hz.toFixed(3),
+        'ops/sec',
+      );
+    }
+  }
+}
+
+function createEventCollector() {
+  return new EventCollector();
 }
 
 module.exports = {


### PR DESCRIPTION
# Description

This PR adds two new benchmarks, updates an existing benchmark, and adds an `eventCollector` utility to make capturing and displaying benchmark information easier.

This partially addresses issue #643, but there is still more that could be done. This only benchmarks the `jobState.addEntities` function.

## Results
Benchmarks done on a 2019 MacBook Pro | 2.3 GHz 8-Core Intel Core i9 | 16 GB 2667 MHz DDR4

### FileSystemGraphObjectStore#addEntities
FileSystemGraphObjectStore#addEntities 100 Entities        46426.504 ops/sec
FileSystemGraphObjectStore#addEntities 1000 Entities       2479.691 ops/sec
FileSystemGraphObjectStore#addEntities 10000 Entities      128.303 ops/sec
FileSystemGraphObjectStore#addEntities 100000 Entities     9.504 ops/sec
### InMemoryGraphObjectStore#addEntities
InMemoryGraphObjectStore#addEntities 100   66478.234 ops/sec
InMemoryGraphObjectStore#addEntities 1000          3250.880 ops/sec
InMemoryGraphObjectStore#addEntities 10000         148.766 ops/sec
InMemoryGraphObjectStore#addEntities 100000        10.066 ops/sec
### JobState.addEntities
JobState#addEntities 100         25205.276 ops/sec
JobState#addEntities 1000        1600.863 ops/sec
JobState#addEntities 10000       71.557 ops/sec
JobState#addEntities 100000      4.855 ops/sec