### PR TITLE
Add j1-integration run --skip-finalize option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- `j1-integration run --skip-finalize` option to avoid finalizing the
+  integration run. This is useful for scenarios where you want to run the
+  integration to collect and upload data to a synchronization job, but do not
+  want to initiate the finalization process.
+
 ## 8.23.1 - 2022-09-07
 
 ### Fixed

--- a/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
@@ -99,6 +99,8 @@ test('step should fail if enableSchemaValidation = true', async () => {
   ]);
 
   expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
+
+  expect(log.displayExecutionResults).toHaveBeenCalledTimes(1);
   expect(log.displayExecutionResults).toHaveBeenCalledWith({
     integrationStepResults: [
       {
@@ -138,6 +140,8 @@ test('step should pass if enableSchemaValidation = false', async () => {
   ]);
 
   expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
+
+  expect(log.displayExecutionResults).toHaveBeenCalledTimes(1);
   expect(log.displayExecutionResults).toHaveBeenCalledWith({
     integrationStepResults: [
       {
@@ -170,8 +174,7 @@ test('executes integration and performs upload', async () => {
     'test',
   ]);
 
-  expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
-
+  expect(log.displayExecutionResults).toHaveBeenCalledTimes(1);
   expect(log.displayExecutionResults).toHaveBeenCalledWith({
     integrationStepResults: [
       {
@@ -229,8 +232,7 @@ test('executes integration and performs upload with api-base-url', async () => {
     'https://api.TEST.jupiterone.io',
   ]);
 
-  expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
-
+  expect(log.displayExecutionResults).toHaveBeenCalledTimes(1);
   expect(log.displayExecutionResults).toHaveBeenCalledWith({
     integrationStepResults: [
       {
@@ -261,6 +263,38 @@ test('executes integration and performs upload with api-base-url', async () => {
   expect(log.displaySynchronizationResults).toHaveBeenCalledWith({
     ...job,
     status: SynchronizationJobStatus.FINALIZE_PENDING,
+    // These are the expected number of entities and relationships
+    // collected when executing the
+    // 'typeScriptIntegrationProject' fixture
+    numEntitiesUploaded: 2,
+    numRelationshipsUploaded: 1,
+  });
+});
+
+test('executes integration and skips finalization with skip-finalize', async () => {
+  const job = generateSynchronizationJob();
+
+  setupSynchronizerApi({
+    polly,
+    job,
+    baseUrl: 'https://api.us.jupiterone.io',
+  });
+
+  await createCli().parseAsync([
+    'node',
+    'j1-integration',
+    'run',
+    '--integrationInstanceId',
+    'test',
+    '--skip-finalize',
+  ]);
+
+  expect(log.displayExecutionResults).toHaveBeenCalledTimes(1);
+
+  expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
+  expect(log.displaySynchronizationResults).toHaveBeenCalledWith({
+    ...job,
+    status: SynchronizationJobStatus.AWAITING_UPLOADS,
     // These are the expected number of entities and relationships
     // collected when executing the
     // 'typeScriptIntegrationProject' fixture

--- a/packages/integration-sdk-cli/src/__tests__/util/synchronization.ts
+++ b/packages/integration-sdk-cli/src/__tests__/util/synchronization.ts
@@ -19,6 +19,13 @@ export function setupSynchronizerApi({ polly, job, baseUrl }: SetupOptions) {
     });
 
   polly.server
+    .get(`${baseUrl}/persister/synchronization/jobs/${job.id}`)
+    .intercept((req, res) => {
+      allowCrossOrigin(req, res);
+      res.status(200).json({ job });
+    });
+
+  polly.server
     .post(`${baseUrl}/persister/synchronization/jobs/${job.id}/entities`)
     .intercept((req, res) => {
       allowCrossOrigin(req, res);

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/index.test.ts
@@ -20,6 +20,7 @@ import {
   abortSynchronization,
   uploadDataChunk,
   SynchronizeInput,
+  synchronizationStatus,
 } from '../index';
 
 import { getApiBaseUrl, createApiClient } from '../../api';
@@ -294,6 +295,34 @@ describe('finalizeSynchronization', () => {
       {
         partialDatasets,
       },
+    );
+  });
+});
+
+describe('synchronizationStatus', () => {
+  test('fetches status of job', async () => {
+    loadProjectStructure('synchronization');
+
+    const job = generateSynchronizationJob();
+    const context = createTestContext();
+    const { apiClient } = context;
+
+    const getSpy = jest.spyOn(apiClient, 'get').mockResolvedValue({
+      data: {
+        job,
+      },
+    });
+
+    const returnedJob = await synchronizationStatus({
+      ...context,
+      job,
+    });
+
+    expect(returnedJob).toEqual(job);
+
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(getSpy).toHaveBeenCalledWith(
+      `/persister/synchronization/jobs/${job.id}`,
     );
   });
 });

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -134,6 +134,29 @@ export async function initiateSynchronization({
   };
 }
 
+type SynchronizationStatusInput = SynchronizationJobContext;
+
+export async function synchronizationStatus({
+  apiClient,
+  job,
+}: SynchronizationStatusInput): Promise<SynchronizationJob> {
+  let status: SynchronizationJob;
+
+  try {
+    const response = await apiClient.get(
+      `/persister/synchronization/jobs/${job.id}`,
+    );
+    status = response.data.job;
+  } catch (err) {
+    throw synchronizationApiError(
+      err,
+      'Error occurred fetching synchronization job status.',
+    );
+  }
+
+  return status;
+}
+
 interface FinalizeSynchronizationInput extends SynchronizationJobContext {
   partialDatasets: PartialDatasets;
 }
@@ -251,7 +274,7 @@ export async function uploadGraphObjectData(
 }
 
 /**
- * Uploads data collected by the integration into the
+ * Uploads data collected by the integration.
  */
 export async function uploadCollectedData(context: SynchronizationJobContext) {
   context.logger.synchronizationUploadStart(context.job);


### PR DESCRIPTION
We'd like to leverage the integration SDK to create sync jobs and upload data and avoid finalizing the job so we can process sync jobs in a different way.