### PR TITLE
Add Step Collection Test Helper

### DIFF
--- a/packages/integration-sdk-testing/src/createStepTest.ts
+++ b/packages/integration-sdk-testing/src/createStepTest.ts
@@ -1,0 +1,68 @@
+import {
+  Entity,
+  IntegrationInstanceConfig,
+  IntegrationInvocationConfig,
+  Relationship,
+} from '@jupiterone/integration-sdk-core';
+import { StepTestConfig } from './config';
+import { executeStepWithDependencies } from './executeStepWithDependencies';
+import { setupRecording, SetupRecordingInput } from './recording';
+
+export type WithRecordingParams = SetupRecordingInput;
+
+export async function withRecording(
+  withRecordingParams: WithRecordingParams,
+  cb: () => Promise<void>,
+) {
+  const recording = setupRecording(withRecordingParams);
+
+  try {
+    await cb();
+  } finally {
+    await recording.stop();
+  }
+}
+
+type AfterStepCollectionExecutionParams = {
+  stepConfig: StepTestConfig<
+    IntegrationInvocationConfig<IntegrationInstanceConfig>,
+    IntegrationInstanceConfig
+  >;
+  stepResult: {
+    collectedEntities: Entity[];
+    collectedRelationships: Relationship[];
+    collectedData: {
+      [key: string]: any;
+    };
+    encounteredTypes: string[];
+  };
+};
+
+type CreateStepCollectionTestParams = {
+  recordingSetup: WithRecordingParams;
+  stepConfig: StepTestConfig;
+  afterExecute?: (params: AfterStepCollectionExecutionParams) => Promise<void>;
+};
+
+/**
+ * createStepCollectionTest creates a step collection test using a recording.
+ * The step collection test verifies that at least one of all declared entities
+ * and direct relationships are found in the collected data.
+ *
+ * NOTE: Mapped relationships are currently not supported
+ */
+export function createStepCollectionTest({
+  recordingSetup,
+  stepConfig,
+  afterExecute,
+}: CreateStepCollectionTestParams) {
+  return async () => {
+    await withRecording(recordingSetup, async () => {
+      const stepResult = await executeStepWithDependencies(stepConfig);
+
+      expect(stepResult).toMatchStepMetadata(stepConfig);
+
+      if (afterExecute) await afterExecute({ stepResult, stepConfig });
+    });
+  };
+}


### PR DESCRIPTION
# Description

This PR adds `createStepCollectionTest`, a utility to simplify the process of testing steps. First, thanks to @austinkelleher for creating the original implementation. See original implementation [here](https://github.com/JupiterOne/graph-snyk/blob/main/test/recording.ts) and example of usage [here](https://github.com/JupiterOne/graph-snyk/blob/main/src/steps/projects/index.test.ts).

The function here is slightly more general to allow the function to work across projects.

The original implementation used `StepId` and built the `StepTestConfig` for the user, but this is 1.) harder to implement in the SDK, 2.) doesn't allow testing different `StepTestConfig`s very easily. If a project (like the one I'm currently working on) uses different/optional configurations then it's necessary to test those separately.

Lastly, still working on the test for the test. Will update PR once those are ready. :smile: 

Any feedback on the interface would be great! Would love to have this be as painless and pretty for end-use as possible.

Example usage:
:file_folder: **`src/steps/examplestep/index.test.ts`**
```ts
test(
  'creates site entities',
  createStepCollectionTest({
    recordingSetup: {
      directory: __dirname,
      name: 'fetchSiteDetailsShouldCollectData',
      ...rumbleRecordingOptions,
    },
    stepConfig: buildStepTestConfigForAPIKey(Steps.SITES),
  }),
);
```

:file_folder: **`test/config.ts`**
```ts
export const apiKeyIntegrationConfig: IntegrationConfig = {
  accountAPIKey: process.env.ACCOUNT_API_KEY || DEFAULT_ACCOUNT_API_KEY,
  exportTokens: '',
};

export const exportTokensIntegrationConfig: IntegrationConfig = {
  accountAPIKey: '',
  exportTokens: process.env.EXPORT_TOKENS || DEFAULT_EXPORT_TOKENS,
};

export function buildStepTestConfigForAPIKey(stepId: string): StepTestConfig {
  return {
    stepId,
    instanceConfig: apiKeyIntegrationConfig,
    invocationConfig: invocationConfig as IntegrationInvocationConfig,
  };
}

export function buildStepTestConfigForExportTokens(
  stepId: string,
): StepTestConfig {
  return {
    stepId,
    instanceConfig: exportTokensIntegrationConfig,
    invocationConfig: invocationConfig as IntegrationInvocationConfig,
  };
}
```
:file_folder: **`test/recording.ts`**
```ts
...
export const rumbleRecordingOptions: Partial<SetupRecordingInput> = {
  mutateEntry: (entry) => redact(entry),
};
...
```
