### PR TITLE
Add skipped steps to event log

### DIFF
--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -45,7 +45,7 @@ export interface InvocationConfig<
    * graphs in a specific order. These values should match the
    * StepMetadata `dependencyGraphId` prpoperties.
    *
-   * If this is not provided, all steps will be evalueted in
+   * If this is not provided, all steps will be evaluated in
    * the same dependency graph.
    */
   dependencyGraphOrder?: string[];

--- a/packages/integration-sdk-core/src/types/logger.ts
+++ b/packages/integration-sdk-core/src/types/logger.ts
@@ -11,6 +11,7 @@ interface ChildLogFunction {
 }
 
 type StepLogFunction = (step: StepMetadata) => void;
+type StepLogFunctionWithMessage = (step: StepMetadata, reason?: string) => void;
 type StepLogFunctionWithError = (step: StepMetadata, err: Error) => void;
 type SynchronizationLogFunction = (job: SynchronizationJob) => void;
 type ValidationLogFunction = (err: Error) => void;
@@ -112,6 +113,7 @@ export interface IntegrationLoggerFunctions {
   stepStart: StepLogFunction;
   stepSuccess: StepLogFunction;
   stepFailure: StepLogFunctionWithError;
+  stepSkip: StepLogFunctionWithMessage;
   synchronizationUploadStart: SynchronizationLogFunction;
   synchronizationUploadEnd: SynchronizationLogFunction;
 

--- a/packages/integration-sdk-core/src/types/logger.ts
+++ b/packages/integration-sdk-core/src/types/logger.ts
@@ -1,4 +1,4 @@
-import { StepMetadata } from './';
+import { DisabledStepReason, StepMetadata } from './';
 import { SynchronizationJob } from './synchronization';
 import { Metric } from './metric';
 
@@ -11,7 +11,10 @@ interface ChildLogFunction {
 }
 
 type StepLogFunction = (step: StepMetadata) => void;
-type StepLogFunctionWithMessage = (step: StepMetadata, reason?: string) => void;
+type StepLogFunctionWithReason = (
+  step: StepMetadata,
+  reason: DisabledStepReason,
+) => void;
 type StepLogFunctionWithError = (step: StepMetadata, err: Error) => void;
 type SynchronizationLogFunction = (job: SynchronizationJob) => void;
 type ValidationLogFunction = (err: Error) => void;
@@ -113,7 +116,7 @@ export interface IntegrationLoggerFunctions {
   stepStart: StepLogFunction;
   stepSuccess: StepLogFunction;
   stepFailure: StepLogFunctionWithError;
-  stepSkip: StepLogFunctionWithMessage;
+  stepSkip: StepLogFunctionWithReason;
   synchronizationUploadStart: SynchronizationLogFunction;
   synchronizationUploadEnd: SynchronizationLogFunction;
 

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -11,6 +11,13 @@ import {
 import { IntegrationInstanceConfig } from './instance';
 import { RelationshipDirection } from './relationship';
 
+export enum DisabledStepReason {
+  NONE = 'none', // No reason was provided
+  PERMISSION = 'permission', // Missing permission disabled this step
+  BETA = 'beta', // Step is in beta and only enabled on request
+  CONFIG = 'config', // Step was disabled via config
+}
+
 export interface StepStartState {
   /**
    * Indicates the step is disabled and should not be
@@ -19,10 +26,10 @@ export interface StepStartState {
   disabled: boolean;
 
   /**
-   * Message to user describing why the step was disabled.
-   * Should be user-friendly!
+   * Allows for a user-friendly message to explain
+   * why a step is disabled.
    */
-  disabledReason?: string;
+  disabledReason?: DisabledStepReason;
 
   /**
    * Provides a filepath to a cache for the given step.

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -19,6 +19,12 @@ export interface StepStartState {
   disabled: boolean;
 
   /**
+   * Message to user describing why the step was disabled.
+   * Should be user-friendly!
+   */
+  disabledReason?: string;
+
+  /**
    * Provides a filepath to a cache for the given step.
    * This cache will be loaded instead of executing the step.
    */

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -3,6 +3,7 @@ import PromiseQueue from 'p-queue';
 
 import {
   BeforeAddEntityHookFunction,
+  DisabledStepReason,
   Entity,
   ExecutionContext,
   IntegrationStepResult,
@@ -155,7 +156,7 @@ export function executeStepDependencyGraph<
 
   /**
    * Safely removes a step from the workingGraph, ensuring
-   * that dependencys are removed.
+   * that dependencies are removed.
    *
    * This function helps create new leaf nodes to execute.
    */
@@ -245,8 +246,8 @@ export function executeStepDependencyGraph<
          * and prevents dependent steps from executing.
          */
         if (stepDependenciesAreComplete(stepId)) {
+          removeStepFromWorkingGraph(stepId);
           if (isStepEnabled(stepId)) {
-            removeStepFromWorkingGraph(stepId);
             void promiseQueue.add(() =>
               timeOperation({
                 logger: executionContext.logger,
@@ -262,7 +263,11 @@ export function executeStepDependencyGraph<
             // Step is disabled
             executionContext.logger
               .child({ stepId })
-              .stepSkip(step, stepStartStates[stepId]?.disabledReason);
+              .stepSkip(
+                step,
+                stepStartStates[stepId]?.disabledReason ??
+                  DisabledStepReason.NONE,
+              );
           }
         }
       });

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -271,8 +271,8 @@ export function executeStepDependencyGraph<
                   stepStartStates[stepId]?.disabledReason ??
                     DisabledStepReason.NONE,
                 );
+              skippedStepTracker.add(stepId);
             }
-            skippedStepTracker.add(stepId);
           }
         }
       });

