### PR TITLE
Update ProviderSourceData tags type

### DIFF
--- a/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
@@ -1,7 +1,7 @@
 import {
   getSchema,
   IntegrationEntitySchema,
-  validateEntityWithSchema,
+  validateEntityWithSchema
 } from '@jupiterone/data-model';
 
 import { IntegrationError } from '../errors';
@@ -35,7 +35,7 @@ type ProviderSourceData = {
    * and the tag values will be collected in the generated entity as `tags` (a
    * `string[]`);
    */
-  tags?: ResourceTagList | ResourceTagMap;
+  tags?: ResourceTagList | ResourceTagMap | string | string[] | undefined | null;
 
   [key: string]: any;
 };

--- a/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
@@ -1,7 +1,7 @@
 import {
   getSchema,
   IntegrationEntitySchema,
-  validateEntityWithSchema
+  validateEntityWithSchema,
 } from '@jupiterone/data-model';
 
 import { IntegrationError } from '../errors';
@@ -35,7 +35,13 @@ type ProviderSourceData = {
    * and the tag values will be collected in the generated entity as `tags` (a
    * `string[]`);
    */
-  tags?: ResourceTagList | ResourceTagMap | string | string[] | undefined | null;
+  tags?:
+    | ResourceTagList
+    | ResourceTagMap
+    | string
+    | string[]
+    | undefined
+    | null;
 
   [key: string]: any;
 };


### PR DESCRIPTION
This now matches the sdk-core version of it

https://github.com/JupiterOne/sdk/blob/main/packages/integration-sdk-core/src/data/tagging.ts#L62

-- We ran into an issue when trying to define an entity from Google Cloud which defines `tags` as a different `type` required by the `ProviderSourceData`.`type`.

This MR updates the type to match `assignTags` input