### PR TITLE
Enforce fromEntityKey and toEntityKey exist in job state when using .toMatchStepMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added an optional `encounteredEntityKeys` property on `.toMatchStepMetadata()`
+  to verify that any relationship `_fromEntityKey` and `_toEntityKey` has
+  actually been encountered in the job state.
+
 ## [8.15.0] - 2022-06-22
 
 ### Changed

--- a/packages/integration-sdk-testing/src/executeStepWithDependencies.ts
+++ b/packages/integration-sdk-testing/src/executeStepWithDependencies.ts
@@ -56,5 +56,9 @@ export async function executeStepWithDependencies(params: StepTestConfig) {
     collectedRelationships: context.jobState.collectedRelationships,
     collectedData: context.jobState.collectedData,
     encounteredTypes: context.jobState.encounteredTypes,
+    encounteredEntityKeys: new Set<string>([
+      ...context.jobState.collectedEntities.map((e) => e._key),
+      ...preContext.jobState.collectedEntities.map((e) => e._key),
+    ]),
   };
 }

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -638,6 +638,7 @@ export function toMatchStepMetadata(
   results: {
     collectedEntities: Entity[];
     collectedRelationships: Relationship[];
+    encounteredEntityKeys?: Set<string>;
   },
   testConfig: Omit<StepTestConfig, 'instanceConfig'>,
 ): SyncExpectationResult {
@@ -748,6 +749,55 @@ export function toMatchStepMetadata(
       message: () =>
         `Expected 0 mapped relationships, got ${collectedMappedRelationships.length}. (declaredTypes=${declaredTypes}, encounteredTypes=${encounteredTypes})`,
     };
+  }
+
+  if (results.encounteredEntityKeys != undefined) {
+    const relationshipsMissingEntityKeys: {
+      [relationshipType: string]: {
+        missingFromEntityKey: boolean;
+        missingToEntityKey: boolean;
+      };
+    } = {};
+    for (const directRelationship of collectedDirectRelationships) {
+      const fromEntityKeyExists = results.encounteredEntityKeys.has(
+        directRelationship._fromEntityKey as string,
+      );
+      const toEntityKeyExists = results.encounteredEntityKeys.has(
+        directRelationship._toEntityKey as string,
+      );
+      if (!fromEntityKeyExists || !toEntityKeyExists) {
+        if (!relationshipsMissingEntityKeys[directRelationship._type]) {
+          relationshipsMissingEntityKeys[directRelationship._type] = {
+            missingFromEntityKey: false,
+            missingToEntityKey: false,
+          };
+        }
+
+        if (!fromEntityKeyExists) {
+          relationshipsMissingEntityKeys[
+            directRelationship._type
+          ].missingFromEntityKey = true;
+        }
+
+        if (!toEntityKeyExists) {
+          relationshipsMissingEntityKeys[
+            directRelationship._type
+          ].missingToEntityKey = true;
+        }
+      }
+    }
+
+    if (Object.keys(relationshipsMissingEntityKeys).length > 0) {
+      return {
+        pass: false,
+        message: () =>
+          `Some direct relationships contain from/to entity keys which do not exist in the jobState: ${JSON.stringify(
+            relationshipsMissingEntityKeys,
+            null,
+            2,
+          )}`,
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
### Added

- Added an optional `encounteredEntityKeys` property on `.toMatchStepMetadata()` to verify that any relationship `_fromEntityKey` and `_toEntityKey` has actually been encountered in the job state.

---
Usage remains the same as it was before:

```ts
test('fetch-users', async () => {
  recording = setupProjectRecording({
    directory: __dirname,
    name: 'fetch-users',
  });

  const stepConfig = buildStepTestConfigForStep(Steps.USERS);
  const stepResult = await executeStepWithDependencies(stepConfig);
  expect(stepResult).toMatchStepMetadata(stepConfig);
});
```

However, tests will now fail with the following if `_fromEntityKey` or `_toEntityKey` target an entity that was _not_ encountered: 

```
  ● buildVpcRouteTableRels exec handler

    Some direct relationships contain from/to entity keys which do not exist in the jobState: {
      "aws_vpc_has_aws_route_table": {
        "missingFromEntityKey": true,
        "missingToEntityKey": true
      }
    }

      35 |   );
      36 |   const stepResult = await executeStepWithDependencies(stepConfig);
    > 37 |   expect(stepResult).toMatchStepMetadata(stepConfig);
         |                      ^
      38 | });
      39 |

      at Object.<anonymous> (src/steps/services/ec2/executionHandlers/routeTables.test.ts:37:22)
```