### PR TITLE
INT-5226 Update getPropSizeMapFromEntity and add new unit test

### DIFF
--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/shrinkBatchRawData.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/shrinkBatchRawData.test.ts
@@ -304,7 +304,6 @@ describe('shrinkBatchRawData', () => {
       shrinkBatchRawData(data, logger);
       shrinkBatchRawDataSucceeded = true;
     } catch (err) {
-      expect(shrinkBatchRawDataSucceeded).toEqual(false);
       expect(err).toBeInstanceOf(IntegrationError);
       expect(logger.error).toBeCalledTimes(1);
       // should give details on largest entity in batch after finished shrinking, this should be item with _key=testKey3
@@ -333,5 +332,7 @@ describe('shrinkBatchRawData', () => {
       expect(logger.info).toBeCalledTimes(1);
       expect(logger.info).toHaveBeenCalledWith('Attempting to shrink rawData');
     }
+
+    expect(shrinkBatchRawDataSucceeded).toEqual(false);
   });
 });

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/shrinkBatchRawData.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/shrinkBatchRawData.test.ts
@@ -263,6 +263,7 @@ describe('shrinkBatchRawData', () => {
   });
 
   it('should assign 0 to the size of an undefined property when building the property map', () => {
+    let shrinkBatchRawDataSucceeded = false;
     const largeData = new Array(700000).join('aaaaaaaaaa');
     const data = [
       {
@@ -301,7 +302,9 @@ describe('shrinkBatchRawData', () => {
     ];
     try {
       shrinkBatchRawData(data, logger);
+      shrinkBatchRawDataSucceeded = true;
     } catch (err) {
+      expect(shrinkBatchRawDataSucceeded).toEqual(false);
       expect(err).toBeInstanceOf(IntegrationError);
       expect(logger.error).toBeCalledTimes(1);
       // should give details on largest entity in batch after finished shrinking, this should be item with _key=testKey3

--- a/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
@@ -220,7 +220,7 @@ function getPropSizeMapFromEntity(data: Entity): any {
   const propSizeMap = {};
 
   for (const [key, value] of Object.entries(data)) {
-    if (!value) {
+    if (value === undefined) {
       propSizeMap[key] = 0;
     } else {
       propSizeMap[key] = Buffer.byteLength(JSON.stringify(value));


### PR DESCRIPTION
Updated the getPropSizeMapFromEntity helper function so that it only sets
a size of 0 to undefined properties, not all falsey properties.
Additionally added a unit test that tests this new functionality.