### PR TITLE
Closes #757 - Introduce `beforeAddRelationship` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## Unreleased
 
+## 8.20.0 - 2021-07-16
+
+### Added
+
+- Introduce `beforeAddRelationship` hook into `IntegrationInvocationConfig`. See
+  the development documentation for more information on its usage.
+
 ## [8.19.0] - 2022-07-07
 
 ### Added

--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -323,6 +323,39 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
   };
 ```
 
+#### `beforeAddRelationship`
+
+`beforeAddRelationship` is an optional hook function that can be provided. The
+function is called before a relationship is added to the job state internally
+and the return value of the function is the relationship that will ultimately be
+added to the job state. The hook is particularly useful for when a specific
+property should be added to every relationship that is produced by the
+integration.
+
+Example:
+
+```typescript
+import {
+  Relationship,
+  IntegrationInvocationConfig,
+} from '@jupiterone/integration-sdk-core';
+import { IntegrationConfig, IntegrationStepContext } from './types';
+import getStepStartStates from './getStepStartStates';
+
+export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
+  {
+    instanceConfigFields: {},
+    integrationSteps: [],
+
+    beforeAddRelationship(
+      context: IntegrationExecutionContext<IntegrationConfig>,
+      relationship: Relationship,
+    ): Entity {
+      return relationship;
+    },
+  };
+```
+
 ### How integrations are executed
 
 The `IntegrationInvocationConfig` declaratively defines how an integration runs.

--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -350,7 +350,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
     beforeAddRelationship(
       context: IntegrationExecutionContext<IntegrationConfig>,
       relationship: Relationship,
-    ): Entity {
+    ): Relationship {
       return relationship;
     },
   };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.19.0",
-    "@jupiterone/integration-sdk-runtime": "^8.19.0",
+    "@jupiterone/integration-sdk-core": "^8.20.0",
+    "@jupiterone/integration-sdk-runtime": "^8.20.0",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do yarn prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.19.0",
-    "@jupiterone/integration-sdk-runtime": "^8.19.0",
+    "@jupiterone/integration-sdk-core": "^8.20.0",
+    "@jupiterone/integration-sdk-runtime": "^8.20.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^8.19.0",
+    "@jupiterone/integration-sdk-runtime": "^8.20.0",
     "chalk": "^4",
     "commander": "^5.0.0",
     "fs-extra": "^10.1.0",
@@ -37,7 +37,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.19.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.20.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -9,6 +9,7 @@ import {
   IntegrationExecutionConfig,
 } from './context';
 import { Entity } from './entity';
+import { Relationship } from './relationship';
 
 /**
  * Normalization transform for tracking keys in an integration. Allows
@@ -25,6 +26,10 @@ export type BeforeAddEntityHookFunction<
   TExecutionContext extends ExecutionContext,
 > = (context: TExecutionContext, entity: Entity) => Entity;
 
+export type BeforeAddRelationshipHookFunction<
+  TExecutionContext extends ExecutionContext,
+> = (context: TExecutionContext, relationship: Relationship) => Relationship;
+
 export type LoadExecutionConfigFunction<
   TInstanceConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,
   TExecutionConfig extends IntegrationExecutionConfig = IntegrationExecutionConfig,
@@ -39,6 +44,7 @@ export interface InvocationConfig<
   integrationSteps: Step<TStepExecutionContext>[];
   normalizeGraphObjectKey?: KeyNormalizationFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
+  beforeAddRelationship?: BeforeAddRelationshipHookFunction<TExecutionContext>;
   loadExecutionConfig?: LoadExecutionConfigFunction;
   /**
    * An optional array of identifiers used to execute dependency

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^8.19.0",
-    "@jupiterone/integration-sdk-testing": "^8.19.0",
+    "@jupiterone/integration-sdk-cli": "^8.20.0",
+    "@jupiterone/integration-sdk-testing": "^8.20.0",
     "@types/jest": "^27.1.0",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -27,8 +27,8 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^8.19.0",
-    "@jupiterone/integration-sdk-private-test-utils": "^8.19.0",
+    "@jupiterone/integration-sdk-dev-tools": "^8.20.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.20.0",
     "fetch-mock-jest": "^1.5.1"
   },
   "bugs": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.19.0",
+    "@jupiterone/integration-sdk-core": "^8.20.0",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.19.0",
+    "@jupiterone/integration-sdk-core": "^8.20.0",
     "@lifeomic/alpha": "^1.4.0",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.19.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.20.0",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -230,6 +230,7 @@ export async function executeWithContext<
       dataStore: new MemoryDataStore(),
       createStepGraphObjectDataUploader,
       beforeAddEntity: config.beforeAddEntity,
+      beforeAddRelationship: config.beforeAddRelationship,
       dependencyGraphOrder: config.dependencyGraphOrder,
     });
 

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -163,6 +163,7 @@ export interface CreateStepJobStateParams {
   dataStore: MemoryDataStore;
   uploader?: StepGraphObjectDataUploader;
   beforeAddEntity?: (entity: Entity) => Entity;
+  beforeAddRelationship?: (relationship: Relationship) => Relationship;
 }
 
 export function createStepJobState({
@@ -172,6 +173,7 @@ export function createStepJobState({
   graphObjectStore,
   dataStore,
   beforeAddEntity,
+  beforeAddRelationship,
   uploader,
 }: CreateStepJobStateParams): JobState {
   const addEntities = async (entities: Entity[]): Promise<Entity[]> => {
@@ -202,6 +204,10 @@ export function createStepJobState({
   };
 
   const addRelationships = (relationships: Relationship[]) => {
+    if (beforeAddRelationship) {
+      relationships = relationships.map(beforeAddRelationship);
+    }
+
     relationships.forEach((r) => {
       duplicateKeyTracker.registerKey(r._key, {
         _type: r._type,

--- a/packages/integration-sdk-runtime/src/execution/step.ts
+++ b/packages/integration-sdk-runtime/src/execution/step.ts
@@ -6,6 +6,7 @@ import { pick } from 'lodash';
 
 import {
   BeforeAddEntityHookFunction,
+  BeforeAddRelationshipHookFunction,
   ExecutionContext,
   IntegrationStepResult,
   InvocationConfig,
@@ -40,6 +41,7 @@ export async function executeSteps<
   dataStore,
   createStepGraphObjectDataUploader,
   beforeAddEntity,
+  beforeAddRelationship,
   dependencyGraphOrder,
 }: {
   executionContext: TExecutionContext;
@@ -50,6 +52,7 @@ export async function executeSteps<
   dataStore: MemoryDataStore;
   createStepGraphObjectDataUploader?: CreateStepGraphObjectDataUploaderFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
+  beforeAddRelationship?: BeforeAddRelationshipHookFunction<TExecutionContext>;
   dependencyGraphOrder?: string[];
 }): Promise<IntegrationStepResult[]> {
   const stepsByGraphId = seperateStepsByDependencyGraph(integrationSteps);
@@ -80,6 +83,7 @@ export async function executeSteps<
         dataStore,
         createStepGraphObjectDataUploader,
         beforeAddEntity,
+        beforeAddRelationship,
       }),
     );
   }

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.19.0",
-    "@jupiterone/integration-sdk-runtime": "^8.19.0",
+    "@jupiterone/integration-sdk-core": "^8.20.0",
+    "@jupiterone/integration-sdk-runtime": "^8.20.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.19.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.20.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
There are circumstances where an integration should apply some type of
mutation to all relationships. We should introduce a new hook called
`beforeAddRelationship` that is similar to `beforeAddEntity`.

Example usage:

```typescript
export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
  instanceConfigFields: {},
  integrationSteps: [],

  beforeAddRelationship(context: IntegrationStepContext, relationship: Relationship): Relationship {
    return {
      ...relationship,
      customProp: true
    };
  }
};
```