--- a/packages/integration-sdk-runtime/src/execution/step.ts
+++ b/packages/integration-sdk-runtime/src/execution/step.ts
@@ -64,7 +64,7 @@ export async function executeSteps<
     if (!steps) {
       executionContext.logger.warn(
         { graphId },
-        'A graphId in the dependencyGraphOrder was not refrenced by any steps.',
+        'A graphId in the dependencyGraphOrder was not referenced by any steps.',
       );
       continue;
     }

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -312,12 +312,13 @@ describe('step event publishing', () => {
 
     logger.stepStart(step);
     logger.stepSuccess(step);
+    logger.stepSkip(step, 'Beta feature, please contact J1 to enable.');
 
     // just use some error that contains a code
     const error = new IntegrationLocalConfigFieldMissingError('ripperoni');
     logger.stepFailure(step, error);
 
-    expect(onEmitEvent).toHaveBeenCalledTimes(3);
+    expect(onEmitEvent).toHaveBeenCalledTimes(4);
     expect(onEmitEvent).toHaveBeenNthCalledWith(1, {
       name: 'step_start',
       level: PublishEventLevel.Info,
@@ -329,6 +330,12 @@ describe('step event publishing', () => {
       description: 'Completed step "Mochi".',
     });
     expect(onEmitEvent).toHaveBeenNthCalledWith(3, {
+      name: 'step_skip',
+      level: PublishEventLevel.Info,
+      description:
+        'Skipped step "Mochi". Beta feature, please contact J1 to enable.',
+    });
+    expect(onEmitEvent).toHaveBeenNthCalledWith(4, {
       name: 'step_failure',
       level: PublishEventLevel.Error,
       description: expect.stringMatching(

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -286,6 +286,16 @@ export class IntegrationLogger
     this.publishEvent({ name, description });
   }
 
+  stepSkip(step: StepMetadata, reason?: string) {
+    const name = 'step_skip';
+    let description = `Skipped step "${step.name}".`;
+    if (reason) {
+      description += ` ${reason}`;
+    }
+    this.info(description);
+    this.publishEvent({ name, description });
+  }
+
   stepFailure(step: StepMetadata, err: Error) {
     const eventName = 'step_failure';
     const { errorId, description } = createErrorEventDescription(

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -27,6 +27,7 @@ import {
   IntegrationEvent,
   PublishInfoEventInput,
   PublishErrorEventInput,
+  DisabledStepReason,
 } from '@jupiterone/integration-sdk-core';
 
 export * from './registerEventHandlers';
@@ -286,12 +287,28 @@ export class IntegrationLogger
     this.publishEvent({ name, description });
   }
 
-  stepSkip(step: StepMetadata, reason?: string) {
-    const name = 'step_skip';
-    let description = `Skipped step "${step.name}".`;
-    if (reason) {
-      description += ` ${reason}`;
+  stepSkip(step: StepMetadata, reason: DisabledStepReason) {
+    if (!reason || reason === DisabledStepReason.NONE) {
+      return;
     }
+
+    const name = 'step_skip';
+    let description = `Skipped step "${step.name}". `;
+
+    switch (reason) {
+      case DisabledStepReason.BETA: {
+        description += `Beta feature, please contact support to enable.`;
+        break;
+      }
+      case DisabledStepReason.PERMISSION: {
+        description += `The required permission was not provided to perform this step.`;
+        break;
+      }
+      case DisabledStepReason.CONFIG: {
+        description += `This step is disabled via configuration. Please contact support to enabled.`;
+      }
+    }
+
     this.info(description);
     this.publishEvent({ name, description });
   }


### PR DESCRIPTION
## Purpose
The desired result of this change is to provide users an understanding of all possible steps available in an integration

## How?
Before a step is executed, the stepStartState is reference to see if the step is disabled. Prior to this change, if the step was disabled nothing would happen. Now, we add a job event log for the step indicating to the user that the step was disabled. Within the StepStartState, each step can be provided a reason for why it is disabled. It is the responsibility of the graph-* project to indicate why it was disabled. 

I believe this a positive change to exposing more information to the user about their integrations.