### PR TITLE
INT-5226 Fix the getPropSizeMapFromEntity function when shrinking _rawData

### DIFF
--- a/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
@@ -220,7 +220,11 @@ function getPropSizeMapFromEntity(data: Entity): any {
   const propSizeMap = {};
 
   for (const [key, value] of Object.entries(data)) {
-    propSizeMap[key] = Buffer.byteLength(JSON.stringify(value));
+    if (!value) {
+      propSizeMap[key] = 0;
+    } else {
+      propSizeMap[key] = Buffer.byteLength(JSON.stringify(value));
+    }
   }
 
   return propSizeMap;


### PR DESCRIPTION
When attempting to shrink _rawData, the helper function getPropSizeMapFromEntity
may be called. It goes through each key/value pair of a given entity and records
how large each field of the entity is. However, some values of an entity can be undefined,
which will cause Buffer.byteLength to throw. If there is an undefined value, set the size
to 0.