### PR TITLE
Fix Starbase Duplicate Nodes

### DIFF
--- a/packages/integration-sdk-cli/src/neo4j/uploadToNeo4j.ts
+++ b/packages/integration-sdk-cli/src/neo4j/uploadToNeo4j.ts
@@ -52,8 +52,8 @@ export async function uploadToNeo4j({
     // key constraint consisting of both the _key value as well as the _integrationInstanceID
     // value and that would require users to have an enterprise Neo4j instance instead
     // of just a community version.  Additionally, MERGE commands within relationship 
-    // creation to create the start and end nodes if they do not yet exist are not able 
-    // to set the Type label correctly always, and are therefore not always found by 
+    // creation to create the start and end nodes if they do not yet exist do not always
+    // have access to the Type label during creation, and are therefore not always found by 
     // the MERGE command within entity creation.  The current workaround is to make 
     // sure all entities are created before relationship creation occurs.
     await iterateParsedGraphFiles(handleGraphObjectEntityFiles, pathToData);

--- a/packages/integration-sdk-cli/src/neo4j/uploadToNeo4j.ts
+++ b/packages/integration-sdk-cli/src/neo4j/uploadToNeo4j.ts
@@ -36,11 +36,15 @@ export async function uploadToNeo4j({
     integrationInstanceID: integrationInstanceID,
   });
 
-  async function handleGraphObjectEntityFiles(parsedData: FlushedGraphObjectData) {
+  async function handleGraphObjectEntityFiles(
+    parsedData: FlushedGraphObjectData,
+  ) {
     if (parsedData.entities) await store.addEntities(parsedData.entities);
   }
 
-  async function handleGraphObjectRelationshipFiles(parsedData: FlushedGraphObjectData) {
+  async function handleGraphObjectRelationshipFiles(
+    parsedData: FlushedGraphObjectData,
+  ) {
     if (parsedData.relationships)
       await store.addRelationships(parsedData.relationships);
   }
@@ -51,13 +55,16 @@ export async function uploadToNeo4j({
     // only uses indexes and not constraints due to the fact that we would need a node
     // key constraint consisting of both the _key value as well as the _integrationInstanceID
     // value and that would require users to have an enterprise Neo4j instance instead
-    // of just a community version.  Additionally, MERGE commands within relationship 
+    // of just a community version.  Additionally, MERGE commands within relationship
     // creation to create the start and end nodes if they do not yet exist do not always
-    // have access to the Type label during creation, and are therefore not always found by 
-    // the MERGE command within entity creation.  The current workaround is to make 
+    // have access to the Type label during creation, and are therefore not always found by
+    // the MERGE command within entity creation.  The current workaround is to make
     // sure all entities are created before relationship creation occurs.
     await iterateParsedGraphFiles(handleGraphObjectEntityFiles, pathToData);
-    await iterateParsedGraphFiles(handleGraphObjectRelationshipFiles, pathToData);
+    await iterateParsedGraphFiles(
+      handleGraphObjectRelationshipFiles,
+      pathToData,
+    );
   } finally {
     await store.close();
   }

--- a/packages/integration-sdk-cli/src/neo4j/uploadToNeo4j.ts
+++ b/packages/integration-sdk-cli/src/neo4j/uploadToNeo4j.ts
@@ -36,14 +36,28 @@ export async function uploadToNeo4j({
     integrationInstanceID: integrationInstanceID,
   });
 
-  async function handleGraphObjectFile(parsedData: FlushedGraphObjectData) {
+  async function handleGraphObjectEntityFiles(parsedData: FlushedGraphObjectData) {
     if (parsedData.entities) await store.addEntities(parsedData.entities);
+  }
+
+  async function handleGraphObjectRelationshipFiles(parsedData: FlushedGraphObjectData) {
     if (parsedData.relationships)
       await store.addRelationships(parsedData.relationships);
   }
 
   try {
-    await iterateParsedGraphFiles(handleGraphObjectFile, pathToData);
+    // We have to traverse all graph files twice so that we can first create all
+    // entities followed by all relationships.  The current Neo4j data architecture
+    // only uses indexes and not constraints due to the fact that we would need a node
+    // key constraint consisting of both the _key value as well as the _integrationInstanceID
+    // value and that would require users to have an enterprise Neo4j instance instead
+    // of just a community version.  Additionally, MERGE commands within relationship 
+    // creation to create the start and end nodes if they do not yet exist are not able 
+    // to set the Type label correctly always, and are therefore not always found by 
+    // the MERGE command within entity creation.  The current workaround is to make 
+    // sure all entities are created before relationship creation occurs.
+    await iterateParsedGraphFiles(handleGraphObjectEntityFiles, pathToData);
+    await iterateParsedGraphFiles(handleGraphObjectRelationshipFiles, pathToData);
   } finally {
     await store.close();
   }


### PR DESCRIPTION
Fix Starbase Duplicate Nodes

Forcing entity creation prior to relationship creation for Neo4j uploads to fix intermittent duplicate node error.

I provided the following detailed info in an inline comment regarding why we need to make this change:

_We have to traverse all graph files twice so that we can first create all entities followed by all relationships.  The current Neo4j data architecture only uses indexes and not constraints due to the fact that we would need a node key constraint consisting of both the _key value as well as the _integrationInstanceID value and that would require users to have an enterprise Neo4j instance instead of just a community version.  Additionally, MERGE commands within relationship creation to create the start and end nodes if they do not yet exist do not always have access to the Type label during creation, and are therefore not always found by the MERGE command within entity creation.  The current workaround is to make sure all entities are created before relationship creation occurs._