### PR TITLE
Add sync|run --source and --scope options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to
   integration run. This is useful for scenarios where you want to run the
   integration to collect and upload data to a synchronization job, but do not
   want to initiate the finalization process.
+- `j1-integration [run|sync] --source api --scope anystring` options to allow
+  use of the SDK without configuring an integration instance.
+  `--integrationInstanceId` is not required when using these options.
 
 ## 8.23.1 - 2022-09-07
 

--- a/packages/integration-sdk-cli/src/__tests__/cli-sync.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-sync.test.ts
@@ -94,6 +94,36 @@ test('hits dev urls if JUPITERONE_DEV environment variable is set', async () => 
   });
 });
 
+test('does not publish events for source "api" since there is no integrationJobId', async () => {
+  const job = generateSynchronizationJob({ source: 'api', scope: 'test' });
+
+  setupSynchronizerApi({
+    polly,
+    job,
+    baseUrl: 'https://api.us.jupiterone.io',
+  });
+
+  let eventsPublished = false;
+  polly.server
+    .post(`https://example.com/persister/synchronization/jobs/${job.id}/events`)
+    .intercept((req, res) => {
+      eventsPublished = true;
+    });
+
+  await createCli().parseAsync([
+    'node',
+    'j1-integration',
+    'sync',
+    '--source',
+    'api',
+    '--scope',
+    'test',
+  ]);
+
+  expect(eventsPublished).toBe(false);
+  expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
+});
+
 test('hits different url if --api-base-url is set', async () => {
   const job = generateSynchronizationJob();
 

--- a/packages/integration-sdk-cli/src/__tests__/util/synchronization.ts
+++ b/packages/integration-sdk-cli/src/__tests__/util/synchronization.ts
@@ -79,11 +79,18 @@ function allowCrossOrigin(req, res) {
   });
 }
 
