### PR TITLE
Add `--upload-batch-size` option

### DIFF
--- a/packages/integration-sdk-cli/src/commands/collect.ts
+++ b/packages/integration-sdk-cli/src/commands/collect.ts
@@ -41,10 +41,6 @@ export function collect() {
       'Can be used with the `--step` to specify a path to a non-default cache location.',
     )
     .option('-V, --disable-schema-validation', 'disable schema validation')
-    .option(
-      '-b, --buffer-size <number>',
-      'specify maximum number of entities and relationships per buffer or file (default 500)',
-    )
     .action(async (options) => {
       if (!options.cache && options.step.length === 0) {
         throw new Error(
@@ -85,7 +81,6 @@ export function collect() {
       const graphObjectStore = new FileSystemGraphObjectStore({
         prettifyFiles: true,
         integrationSteps: config.integrationSteps,
-        graphObjectBufferThreshold: options.bufferSize,
       });
 
       const enableSchemaValidation = !options.disableSchemaValidation;

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -42,10 +42,6 @@ export function run() {
     )
     .option('--api-base-url <url>', 'API base URL used during run operation.')
     .option('-V, --disable-schema-validation', 'disable schema validation')
-    .option(
-      '-b, --buffer-size <number>',
-      'specify maximum number of entities and relationships per buffer or file (default 500)',
-    )
     .action(async (options) => {
       const projectPath = path.resolve(options.projectPath);
       // Point `fileSystem.ts` functions to expected location relative to
@@ -113,7 +109,6 @@ export function run() {
       const graphObjectStore = new FileSystemGraphObjectStore({
         prettifyFiles: true,
         integrationSteps: invocationConfig.integrationSteps,
-        graphObjectBufferThreshold: options.bufferSize,
       });
 
       try {

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -42,6 +42,7 @@ export function run() {
     )
     .option('--api-base-url <url>', 'API base URL used during run operation.')
     .option('-V, --disable-schema-validation', 'disable schema validation')
+    .option('-u, --upload-batch-size <number>', 'specify number of items per batch for upload (default 250)')
     .action(async (options) => {
       const projectPath = path.resolve(options.projectPath);
       // Point `fileSystem.ts` functions to expected location relative to
@@ -130,6 +131,7 @@ export function run() {
                 stepId,
                 synchronizationJobContext: synchronizationContext,
                 uploadConcurrency: DEFAULT_UPLOAD_CONCURRENCY,
+                uploadBatchSize: options.uploadBatchSize
               });
             },
           },

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -42,7 +42,10 @@ export function run() {
     )
     .option('--api-base-url <url>', 'API base URL used during run operation.')
     .option('-V, --disable-schema-validation', 'disable schema validation')
-    .option('-u, --upload-batch-size <number>', 'specify number of items per batch for upload (default 250)')
+    .option(
+      '-u, --upload-batch-size <number>',
+      'specify number of items per batch for upload (default 250)',
+    )
     .action(async (options) => {
       const projectPath = path.resolve(options.projectPath);
       // Point `fileSystem.ts` functions to expected location relative to
@@ -131,7 +134,7 @@ export function run() {
                 stepId,
                 synchronizationJobContext: synchronizationContext,
                 uploadConcurrency: DEFAULT_UPLOAD_CONCURRENCY,
-                uploadBatchSize: options.uploadBatchSize
+                uploadBatchSize: options.uploadBatchSize,
               });
             },
           },

--- a/packages/integration-sdk-cli/src/commands/sync.ts
+++ b/packages/integration-sdk-cli/src/commands/sync.ts
@@ -32,6 +32,7 @@ export function sync() {
       !!process.env.JUPITERONE_DEV,
     )
     .option('--api-base-url <url>', 'API base URL used during sync operation.')
+    .option('-u, --upload-batch-size <number>', 'specify number of items per batch for upload (default 250)')
     .action(async (options) => {
       // Point `fileSystem.ts` functions to expected location relative to
       // integration project path.
@@ -73,11 +74,11 @@ export function sync() {
         name: 'local',
         pretty: true,
       });
-
       const job = await synchronizeCollectedData({
         logger: logger.child({ integrationInstanceId }),
         apiClient,
         integrationInstanceId,
+        uploadBatchSize: options.uploadBatchSize,
       });
 
       log.displaySynchronizationResults(job);

--- a/packages/integration-sdk-cli/src/commands/sync.ts
+++ b/packages/integration-sdk-cli/src/commands/sync.ts
@@ -32,7 +32,10 @@ export function sync() {
       !!process.env.JUPITERONE_DEV,
     )
     .option('--api-base-url <url>', 'API base URL used during sync operation.')
-    .option('-u, --upload-batch-size <number>', 'specify number of items per batch for upload (default 250)')
+    .option(
+      '-u, --upload-batch-size <number>',
+      'specify number of items per batch for upload (default 250)',
+    )
     .action(async (options) => {
       // Point `fileSystem.ts` functions to expected location relative to
       // integration project path.

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -98,7 +98,7 @@ export async function initiateSynchronization({
   apiClient,
   integrationInstanceId,
   integrationJobId,
-  uploadBatchSize
+  uploadBatchSize,
 }: SynchronizeInput): Promise<SynchronizationJobContext> {
   logger.info('Initiating synchronization job...');
 

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -41,6 +41,7 @@ export interface SynchronizeInput {
   apiClient: ApiClient;
   integrationInstanceId: string;
   integrationJobId?: string;
+  uploadBatchSize?: number | undefined;
 }
 
 /**
@@ -50,7 +51,6 @@ export async function synchronizeCollectedData(
   input: SynchronizeInput,
 ): Promise<SynchronizationJob> {
   const jobContext = await initiateSynchronization(input);
-
   const eventPublishingQueue = createEventPublishingQueue(jobContext);
   jobContext.logger.on('event', (event) => eventPublishingQueue.enqueue(event));
 
@@ -87,6 +87,7 @@ export interface SynchronizationJobContext {
   apiClient: ApiClient;
   job: SynchronizationJob;
   logger: IntegrationLogger;
+  uploadBatchSize?: number | undefined;
 }
 
 /**
@@ -97,6 +98,7 @@ export async function initiateSynchronization({
   apiClient,
   integrationInstanceId,
   integrationJobId,
+  uploadBatchSize
 }: SynchronizeInput): Promise<SynchronizationJobContext> {
   logger.info('Initiating synchronization job...');
 
@@ -124,6 +126,7 @@ export async function initiateSynchronization({
       integrationJobId: job.integrationJobId,
       integrationInstanceId: job.integrationInstanceId,
     }),
+    uploadBatchSize,
   };
 }
 
@@ -245,7 +248,7 @@ export async function uploadCollectedData(context: SynchronizationJobContext) {
   context.logger.synchronizationUploadStart(context.job);
 
   async function uploadGraphObjectFile(parsedData: FlushedGraphObjectData) {
-    await uploadGraphObjectData(context, parsedData);
+    await uploadGraphObjectData(context, parsedData, context.uploadBatchSize);
   }
 
   await timeOperation({


### PR DESCRIPTION
- Adding `--upload-batch-size` option for `sync` and `run` commands.
- Removing no longer needed `--buffer-size` command.