### PR TITLE
INT-3984 - Support --disable-schema-validation option in run command

### DIFF
--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -1319,6 +1319,8 @@ The `j1-integration run` command combines the functionality of the `collect` and
 `sync` commands, essentially running the commands back to back.
 
 The `run` command accepts the same options that the `sync` command accepts.
+Additionally, `run` accepts the `--disable-schema-validation` option that allows
+disabling schema validation in the same way as the `collect` command.
 
 There are some differences when performing `run` compared to individually
 running `collect` and `sync`.

--- a/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
@@ -61,6 +61,25 @@ test('enables graph object schema validation', async () => {
   expect(process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION).toBeDefined();
 });
 
+test('disables graph object schema validation', async () => {
+  const job = generateSynchronizationJob();
+
+  setupSynchronizerApi({ polly, job, baseUrl: 'https://api.us.jupiterone.io' });
+
+  expect(process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION).toBeUndefined();
+
+  await createCli().parseAsync([
+    'node',
+    'j1-integration',
+    'run',
+    '--integrationInstanceId',
+    'test',
+    '--disable-schema-validation',
+  ]);
+
+  expect(process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION).toBeUndefined();
+});
+
 test('executes integration and performs upload', async () => {
   const job = generateSynchronizationJob();
 

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -41,6 +41,7 @@ export function run() {
       !!process.env.JUPITERONE_DEV,
     )
     .option('--api-base-url <url>', 'API base URL used during run operation.')
+    .option('-V, --disable-schema-validation', 'disable schema validation')
     .action(async (options) => {
       const projectPath = path.resolve(options.projectPath);
       // Point `fileSystem.ts` functions to expected location relative to
@@ -111,6 +112,7 @@ export function run() {
       });
 
       try {
+        const enableSchemaValidation = !options.disableSchemaValidation;
         const executionResults = await executeIntegrationInstance(
           logger,
           createIntegrationInstanceForLocalExecution(invocationConfig),
@@ -121,7 +123,7 @@ export function run() {
             },
           },
           {
-            enableSchemaValidation: true,
+            enableSchemaValidation,
             graphObjectStore,
             createStepGraphObjectDataUploader(stepId) {
               return createPersisterApiStepGraphObjectDataUploader({


### PR DESCRIPTION
Adding support to be able to pass --disable-schema-validation to the j1-integration run command (fix for Issue #626 )