### PR TITLE
INT-5336 Add warn log statement for when our handleError function throws

### DIFF
--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -338,11 +338,6 @@ function handleUploadDataChunkError({
   batch,
   uploadCorrelationId,
 }: HandleUploadDataChunkErrorParams): void {
-  if (err.code !== 'CredentialsError') {
-    // we don't want to log on credential errors
-    logger.warn({ error: err }, 'Error uploading graph data chunk', err);
-  }
-
   /**
    * The JupiterOne system will encapsulate error details in the response in
    * some situations. For example:
@@ -421,13 +416,22 @@ export async function uploadDataChunk<
       delay: 200,
       factor: 1.05,
       handleError(err, attemptContext) {
-        handleUploadDataChunkError({
-          err,
-          attemptContext,
-          logger,
-          batch,
-          uploadCorrelationId,
-        });
+        try {
+          handleUploadDataChunkError({
+            err,
+            attemptContext,
+            logger,
+            batch,
+            uploadCorrelationId,
+          });
+        } catch (error) {
+          logger.warn(
+            { error },
+            'handleUploadDataChunkError function threw',
+            error,
+          );
+          throw error;
+        }
       },
     },
   );


### PR DESCRIPTION
When we attempt to upload graph data and the upload fails, we retry using the
handleUploadDataChunkError function. However, if that function throws, we bail
immediately, which seems tobe happening in prod. As we investigate, add a warning
log if this happens.