### PR TITLE
throw upload error when shrunk payload too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to
 
 ## Unreleased
 
+## [8.13.3] - 2022-05-11
+
+### Fixed
+
+- Hanging execution when encountering upload failure due to entity properties
+  being too large
+- add logging surrounding the size distribution of upload batch and its largest
+  entity when such a situation occurs
+- throw fatal error when such a situation occurs
+
 ## [8.13.2] - 2022-05-05
 
 ### Changed

--- a/packages/integration-sdk-core/src/types/logger.ts
+++ b/packages/integration-sdk-core/src/types/logger.ts
@@ -69,6 +69,12 @@ export enum IntegrationErrorEventName {
    * We would like to indicate to the end-user when this limit is encountered, and then fail the execution on completion.
    */
   IngestionLimitEncountered = 'error_ingestion_limit_encountered',
+  /**
+   * In some rare cases, the mapped properties of an entity can be so large that they trigger upload errors due to payload size.
+   * This points to a possible poison pill in the api the integration is consuming. We would like to indicate to the end-user when this
+   * error is encountered.
+   */
+  EntitySizeLimitEncountered = 'error_entity_size_limit_encountered',
 }
 
 export interface PublishErrorEventInput extends PublishEventInput {

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -37,8 +37,14 @@ const UPLOAD_CONCURRENCY = 6;
 // 6291456 bytes, but we need header space.  Most web
 // servers will only allow 8KB or 16KB as a max header
 // size, so 6291456 - 16384 = 6275072
-// We're further reducing to a max size of 1 MB or 1048576
-const UPLOAD_SIZE_MAX = 1048576;
+// to be completely safe, we are using 6000000 bytes as default
+const MAX_BATCH_SIZE = 6000000;
+
+// TODO [INT-3707]: uncomment and use when implementing method
+// to shrink single entity's rawData until that entity is < 1MB
+
+// const MAX_RAW_DATA_SIZE = 1194304;
+
 export enum RequestHeaders {
   CorrelationId = 'JupiterOne-Correlation-Id',
 }
@@ -351,8 +357,9 @@ function handleUploadDataChunkError({
   );
 
   if (isRequestUploadTooLargeError(err)) {
+    // shrink rawData further to try and achieve a batch size of < 6MB
     logger.info(`Attempting to shrink rawData`);
-    const shrinkResults = shrinkRawData(batch, logger);
+    const shrinkResults = shrinkBatchRawData(batch, logger);
     logger.info(shrinkResults, 'Shrink raw data result');
   } else if (systemErrorResponseData?.code === 'JOB_NOT_AWAITING_UPLOADS') {
     throw new IntegrationError({
@@ -373,6 +380,8 @@ export async function uploadDataChunk<
 
   await retry(
     async (ctx) => {
+      // TODO [INT-3707]: on first try, shrink raw data of every entity
+      // to the point where each entity is < 1MB
       logger.info(
         {
           uploadCorrelationId,
@@ -476,40 +485,58 @@ function getLargestItemKeyAndByteSize(data: any): KeyAndSize {
 }
 
 /**
- * Helper function to find the largest Entity in our data array and return it.
+ * Helper function to find the entity in our data array with the largest rawData and return it.
  * We JSON.stringify as a method to try and have an apples to apples comparison
  * no matter what the data type of the value is.
  *
  * @param data
  * @returns
  */
-function getLargestEntityFromBatch(
+function getEntityFromBatchWithLargestRawData(
   data: UploadDataLookup[keyof UploadDataLookup][],
 ): Entity {
-  let largestItem;
-  let largestItemSize = 0;
+  let itemWithLargestRawData;
+  let largestRawDataSize = Number.MIN_SAFE_INTEGER;
+
+  for (const item of data) {
+    const length = item?._rawData
+      ? Buffer.byteLength(JSON.stringify(item._rawData))
+      : 0;
+    if (length > largestRawDataSize) {
+      itemWithLargestRawData = item;
+      largestRawDataSize = length;
+    }
+  }
+  return itemWithLargestRawData;
+}
+
+function getLargestEntityInBatch(
+  data: UploadDataLookup[keyof UploadDataLookup][],
+): Entity {
+  let largestEntity;
+  let largestEntitySize = Number.MIN_SAFE_INTEGER;
 
   for (const item of data) {
     const length = item ? Buffer.byteLength(JSON.stringify(item)) : 0;
-    if (length > largestItemSize) {
-      largestItem = item;
-      largestItemSize = length;
+    if (length > largestEntitySize) {
+      largestEntity = item;
+      largestEntitySize = length;
     }
   }
-  return largestItem;
+  return largestEntity;
 }
 
 /**
- * Helper function to find the largest _rawData entry in an Entity and return
+ * Helper function to find the largest element of the _rawData array in an Entity and return
  * it.  We JSON.stringify as a method to try and have an apples to apples comparison
  * no matter what the data type of the value is.
  *
  * @param data
  * @returns
  */
-function getLargestKeyFromData(data: EntityRawData[]): EntityRawData {
+function getLargestRawDataEntry(data: EntityRawData[]): EntityRawData {
   let largestItem;
-  let largestItemSize = 0;
+  let largestItemSize = Number.MIN_SAFE_INTEGER;
 
   for (const item of data) {
     const length = item ? Buffer.byteLength(JSON.stringify(item)) : 0;
@@ -533,9 +560,7 @@ function getLargestKeyFromData(data: EntityRawData[]): EntityRawData {
 function getPropSizeMapFromEntity(data: Entity): any {
   const propSizeMap = {};
 
-  for (const [key, value] of Object.entries({
-    ...data,
-  })) {
+  for (const [key, value] of Object.entries(data)) {
     propSizeMap[key] = Buffer.byteLength(JSON.stringify(value));
   }
 
@@ -544,32 +569,34 @@ function getPropSizeMapFromEntity(data: Entity): any {
 
 /**
  * Removes data from the rawData of the largest entity until the overall size
- * of the data object is less than maxSize (defaulted to UPLOAD_SIZE_MAX).
+ * of the data object is less than maxSize (defaulted to MAX_BATCH_SIZE).
  *
- * @param data
+ * @param batchData
  */
-export function shrinkRawData(
-  data: UploadDataLookup[keyof UploadDataLookup][],
+export function shrinkBatchRawData(
+  batchData: UploadDataLookup[keyof UploadDataLookup][],
   logger: IntegrationLogger,
-  maxSize = UPLOAD_SIZE_MAX,
+  maxBatchSize = MAX_BATCH_SIZE,
 ): ShrinkRawDataResults {
   const startTimeInMilliseconds = Date.now();
-  let totalSize = Buffer.byteLength(JSON.stringify(data));
-  const initialSize = totalSize;
+  let totalBatchSize = Buffer.byteLength(JSON.stringify(batchData));
+  const initialBatchSize = totalBatchSize;
   let itemsRemoved = 0;
   const sizeOfTruncated = Buffer.byteLength("'TRUNCATED'");
 
-  while (totalSize > maxSize) {
-    // Find largest Entity
-    const largestEntity = getLargestEntityFromBatch(data);
+  while (totalBatchSize > maxBatchSize) {
+    // Find Entity with largest rawData
+    const entityWithLargestRawData =
+      getEntityFromBatchWithLargestRawData(batchData);
 
     // If we don't have any entities to shrink or the optional _rawData array is empty,
     // we have no other options than to throw an error.
-    if (largestEntity?._rawData) {
-      // Find largest _rawData entry (typically 0, but check to be certain)
-      const largestRawDataEntry = getLargestKeyFromData(largestEntity._rawData);
-
-      // Find largest item within rawData
+    if (entityWithLargestRawData?._rawData) {
+      // Find largest element of the _rawData array (typically at index 0, but check to be certain)
+      const largestRawDataEntry = getLargestRawDataEntry(
+        entityWithLargestRawData._rawData,
+      );
+      // Find largest item within largest that element
       const largestItemLookup = getLargestItemKeyAndByteSize(
         largestRawDataEntry.rawData,
       );
@@ -577,22 +604,24 @@ export function shrinkRawData(
       // if we can no longer truncate, log and error out
       if (largestItemLookup.size === sizeOfTruncated) {
         const sizeDistribution = {};
-        for (const entity of data) {
+        for (const entity of batchData) {
           sizeDistribution[entity._key] = Buffer.byteLength(
             JSON.stringify(entity),
           );
         }
         logger.error(
           {
-            largestEntityPropSizeMap: getPropSizeMapFromEntity(largestEntity),
-            totalBatchSize: totalSize,
+            largestEntityPropSizeMap: getPropSizeMapFromEntity(
+              getLargestEntityInBatch(batchData),
+            ),
+            totalBatchSize: totalBatchSize,
             sizeDistribution,
           },
-          'Encountered upload size error after fully shrinking',
+          'Encountered upload size error after fully shrinking. This is likely due to properties on the entity being too large in size.',
         );
         logger.publishErrorEvent({
           name: IntegrationErrorEventName.EntitySizeLimitEncountered,
-          description: `Failed to upload integration data because the payload is too large. This batch of ${data.length} entities is still ${totalSize} bytes after truncating all non-mapped properties.`,
+          description: `Failed to upload integration data because the payload is too large. This batch of ${batchData.length} entities is still ${totalBatchSize} bytes after truncating all non-mapped properties.`,
         });
         throw new IntegrationError({
           code: 'INTEGRATION_UPLOAD_FAILED',
@@ -605,7 +634,8 @@ export function shrinkRawData(
       // Truncate largest item and recalculate size to see if we need to continue truncating additional items
       largestRawDataEntry.rawData[largestItemLookup.key] = 'TRUNCATED';
       itemsRemoved += 1;
-      totalSize = totalSize - largestItemLookup.size + sizeOfTruncated;
+      totalBatchSize =
+        totalBatchSize - largestItemLookup.size + sizeOfTruncated;
     } else {
       // Cannot find any entities to shrink, so throw
       throw new IntegrationError({
@@ -619,8 +649,8 @@ export function shrinkRawData(
 
   const endTimeInMilliseconds = Date.now();
   return {
-    initialSize,
-    totalSize,
+    initialSize: initialBatchSize,
+    totalSize: totalBatchSize,
     itemsRemoved,
     totalTime: endTimeInMilliseconds - startTimeInMilliseconds,
   };


### PR DESCRIPTION
In time it would be great to have the sdk attempt to re-shuffle batches in an attempt to get larger entities uploaded. However, this change will prevent infinite loops when shrinking rawData on entities whose **mapped properties** alone are enough to cause a batch to fail due to upload size > 6MB.

I've seen real-world examples in the Tenable integration where the properties on a **single vulnerability entity* was between 1-2MB. Seeing as batches can be up to 250 entities, just a few of these was enough to cause an upload failure. However, it is important to note that if these entities were in batches of size `1`, the upload would have succeeded.