-export function generateSynchronizationJob(): SynchronizationJob {
+export function generateSynchronizationJob(
+  options?: Pick<
+    SynchronizationJob,
+    'source' | 'scope' | 'integrationInstanceId' | 'integrationJobId'
+  >,
+): SynchronizationJob {
   return {
     id: 'test',
-    integrationJobId: 'test-job-id',
-    integrationInstanceId: 'test-instance-id',
+    source: options?.source || 'integration-managed',
+    scope: options?.scope,
+    integrationJobId: options?.integrationJobId || 'test-job-id',
+    integrationInstanceId: options?.integrationInstanceId || 'test-instance-id',
     status: SynchronizationJobStatus.AWAITING_UPLOADS,
     startTimestamp: Date.now(),
     numEntitiesUploaded: 0,

--- a/packages/integration-sdk-cli/src/commands/options.ts
+++ b/packages/integration-sdk-cli/src/commands/options.ts
@@ -1,0 +1,69 @@
+import { getApiBaseUrl } from '@jupiterone/integration-sdk-runtime';
+
+/**
+ * Determines the JupiterOne `apiBaseUrl` based on these mutually-exclusive `options`:
+ * - --api-base-url - a specific URL to use
+ * - --development - use the development API
+ *
+ * @throws Error if both --api-base-url and --development are specified
+ */
+export function getApiBaseUrlOption(options: any): string {
+  let apiBaseUrl: string;
+  if (options.apiBaseUrl) {
+    if (options.development) {
+      throw new Error(
+        'Invalid configuration supplied.  Cannot specify both --api-base-url and --development(-d) flags.',
+      );
+    }
+    apiBaseUrl = options.apiBaseUrl;
+  } else {
+    apiBaseUrl = getApiBaseUrl({
+      dev: options.development,
+    });
+  }
+  return apiBaseUrl;
+}
+
+interface SynchronizationJobSourceOptions {
+  source: 'integration-managed' | 'integration-external' | 'api';
+  scope?: string;
+  integrationInstanceId?: string;
+}
+
+/**
+ * Determines the `source` configuration for the synchronization job based on these `options`:
+ * - --source - a specific source to use
+ * - --scope - a specific scope to use, required when --source is "api"
+ * - --integrationInstanceId - a specific integrationInstanceId to use, required when --source is not "api"
+ */
+export function getSynchronizationJobSourceOptions(
+  options: any,
+): SynchronizationJobSourceOptions {
+  const synchronizeOptions: SynchronizationJobSourceOptions = {
+    source: options.source,
+  };
+  if (options.source === 'api') {
+    if (options.integrationInstanceId)
+      throw new Error(
+        'Invalid configuration supplied. Cannot specify both --source api and --integrationInstanceId flags.',
+      );
+    if (!options.scope)
+      throw new Error(
+        'Invalid configuration supplied. --source api requires --scope flag.',
+      );
+    synchronizeOptions.scope = options.scope;
+  } else if (
+    !['integration-managed', 'integration-external'].includes(options.source)
+  ) {
+    throw new Error(
+      `Invalid configuration supplied. --source must be one of: integration-managed, integration-external, api. Received: ${options.source}.`,
+    );
+  } else if (options.integrationInstanceId) {
+    synchronizeOptions.integrationInstanceId = options.integrationInstanceId;
+  } else {
+    throw new Error(
+      'Invalid configuration supplied. --integrationInstanceId or --source api and --scope required.',
+    );
+  }
+  return synchronizeOptions;
+}

--- a/packages/integration-sdk-cli/src/commands/sync.ts
+++ b/packages/integration-sdk-cli/src/commands/sync.ts
@@ -5,19 +5,22 @@ import {
   createApiClient,
   createIntegrationLogger,
   getAccountFromEnvironment,
-  getApiBaseUrl,
   getApiKeyFromEnvironment,
   synchronizeCollectedData,
 } from '@jupiterone/integration-sdk-runtime';
 
 import * as log from '../log';
+import {
+  getApiBaseUrlOption,
+  getSynchronizationJobSourceOptions,
+} from './options';
 
 export function sync() {
   return createCommand('sync')
     .description(
       'sync collected data with JupiterOne, requires JUPITERONE_API_KEY, JUPITERONE_ACCOUNT',
     )
-    .requiredOption(
+    .option(
       '-i, --integrationInstanceId <id>',
       '_integrationInstanceId assigned to uploaded entities and relationships',
     )
@@ -32,6 +35,15 @@ export function sync() {
       !!process.env.JUPITERONE_DEV,
     )
     .option('--api-base-url <url>', 'API base URL used during sync operation.')
+    .option(
+      '--source <integration-managed|integration-external|api>',
+      'configure the synchronization job source value',
+      'integration-managed',
+    )
+    .option(
+      '--scope <anystring>',
+      'configure the synchronization job scope value',
+    )
     .option(
       '-u, --upload-batch-size <number>',
       'specify number of items per batch for upload (default 250)',
@@ -54,19 +66,7 @@ export function sync() {
       log.debug('Loading account from JUPITERONE_ACCOUNT environment variable');
       const account = getAccountFromEnvironment();
 
-      let apiBaseUrl: string;
-      if (options.apiBaseUrl) {
-        if (options.development) {
-          throw new Error(
-            'Invalid configuration supplied.  Cannot specify both --api-base-url and --development(-d) flags.',
-          );
-        }
-        apiBaseUrl = options.apiBaseUrl;
-      } else {
-        apiBaseUrl = getApiBaseUrl({
-          dev: options.development,
-        });
-      }
+      const apiBaseUrl = getApiBaseUrlOption(options);
       log.debug(`Configuring client to access "${apiBaseUrl}"`);
 
       const apiClient = createApiClient({
@@ -75,18 +75,19 @@ export function sync() {
         accessToken,
       });
 
-      const { integrationInstanceId } = options;
+      const synchronizationJobSourceOptions =
+        getSynchronizationJobSourceOptions(options);
 
       const logger = createIntegrationLogger({
         name: 'local',
         pretty: true,
       });
       const job = await synchronizeCollectedData({
-        logger: logger.child({ integrationInstanceId }),
+        logger: logger.child(synchronizationJobSourceOptions),
         apiClient,
-        integrationInstanceId,
         uploadBatchSize: options.uploadBatchSize,
         uploadRelationshipBatchSize: options.uploadRelationshipBatchSize,
+        ...synchronizationJobSourceOptions,
       });
 
       log.displaySynchronizationResults(job);

--- a/packages/integration-sdk-core/src/types/synchronization.ts
+++ b/packages/integration-sdk-core/src/types/synchronization.ts
@@ -11,8 +11,30 @@ export enum SynchronizationJobStatus {
 
 export interface SynchronizationJob {
   id: string;
-  integrationJobId: string;
-  integrationInstanceId: string;
+
+  /**
+   * The `source` value used when creating the synchronization job.
+   */
+  source: string;
+
+  /**
+   * The `scope` value used when creating the synchronization job. This value will be null when the
+   * synchronization job is configured with source `'integration-managed'` or `'integration-external'`.
+   */
+  scope?: string;
+
+  /**
+   * The integration instance ID provided to execute a synchronization job. This value will be null when the
+   * synchronization job is configured with source `'api'`.
+   */
+  integrationInstanceId?: string;
+
+  /**
+   * The integration job ID associated with the synchronization job. This value will be null when the
+   * synchronization job is configured with source `'api'`.
+   */
+  integrationJobId?: string;
+
   status: SynchronizationJobStatus;
   startTimestamp: number;
   numEntitiesUploaded: number;

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/events.test.ts
@@ -8,7 +8,7 @@ import { createApiClient } from '../../api';
 import { createEventPublishingQueue } from '../index';
 import noop from 'lodash/noop';
 
-test('publishes events added to the queue in the order they were enqueued', async () => {
+test('publishes integration events added to the queue in the order they were enqueued', async () => {
   const eventA = {
     name: 'a',
     description: 'Event A',
@@ -60,6 +60,22 @@ test('publishes events added to the queue in the order they were enqueued', asyn
   );
 });
 
+test('publishes no integration events when there is no integrationJobId', async () => {
+  const { apiClient, queue } = createContext({ integrationJobId: undefined });
+
+  const postSpy = jest.spyOn(apiClient, 'post').mockImplementation(noop as any);
+
+  await queue.enqueue({
+    name: 'a',
+    description: 'Event A',
+    level: PublishEventLevel.Info,
+  });
+
+  await queue.onIdle();
+
+  expect(postSpy).not.toHaveBeenCalled();
+});
+
 test('logs an error if publish fails', async () => {
   const event = {
     name: 'a',
@@ -97,7 +113,7 @@ test('logs an error if publish fails', async () => {
   );
 });
 
-function createContext() {
+function createContext(options?: Pick<SynchronizationJob, 'integrationJobId'>) {
   const apiClient = createApiClient({
     apiBaseUrl: 'https://mochi:8080',
     account: 'mochi',
@@ -107,7 +123,11 @@ function createContext() {
     name: 'test',
   });
 
-  const job = { id: 'test' } as SynchronizationJob;
+  const job = {
+    id: 'test',
+    integrationJobId: 'test',
+    ...options,
+  } as SynchronizationJob;
 
   return {
     apiClient,

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/util/generateSynchronizationJob.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/util/generateSynchronizationJob.ts
@@ -1,13 +1,20 @@
 import {
-  SynchronizationJobStatus,
   SynchronizationJob,
+  SynchronizationJobStatus,
 } from '@jupiterone/integration-sdk-core';
 
-export function generateSynchronizationJob(): SynchronizationJob {
+export function generateSynchronizationJob(
+  options?: Pick<
+    SynchronizationJob,
+    'source' | 'scope' | 'integrationInstanceId' | 'integrationJobId'
+  >,
+): SynchronizationJob {
   return {
     id: 'test',
-    integrationJobId: 'test-job-id',
-    integrationInstanceId: 'test-instance-id',
+    source: options?.source || 'integration-managed',
+    scope: options?.scope,
+    integrationJobId: options?.integrationJobId || 'test-job-id',
+    integrationInstanceId: options?.integrationInstanceId || 'test-instance-id',
     status: SynchronizationJobStatus.AWAITING_UPLOADS,
     startTimestamp: Date.now(),
     numEntitiesUploaded: 0,


### PR DESCRIPTION
The goal is documented in the code, but it may be helpful to provide a bit more concrete context.

We're working to load test Core and need a way to generate a lot of data that we upload to the Persister. The integration SDK has all the code we need to allow us to focus on writing data generation instead of data uploading in batches, upload error handling, etc. However, we plan to have many J1 accounts and many concurrent sync jobs per account, but do not want to manage a lot of integration instances. These changes allow us to execute bulk uploads (sync jobs) without the integration instances.