### PR TITLE
remove multipleResolves event from onFailure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to
 
 ## Unreleased
 
+- `multipleResolves` events are no longer forwarded to loggers `onFailure`
+  callback as they are not strict failures. Logging of `multipleResolves` at log
+  level error remains in place.
 - Updated ESLint to override the `no-misused-promises` rule.
 
 ## 8.25.1 - 2022-09-26
@@ -58,9 +61,6 @@ and this project adheres to
   `--api-base-url` so it is shown in the help output. Any other value for
   `--api-base-url` will cause an error to be thrown if `--development` is set to
   `"true"`.
-- `multipleResolves` events are no longer forwarded to loggers `onFailure`
-  callback as they are not strict failures. Logging of `multipleResolves` at log
-  level error remains in place.
 
 ## 8.24.0 - 2022-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to
   `--api-base-url` so it is shown in the help output. Any other value for
   `--api-base-url` will cause an error to be thrown if `--development` is set to
   `"true"`.
+- `multipleResolves` events are no longer forwarded to loggers `onFailure`
+  callback as they are not strict failures. Logging of `multipleResolves` at log
+  level error remains in place.
 
 ## 8.24.0 - 2022-09-15
 

--- a/packages/integration-sdk-runtime/src/logger/registerEventHandlers.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/registerEventHandlers.test.ts
@@ -1,0 +1,27 @@
+import {
+  registerIntegrationLoggerEventHandlers,
+  registerEventHandlers,
+} from './registerEventHandlers';
+
+test('registerEventHandlers registers a handler for unhandledRejection, uncaughtException, and multipleResolves', () => {
+  const noopCallback = (err, event) => {
+    return;
+  };
+
+  const multipleResolvesCount = process.listeners('multipleResolves').length;
+  const uncaughtExceptionCount = process.listeners('uncaughtException').length;
+  const unhandledRejectionCount =
+    process.listeners('unhandledRejection').length;
+
+  registerEventHandlers(noopCallback);
+
+  expect(process.listeners('multipleResolves').length).toBe(
+    multipleResolvesCount + 1,
+  );
+  expect(process.listeners('uncaughtException').length).toBe(
+    uncaughtExceptionCount + 1,
+  );
+  expect(process.listeners('unhandledRejection').length).toBe(
+    unhandledRejectionCount + 1,
+  );
+});

--- a/packages/integration-sdk-runtime/src/logger/registerEventHandlers.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/registerEventHandlers.test.ts
@@ -1,5 +1,4 @@
 import {
-  registerIntegrationLoggerEventHandlers,
   registerEventHandlers,
 } from './registerEventHandlers';
 

--- a/packages/integration-sdk-runtime/src/logger/registerEventHandlers.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/registerEventHandlers.test.ts
@@ -1,6 +1,4 @@
-import {
-  registerEventHandlers,
-} from './registerEventHandlers';
+import { registerEventHandlers } from './registerEventHandlers';
 
 test('registerEventHandlers registers a handler for unhandledRejection, uncaughtException, and multipleResolves', () => {
   const noopCallback = (err, event) => {

--- a/packages/integration-sdk-runtime/src/logger/registerEventHandlers.ts
+++ b/packages/integration-sdk-runtime/src/logger/registerEventHandlers.ts
@@ -108,7 +108,10 @@ function integrationLoggerEventHandlerCallback(
   return (err, event) => {
     const logger = getErrorLogger();
     logger.error({ err, event });
-    if (logger.onFailure) {
+    // multipleResolves is excluded from `onFailure` as it is
+    // not a strict failure and is at times even expected behavior
+    // in node-fetch, Promise.all, and Promise.race
+    if (logger.onFailure && event !== 'multipleResolves') {
       logger.onFailure({ err });
     }
   };


### PR DESCRIPTION
The `multipleResolves` is not a strict failure. It is at times even expected behavior. As such, we should exclude it from calling `onFailure` which is a more serious error reporting mechanism than just logging the error at level `error`.