### PR TITLE
Adding option to specify a different database name for Neo4j commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to
 
 ## Unreleased
 
-## 8.22.6 - 2022-09-03
+## 8.22.7 - 2022-09-03
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added optional flag to specify a different Neo4j database name to push to or
+  wipe from than the default 'neo4j' (only available on enterprise instances of
+  Neo4j).
+
 ## 8.22.5 - 2022-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## Unreleased
 
+## 8.22.6 - 2022-09-03
+
 ### Added
 
 - Added optional flag to specify a different Neo4j database name to push to or

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "8.22.6",
+  "version": "8.22.7",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.22.6",
-    "@jupiterone/integration-sdk-runtime": "^8.22.6",
+    "@jupiterone/integration-sdk-core": "^8.22.7",
+    "@jupiterone/integration-sdk-runtime": "^8.22.7",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "8.22.6",
+  "version": "8.22.7",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do yarn prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.22.6",
-    "@jupiterone/integration-sdk-runtime": "^8.22.6",
+    "@jupiterone/integration-sdk-core": "^8.22.7",
+    "@jupiterone/integration-sdk-runtime": "^8.22.7",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "8.22.6",
+  "version": "8.22.7",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^8.22.6",
+    "@jupiterone/integration-sdk-runtime": "^8.22.7",
     "chalk": "^4",
     "commander": "^5.0.0",
     "fs-extra": "^10.1.0",
@@ -37,7 +37,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.22.6",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.22.7",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-cli/src/commands/neo4j.ts
+++ b/packages/integration-sdk-cli/src/commands/neo4j.ts
@@ -43,6 +43,7 @@ export function neo4j() {
       await uploadToNeo4j({
         pathToData: finalDir,
         integrationInstanceID: options.integrationInstanceId,
+        neo4jDatabase: options.databaseName,
       });
       log.info(`Data uploaded to local neo4j`);
     });

