### PR TITLE
INT-5593 - Emit metric when error or warn logged

### DIFF
--- a/packages/integration-sdk-core/src/types/metric.ts
+++ b/packages/integration-sdk-core/src/types/metric.ts
@@ -5,7 +5,7 @@ export interface Metric {
   /*
    * The unit that the metric value is associated with
    */
-  unit: 'Milliseconds' | 'Bytes';
+  unit?: 'Milliseconds' | 'Bytes';
 
   /**
    * Additional dimensions to add to a metric

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -864,3 +864,43 @@ describe('#handleFailure', () => {
     expect(handleFailureSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('logged message metric emitting', () => {
+  test('logger.error emits metric event', () => {
+    const onEmitMetric = jest.fn();
+
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    logger.on('metric', onEmitMetric);
+    logger.error('expected');
+
+    expect(onEmitMetric).toBeCalledTimes(1);
+    expect(onEmitMetric).toHaveBeenCalledWith({
+      name: 'logged_error',
+      value: 1,
+      timestamp: expect.any(Number),
+    });
+  });
+
+  test('logger.warn emits metric event', () => {
+    const onEmitMetric = jest.fn();
+
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    logger.on('metric', onEmitMetric);
+    logger.warn('expected');
+
+    expect(onEmitMetric).toBeCalledTimes(1);
+    expect(onEmitMetric).toHaveBeenCalledWith({
+      name: 'logged_warn',
+      value: 1,
+      timestamp: expect.any(Number),
+    });
+  });
+});

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -217,10 +217,18 @@ export class IntegrationLogger
   info(...params: any[]) {
     return this._logger.info(...params);
   }
+
   warn(...params: any[]) {
     this.trackHandledError(params[0]);
+
+    this.publishMetric({
+      name: 'logged_warn',
+      value: 1,
+    });
+
     return this._logger.warn(...params);
   }
+
   fatal(...params: any[]) {
     return this._logger.fatal(...params);
   }
@@ -249,6 +257,12 @@ export class IntegrationLogger
 
   error(...params: any[]) {
     this.trackHandledError(params[0]);
+
+    this.publishMetric({
+      name: 'logged_error',
+      value: 1,
+    });
+
     this._logger.error(...params);
   }
 


### PR DESCRIPTION
When the `IntegrationLogger` logs an error or a warn, the following events will be emitted respectively:

- `logged_error`
  - `value`: 1
- `logged_warn`
  - `value`: 1