### PR TITLE
Adding Relationship Upload Batch Size option

### DIFF
--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -46,6 +46,10 @@ export function run() {
       '-u, --upload-batch-size <number>',
       'specify number of items per batch for upload (default 250)',
     )
+    .option(
+      '-ur, --upload-relationship-batch-size <number>',
+      'specify number of relationships per batch for upload (default 250)',
+    )
     .action(async (options) => {
       const projectPath = path.resolve(options.projectPath);
       // Point `fileSystem.ts` functions to expected location relative to
@@ -135,6 +139,8 @@ export function run() {
                 synchronizationJobContext: synchronizationContext,
                 uploadConcurrency: DEFAULT_UPLOAD_CONCURRENCY,
                 uploadBatchSize: options.uploadBatchSize,
+                uploadRelationshipsBatchSize:
+                  options.uploadRelationshipBatchSize,
               });
             },
           },

--- a/packages/integration-sdk-cli/src/commands/sync.ts
+++ b/packages/integration-sdk-cli/src/commands/sync.ts
@@ -36,6 +36,10 @@ export function sync() {
       '-u, --upload-batch-size <number>',
       'specify number of items per batch for upload (default 250)',
     )
+    .option(
+      '-ur, --upload-relationship-batch-size <number>',
+      'specify number of relationships per batch for upload (default 250)',
+    )
     .action(async (options) => {
       // Point `fileSystem.ts` functions to expected location relative to
       // integration project path.
@@ -82,6 +86,7 @@ export function sync() {
         apiClient,
         integrationInstanceId,
         uploadBatchSize: options.uploadBatchSize,
+        uploadRelationshipBatchSize: options.uploadRelationshipBatchSize,
       });
 
       log.displaySynchronizationResults(job);

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -133,6 +133,7 @@ export interface CreatePersisterApiStepGraphObjectDataUploaderParams {
   synchronizationJobContext: SynchronizationJobContext;
   uploadConcurrency: number;
   uploadBatchSize?: number;
+  uploadRelationshipsBatchSize?: number;
 }
 
 export function createPersisterApiStepGraphObjectDataUploader({
@@ -140,6 +141,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
   synchronizationJobContext,
   uploadConcurrency,
   uploadBatchSize,
+  uploadRelationshipsBatchSize,
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
   return createQueuedStepGraphObjectDataUploader({
     stepId,
@@ -152,13 +154,19 @@ export function createPersisterApiStepGraphObjectDataUploader({
       });
 
       try {
-        await uploadGraphObjectData(context, graphObjectData, uploadBatchSize);
+        await uploadGraphObjectData(
+          context,
+          graphObjectData,
+          uploadBatchSize,
+          uploadRelationshipsBatchSize,
+        );
       } catch (err) {
         context.logger.error(
           {
             err,
             uploadConcurrency,
             uploadBatchSize,
+            uploadRelationshipsBatchSize,
           },
           'Error uploading graph object data',
         );

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -1,0 +1,165 @@
+import { FlushedGraphObjectData } from '../../storage/types';
+import {
+  createTestEntity,
+  createTestRelationship,
+} from '@jupiterone/integration-sdk-private-test-utils';
+import { v4 as uuid } from 'uuid';
+import { createApiClient, getApiBaseUrl } from '../../api';
+import { generateSynchronizationJob } from './util/generateSynchronizationJob';
+import { createMockIntegrationLogger } from '../../../test/util/fixtures';
+import { Entity, Relationship } from '@jupiterone/integration-sdk-core';
+import { SynchronizationJobContext, uploadGraphObjectData } from '..';
+
+function createFlushedGraphObjectData(
+  numEntity: number,
+  numRelationship: number,
+): FlushedGraphObjectData {
+  let entities: Entity[] = [];
+  for (let i = 0; i < numEntity; i++) {
+    entities.push(createTestEntity());
+  }
+  let relationships: Relationship[] = [];
+  for (let i = 0; i < numRelationship; i++) {
+    relationships.push(createTestRelationship());
+  }
+
+  return {
+    entities: entities,
+    relationships: relationships,
+  };
+}
+
+describe('#createPersisterApiStepGraphObjectDataUploader', () => {
+  const flushedObjectData = createFlushedGraphObjectData(20, 20);
+
+  test('should use different batch sizes when given a batchSize and relationshipBatchSize', async () => {
+    const apiClient = createApiClient({
+      apiBaseUrl: getApiBaseUrl(),
+      account: uuid(),
+    });
+
+    const postSpy = jest.spyOn(apiClient, 'post').mockResolvedValue({});
+
+    const job = generateSynchronizationJob();
+    const synchronizationJobContext: SynchronizationJobContext = {
+      logger: createMockIntegrationLogger(),
+      apiClient,
+      job,
+    };
+
+    await uploadGraphObjectData(
+      synchronizationJobContext,
+      flushedObjectData,
+      5,
+      10,
+    );
+
+    const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
+    const relationshipsCalls = postSpy.mock.calls.filter(
+      (c) => c[1].relationships,
+    );
+
+    for (const call of entityCalls) {
+      expect(call[1].entities.length).toBeLessThanOrEqual(5);
+    }
+    for (const call of relationshipsCalls) {
+      expect(call[1].relationships.length).toBeLessThanOrEqual(10);
+    }
+  });
+
+  test('should use batchSize when no relationship batchSize given', async () => {
+    const apiClient = createApiClient({
+      apiBaseUrl: getApiBaseUrl(),
+      account: uuid(),
+    });
+
+    const postSpy = jest.spyOn(apiClient, 'post').mockResolvedValue({});
+
+    const job = generateSynchronizationJob();
+    const synchronizationJobContext: SynchronizationJobContext = {
+      logger: createMockIntegrationLogger(),
+      apiClient,
+      job,
+    };
+
+    await uploadGraphObjectData(
+      synchronizationJobContext,
+      flushedObjectData,
+      5,
+    );
+
+    const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
+    const relationshipsCalls = postSpy.mock.calls.filter(
+      (c) => c[1].relationships,
+    );
+
+    for (const call of entityCalls) {
+      expect(call[1].entities.length).toBeLessThanOrEqual(5);
+    }
+    for (const call of relationshipsCalls) {
+      expect(call[1].relationships.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  test('should still use separate relationship batch size when entity batch size not given', async () => {
+    const apiClient = createApiClient({
+      apiBaseUrl: getApiBaseUrl(),
+      account: uuid(),
+    });
+
+    const postSpy = jest.spyOn(apiClient, 'post').mockResolvedValue({});
+
+    const job = generateSynchronizationJob();
+    const synchronizationJobContext: SynchronizationJobContext = {
+      logger: createMockIntegrationLogger(),
+      apiClient,
+      job,
+    };
+
+    await uploadGraphObjectData(
+      synchronizationJobContext,
+      flushedObjectData,
+      undefined,
+      5,
+    );
+
+    const relationshipsCalls = postSpy.mock.calls.filter(
+      (c) => c[1].relationships,
+    );
+
+    for (const call of relationshipsCalls) {
+      expect(call[1].relationships.length).toBeLessThanOrEqual(5);
+    }
+  });
+  test('should fall back to defaults when no batchSize given', async () => {
+    const apiClient = createApiClient({
+      apiBaseUrl: getApiBaseUrl(),
+      account: uuid(),
+    });
+
+    const postSpy = jest.spyOn(apiClient, 'post').mockResolvedValue({});
+
+    const job = generateSynchronizationJob();
+    const synchronizationJobContext: SynchronizationJobContext = {
+      logger: createMockIntegrationLogger(),
+      apiClient,
+      job,
+    };
+
+    await uploadGraphObjectData(synchronizationJobContext, flushedObjectData);
+
+    const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
+    const relationshipsCalls = postSpy.mock.calls.filter(
+      (c) => c[1].relationships,
+    );
+
+    // This test implicitly relies on the default being higher than 20
+    for (const call of entityCalls) {
+      expect(call[1].entities.length).toBe(20);
+    }
+
+    for (const call of relationshipsCalls) {
+      expect(call[1].relationships.length).toBe(20);
+    }
+  });
+});

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -14,11 +14,11 @@ function createFlushedGraphObjectData(
   numEntity: number,
   numRelationship: number,
 ): FlushedGraphObjectData {
-  let entities: Entity[] = [];
+  const entities: Entity[] = [];
   for (let i = 0; i < numEntity; i++) {
     entities.push(createTestEntity());
   }
-  let relationships: Relationship[] = [];
+  const relationships: Relationship[] = [];
   for (let i = 0; i < numRelationship; i++) {
     relationships.push(createTestRelationship());
   }

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -42,6 +42,7 @@ export interface SynchronizeInput {
   integrationInstanceId: string;
   integrationJobId?: string;
   uploadBatchSize?: number | undefined;
+  uploadRelationshipBatchSize?: number | undefined;
 }
 
 /**
@@ -88,6 +89,7 @@ export interface SynchronizationJobContext {
   job: SynchronizationJob;
   logger: IntegrationLogger;
   uploadBatchSize?: number | undefined;
+  uploadRelationshipBatchSize?: number | undefined;
 }
 
 /**
@@ -99,6 +101,7 @@ export async function initiateSynchronization({
   integrationInstanceId,
   integrationJobId,
   uploadBatchSize,
+  uploadRelationshipBatchSize,
 }: SynchronizeInput): Promise<SynchronizationJobContext> {
   logger.info('Initiating synchronization job...');
 
@@ -127,6 +130,7 @@ export async function initiateSynchronization({
       integrationInstanceId: job.integrationInstanceId,
     }),
     uploadBatchSize,
+    uploadRelationshipBatchSize,
   };
 }
 
@@ -253,7 +257,12 @@ export async function uploadCollectedData(context: SynchronizationJobContext) {
   context.logger.synchronizationUploadStart(context.job);
 
   async function uploadGraphObjectFile(parsedData: FlushedGraphObjectData) {
-    await uploadGraphObjectData(context, parsedData, context.uploadBatchSize);
+    await uploadGraphObjectData(
+      context,
+      parsedData,
+      context.uploadBatchSize,
+      context.uploadRelationshipBatchSize,
+    );
   }
 
   await timeOperation({

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -183,7 +183,12 @@ export async function uploadGraphObjectData(
   synchronizationJobContext: SynchronizationJobContext,
   graphObjectData: FlushedGraphObjectData,
   uploadBatchSize?: number,
+  uploadRelationshipsBatchSize?: number,
 ) {
+  const entityBatchSize = uploadBatchSize;
+  const relationshipsBatchSize =
+    uploadRelationshipsBatchSize || uploadBatchSize;
+
   try {
     if (
       Array.isArray(graphObjectData.entities) &&
@@ -200,7 +205,7 @@ export async function uploadGraphObjectData(
         synchronizationJobContext,
         'entities',
         graphObjectData.entities,
-        uploadBatchSize,
+        entityBatchSize,
       );
 
       synchronizationJobContext.logger.info(
@@ -226,7 +231,7 @@ export async function uploadGraphObjectData(
         synchronizationJobContext,
         'relationships',
         graphObjectData.relationships,
-        uploadBatchSize,
+        relationshipsBatchSize,
       );
 
       synchronizationJobContext.logger.info(


### PR DESCRIPTION
# Description

Relationships are often much smaller and much more certain in size than entities. Allowing a separate batch size for relationships would allow us to upload much faster.