--- a/packages/integration-sdk-cli/src/commands/neo4j.ts
+++ b/packages/integration-sdk-cli/src/commands/neo4j.ts
@@ -66,6 +66,7 @@ export function neo4j() {
     .action(async (options) => {
       await wipeNeo4jByID({
         integrationInstanceID: options.integrationInstanceId,
+        neo4jDatabase: options.databaseName,
       });
     });
 
@@ -78,7 +79,9 @@ export function neo4j() {
       'neo4j',
     )
     .action(async (options) => {
-      await wipeAllNeo4j({});
+      await wipeAllNeo4j({
+        neo4jDatabase: options.databaseName,
+      });
     });
 
   return neo4jCommand;

--- a/packages/integration-sdk-cli/src/commands/neo4j.ts
+++ b/packages/integration-sdk-cli/src/commands/neo4j.ts
@@ -28,6 +28,11 @@ export function neo4j() {
       '_integrationInstanceId assigned to uploaded entities',
       'defaultLocalInstanceID',
     )
+    .option(
+      '-db, --database-name <database>',
+      'optional database to push data to (only available for enterprise Neo4j databases)',
+      'neo4j',
+    )
     .action(async (options) => {
       log.info(`Beginning data upload to local neo4j`);
       // Point `fileSystem.ts` functions to expected location relative to
@@ -52,6 +57,11 @@ export function neo4j() {
       '_integrationInstanceId assigned to uploaded entities',
       'defaultLocalInstanceID',
     )
+    .option(
+      '-db, --database-name <database>',
+      'optional database to wipe data from (only available for enterprise Neo4j databases)',
+      'neo4j',
+    )
     .action(async (options) => {
       await wipeNeo4jByID({
         integrationInstanceID: options.integrationInstanceId,
@@ -61,6 +71,11 @@ export function neo4j() {
   neo4jCommand
     .command('wipe-all')
     .description('wipe all entities and relationships in the Neo4j database')
+    .option(
+      '-db, --database-name <database>',
+      'optional database to wipe data from (only available for enterprise Neo4j databases)',
+      'neo4j',
+    )
     .action(async (options) => {
       await wipeAllNeo4j({});
     });

--- a/packages/integration-sdk-cli/src/neo4j/__tests__/neo4jGraphStore.test.ts
+++ b/packages/integration-sdk-cli/src/neo4j/__tests__/neo4jGraphStore.test.ts
@@ -86,6 +86,20 @@ describe('#neo4jGraphStore', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  test('should generate call to create a driver connection to a database other than the default', () => {
+    const spy = jest.spyOn(neo4j, 'driver').mockReturnValue(mockDriverResp);
+
+    const emptyStore = new Neo4jGraphStore({
+      uri: '',
+      username: '',
+      password: '',
+      integrationInstanceID: testInstanceID,
+      database: 'testDatabase',
+    });
+    expect(async () => await emptyStore.close()).toReturn;
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   test('should generate call to create an Entity', () => {
     expect(async () => await store.addEntities(testEntityData)).toReturn;
   });

--- a/packages/integration-sdk-cli/src/neo4j/__tests__/neo4jGraphStore.test.ts
+++ b/packages/integration-sdk-cli/src/neo4j/__tests__/neo4jGraphStore.test.ts
@@ -86,6 +86,7 @@ describe('#neo4jGraphStore', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  // TODO (adam-in-ict) add in additional testing to verify the correct database is used in a generated session.
   test('should generate call to create a driver connection to a database other than the default', () => {
     const spy = jest.spyOn(neo4j, 'driver').mockReturnValue(mockDriverResp);
 

--- a/packages/integration-sdk-cli/src/neo4j/neo4jGraphStore.ts
+++ b/packages/integration-sdk-cli/src/neo4j/neo4jGraphStore.ts
@@ -15,6 +15,7 @@ export interface Neo4jGraphObjectStoreParams {
   password: string;
   integrationInstanceID: string;
   session?: neo4j.Session;
+  database?: string;
 }
 
 export class Neo4jGraphStore {
@@ -34,6 +35,9 @@ export class Neo4jGraphStore {
       );
     }
     this.integrationInstanceID = params.integrationInstanceID;
+    if (params.database) {
+      this.databaseName = params.database;
+    }
   }
 
   private async runCypherCommand(

--- a/packages/integration-sdk-cli/src/neo4j/uploadToNeo4j.ts
+++ b/packages/integration-sdk-cli/src/neo4j/uploadToNeo4j.ts
@@ -11,6 +11,7 @@ type UploadToNeo4jParams = {
   neo4jUri?: string;
   neo4jUser?: string;
   neo4jPassword?: string;
+  neo4jDatabase?: string;
 };
 
 export async function uploadToNeo4j({
@@ -19,6 +20,7 @@ export async function uploadToNeo4j({
   neo4jUri = process.env.NEO4J_URI,
   neo4jUser = process.env.NEO4J_USER,
   neo4jPassword = process.env.NEO4J_PASSWORD,
+  neo4jDatabase,
 }: UploadToNeo4jParams) {
   if (!neo4jUri || !neo4jUser || !neo4jPassword) {
     throw new Error(
@@ -34,6 +36,7 @@ export async function uploadToNeo4j({
     username: neo4jUser,
     password: neo4jPassword,
     integrationInstanceID: integrationInstanceID,
+    database: neo4jDatabase,
   });
 
   async function handleGraphObjectEntityFiles(

--- a/packages/integration-sdk-cli/src/neo4j/wipeNeo4j.ts
+++ b/packages/integration-sdk-cli/src/neo4j/wipeNeo4j.ts
@@ -5,12 +5,14 @@ type WipeNeo4jParams = {
   neo4jUri?: string;
   neo4jUser?: string;
   neo4jPassword?: string;
+  neo4jDatabase?: string;
 };
 export async function wipeNeo4jByID({
   integrationInstanceID,
   neo4jUri = process.env.NEO4J_URI,
   neo4jUser = process.env.NEO4J_USER,
   neo4jPassword = process.env.NEO4J_PASSWORD,
+  neo4jDatabase,
 }: WipeNeo4jParams) {
   if (!neo4jUri || !neo4jUser || !neo4jPassword) {
     throw new Error(
@@ -23,6 +25,7 @@ export async function wipeNeo4jByID({
     username: neo4jUser,
     password: neo4jPassword,
     integrationInstanceID: integrationInstanceID,
+    database: neo4jDatabase,
   });
   try {
     await store.wipeInstanceIdData();
@@ -35,12 +38,14 @@ type WipeAllNeo4jParams = {
   neo4jUri?: string;
   neo4jUser?: string;
   neo4jPassword?: string;
+  neo4jDatabase?: string;
 };
 
 export async function wipeAllNeo4j({
   neo4jUri = process.env.NEO4J_URI,
   neo4jUser = process.env.NEO4J_USER,
   neo4jPassword = process.env.NEO4J_PASSWORD,
+  neo4jDatabase,
 }: WipeAllNeo4jParams) {
   if (!neo4jUri || !neo4jUser || !neo4jPassword) {
     throw new Error(
@@ -53,6 +58,7 @@ export async function wipeAllNeo4j({
     username: neo4jUser,
     password: neo4jPassword,
     integrationInstanceID: '',
+    database: neo4jDatabase,
   });
   try {
     await store.wipeDatabase();

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "8.22.6",
+  "version": "8.22.7",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "8.22.6",
+  "version": "8.22.7",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^8.22.6",
-    "@jupiterone/integration-sdk-testing": "^8.22.6",
+    "@jupiterone/integration-sdk-cli": "^8.22.7",
+    "@jupiterone/integration-sdk-testing": "^8.22.7",
     "@types/jest": "^27.1.0",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "8.22.6",
+  "version": "8.22.7",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -27,8 +27,8 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^8.22.6",
-    "@jupiterone/integration-sdk-private-test-utils": "^8.22.6",
+    "@jupiterone/integration-sdk-dev-tools": "^8.22.7",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.22.7",
     "fetch-mock-jest": "^1.5.1"
   },
   "bugs": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "8.22.6",
+  "version": "8.22.7",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.22.6",
+    "@jupiterone/integration-sdk-core": "^8.22.7",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "8.22.6",
+  "version": "8.22.7",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.22.6",
+    "@jupiterone/integration-sdk-core": "^8.22.7",
     "@lifeomic/alpha": "^1.4.0",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.22.6",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.22.7",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "8.22.6",
+  "version": "8.22.7",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.22.6",
-    "@jupiterone/integration-sdk-runtime": "^8.22.6",
+    "@jupiterone/integration-sdk-core": "^8.22.7",
+    "@jupiterone/integration-sdk-runtime": "^8.22.7",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.22.6",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.22.7",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
This PR adds the option to specify a different database name other than the default `neo4j` for Neo4j commands. This will allow us to add this requested functionality to Starbase.