### PR TITLE
INT-4145 - Step failure events do not expose original auth errors

### DIFF
--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -537,6 +537,46 @@ describe('createErrorEventDescription', () => {
       `testing (errorCode="${error.code}", errorId="${errorId}", reason="soba")`,
     );
   });
+
+  test('displays code and message from error if error is an IntegrationProviderAuthorizationError', () => {
+    const cause = new Error('original error');
+
+    const error = new IntegrationProviderAuthorizationError({
+      cause,
+      endpoint: 'https://api.jupiterone.io',
+      status: 403,
+      statusText: 'status text',
+    });
+
+    const { description, errorId } = createErrorEventDescription(
+      error,
+      'some job log event message',
+    );
+
+    expect(description).toEqual(
+      `some job log event message Failed to access provider resource. This integration is likely misconfigured or has insufficient permissions required to access the resource. Please ensure your integration's configuration settings are set up correctly. (errorCode="${error.code}", errorId="${errorId}", reason="Provider authorization failed at https://api.jupiterone.io: 403 status text")`,
+    );
+  });
+
+  test('displays code and message from error if error is an IntegrationProviderAuthenticationError', () => {
+    const cause = new Error('original error');
+
+    const error = new IntegrationProviderAuthenticationError({
+      cause,
+      endpoint: 'https://api.jupiterone.io',
+      status: 403,
+      statusText: 'status text',
+    });
+
+    const { description, errorId } = createErrorEventDescription(
+      error,
+      'some job log event message',
+    );
+
+    expect(description).toEqual(
+      `some job log event message Failed to access provider resource. This integration is likely misconfigured or has insufficient permissions required to access the resource. Please ensure your integration's configuration settings are set up correctly. (errorCode="${error.code}", errorId="${errorId}", reason="Provider authentication failed at https://api.jupiterone.io: 403 status text")`,
+    );
+  });
 });
 
 describe('publishMetric', () => {

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -413,18 +413,18 @@ export function createErrorEventDescription(
   let errorCode: string;
   let errorReason: string;
 
-  if (err instanceof IntegrationError) {
+  if (isProviderAuthError(err)) {
+    errorCode = err.code;
+    errorReason = err.message;
+    // add additional instructions to the displayed message
+    // if we know that this is an auth error
+    message += PROVIDER_AUTH_ERROR_HELP;
+  } else if (err instanceof IntegrationError) {
     errorCode = err.code;
     errorReason = err.message;
   } else {
     errorCode = UNEXPECTED_ERROR_CODE;
     errorReason = UNEXPECTED_ERROR_REASON;
-  }
-
-  if (isProviderAuthError(err)) {
-    // add additional instructions to the displayed message
-    // if we know that this is an auth error
-    message += PROVIDER_AUTH_ERROR_HELP;
   }
 
   const nameValuePairs: NameValuePair[] = [


### PR DESCRIPTION
If an integration step threw an `IntegrationProviderAuthorizationError` or an
`IntegrationProviderAuthenticationError`, the integration wasn't reporting a job
event that includes the original details. Instead, the user was seeing an
`UNEXPECTED_ERROR` in their job log.

Fixes #735 - See issue for more details.