### PR TITLE
INT-5226 Add log statement if an error occurs sending axios request

### DIFF
--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -338,6 +338,11 @@ function handleUploadDataChunkError({
   batch,
   uploadCorrelationId,
 }: HandleUploadDataChunkErrorParams): void {
+  if (err.code !== 'CredentialsError') {
+    // we don't want to log on credential errors
+    logger.warn({ error: err }, 'Error uploading graph data chunk', err);
+  }
+
   /**
    * The JupiterOne system will encapsulate error details in the response in
    * some situations. For example:


### PR DESCRIPTION
We are seeing ERR_INVALID_ARG_TYPE errors that seem to be coming from
axios. However, we are losing a lot of helpful data about the error
when we handle convert the error into our custom IntegrationError. Specifically,
it seems that the `cause` (which contains the actual [error](https://github.com/JupiterOne/sdk/blob/26bc8d741cfdd621d253beaea2ba397ca2972017/packages/integration-sdk-runtime/src/synchronization/error.ts#L26)) is lost when logging (see pic).
While we investigate these errors, add a log statement to get more details on why axios threw.

![Screen Shot 2022-08-22 at 11 08 05](https://user-images.githubusercontent.com/10550776/185955478-068f2f47-f690-4779-92bb-bbd499a9367d.png)
