### PR TITLE
Enforce resultsAre in managed questions

### DIFF
--- a/packages/integration-sdk-cli/src/questions/__fixtures__/questions/invalid-results-are.yaml
+++ b/packages/integration-sdk-cli/src/questions/__fixtures__/questions/invalid-results-are.yaml
@@ -1,0 +1,16 @@
+---
+sourceId: managed:google_cloud
+integrationDefinitionId: "${integration_definition_id}"
+questions:
+- id: integration-question-google-cloud-corporate-login-credentials
+  title: Ensure that corporate login credentials are used
+  description:
+    Use corporate login credentials instead of personal accounts, such as Gmail accounts.
+  queries:
+  - name: invalid
+    query: find google_user with email $="@{{domain}}"
+    resultsAre: INVALID_RESULTS_ARE_VALUE
+  tags:
+  - google-cloud
+  - user
+  - access

--- a/packages/integration-sdk-cli/src/questions/__fixtures__/questions/results-are.yaml
+++ b/packages/integration-sdk-cli/src/questions/__fixtures__/questions/results-are.yaml
@@ -1,0 +1,30 @@
+---
+sourceId: managed:google_cloud
+integrationDefinitionId: "${integration_definition_id}"
+questions:
+- id: integration-question-google-cloud-corporate-login-credentials
+  title: Ensure that corporate login credentials are used
+  description:
+    Use corporate login credentials instead of personal accounts, such as Gmail accounts.
+  queries:
+  - name: good
+    query: find google_user with email $="@{{domain}}"
+    resultsAre: GOOD
+  - name: bad
+    query: find google_user with email !$="@{{domain}}"
+    resultsAre: BAD
+  - name: informative
+    query: find google_user with email $="@{{domain}}"
+    resultsAre: INFORMATIVE
+  - name: unknown
+    query: find google_user with email !$="@{{domain}}"
+    resultsAre: UNKNOWN
+  - name: 'null'
+    query: find google_user with email $="@{{domain}}"
+    resultsAre:
+  - name: undefined
+    query: find google_user with email $="@{{domain}}"
+  tags:
+  - google-cloud
+  - user
+  - access

--- a/packages/integration-sdk-cli/src/questions/managedQuestionFileValidator.test.ts
+++ b/packages/integration-sdk-cli/src/questions/managedQuestionFileValidator.test.ts
@@ -43,6 +43,10 @@ describe('#validateManagedQuestionFile dryRun - Valid', () => {
   test('should validate compliance question', async () => {
     await dryRunTest('compliance');
   });
+
+  test('should validate any allowed resultsAre property', async () => {
+    await dryRunTest('results-are');
+  });
 });
 
 describe('#validateManagedQuestionFile dryRun - Invalid', () => {
@@ -75,6 +79,12 @@ describe('#validateManagedQuestionFile dryRun - Invalid', () => {
       dryRunTest('non-unique-question-name'),
     ).rejects.toThrowError(
       `Duplicate query name in question detected (questionId=integration-question-google-cloud-corporate-login-credentials, queryName=good)`,
+    );
+  });
+
+  test('should throw if resultsAre contains invalid property', async () => {
+    await expect(() => dryRunTest('invalid-results-are')).rejects.toThrowError(
+      `Expected "BAD" | "GOOD" | "INFORMATIVE" | "UNKNOWN" | undefined | null, but was string in questions.[0].queries.[0].resultsAre`,
     );
   });
 });

--- a/packages/integration-sdk-cli/src/questions/managedQuestionFileValidator.ts
+++ b/packages/integration-sdk-cli/src/questions/managedQuestionFileValidator.ts
@@ -7,6 +7,14 @@ import * as queryLanguage from '../services/queryLanguage';
 export const ManagedQuestionQueryRecord = Runtypes.Record({
   name: Runtypes.String.Or(Runtypes.Undefined),
   query: Runtypes.String,
+  resultsAre: Runtypes.Union(
+    Runtypes.Literal('BAD'),
+    Runtypes.Literal('GOOD'),
+    Runtypes.Literal('INFORMATIVE'),
+    Runtypes.Literal('UNKNOWN'),
+    Runtypes.Undefined,
+    Runtypes.Null,
+  ),
 });
 
 export const ManagedQuestionComplianceDetailsRecord = Runtypes.Record({


### PR DESCRIPTION
I found that the question ingester is failing with 

```
Invalid question. Reason(s): question.queries[0].resultsAre should be equal to one of the allowed values
```

Specifically, it's using the following enum for validation:

```ts
export declare enum QueryResultsAre {
    BAD = "BAD",
    GOOD = "GOOD",
    INFORMATIVE = "INFORMATIVE",
    UNKNOWN = "UNKNOWN"
}
```