### PR TITLE
Update `parseTimePropertyValue` number definition to allow undefined and null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Allow the use of possibly null or undefined `number` in
+  `parseTimePropertyValue`
+
 ## 8.22.2 - 2022-08-18
 
 ### Added

--- a/packages/integration-sdk-core/src/data/converters.ts
+++ b/packages/integration-sdk-core/src/data/converters.ts
@@ -184,7 +184,7 @@ export function getTime(
  *          sec - seconds
  */
 export function parseTimePropertyValue(
-  time: number,
+  time: number | undefined | null,
   sourcePrecision: 'ms' | 'sec',
 ): number | undefined;
 export function parseTimePropertyValue(


### PR DESCRIPTION
- fix: undefined and null values in number ptpv
- update changelog
