### PR TITLE
INT-5593 - Skip logging metric message on `logged_error` and `logged_warn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## Unreleased
 
+## 8.25.1 - 2022-09-26
+
+### Changed
+
+- Skip logging messages when `logged_error` and `logged_warn` metrics are
+  emitted.
+
 ## 8.25.0 - 2022-09-26
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.25.0",
-    "@jupiterone/integration-sdk-runtime": "^8.25.0",
+    "@jupiterone/integration-sdk-core": "^8.25.1",
+    "@jupiterone/integration-sdk-runtime": "^8.25.1",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do yarn prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.25.0",
-    "@jupiterone/integration-sdk-runtime": "^8.25.0",
+    "@jupiterone/integration-sdk-core": "^8.25.1",
+    "@jupiterone/integration-sdk-runtime": "^8.25.1",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^8.25.0",
+    "@jupiterone/integration-sdk-runtime": "^8.25.1",
     "chalk": "^4",
     "commander": "^9.4.0",
     "fs-extra": "^10.1.0",
@@ -37,7 +37,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.25.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.25.1",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^8.25.0",
-    "@jupiterone/integration-sdk-testing": "^8.25.0",
+    "@jupiterone/integration-sdk-cli": "^8.25.1",
+    "@jupiterone/integration-sdk-testing": "^8.25.1",
     "@types/jest": "^27.1.0",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -27,8 +27,8 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^8.25.0",
-    "@jupiterone/integration-sdk-private-test-utils": "^8.25.0",
+    "@jupiterone/integration-sdk-dev-tools": "^8.25.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.25.1",
     "fetch-mock-jest": "^1.5.1"
   },
   "bugs": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.25.0",
+    "@jupiterone/integration-sdk-core": "^8.25.1",
     "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   },

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.25.0",
+    "@jupiterone/integration-sdk-core": "^8.25.1",
     "@lifeomic/alpha": "^1.4.0",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -43,7 +43,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.25.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.25.1",
     "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -638,6 +638,28 @@ describe('publishMetric', () => {
       'Collected metric.',
     );
   });
+
+  test('should allow disabling logging when metric published', () => {
+    const logger = createIntegrationLogger({
+      name,
+      invocationConfig,
+    });
+
+    const infoSpy = jest.spyOn(logger, 'info');
+
+    logger.publishMetric(
+      {
+        name: 'metric',
+        value: 1000,
+        unit: 'Milliseconds',
+      },
+      {
+        logMetric: false,
+      },
+    );
+
+    expect(infoSpy).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe('#publishEvent', () => {
@@ -874,9 +896,12 @@ describe('logged message metric emitting', () => {
       invocationConfig,
     });
 
+    const infoSpy = jest.spyOn(logger, 'info');
+
     logger.on('metric', onEmitMetric);
     logger.error('expected');
 
+    expect(infoSpy).toHaveBeenCalledTimes(0);
     expect(onEmitMetric).toBeCalledTimes(1);
     expect(onEmitMetric).toHaveBeenCalledWith({
       name: 'logged_error',
@@ -893,9 +918,11 @@ describe('logged message metric emitting', () => {
       invocationConfig,
     });
 
+    const infoSpy = jest.spyOn(logger, 'info');
     logger.on('metric', onEmitMetric);
     logger.warn('expected');
 
+    expect(infoSpy).toHaveBeenCalledTimes(0);
     expect(onEmitMetric).toBeCalledTimes(1);
     expect(onEmitMetric).toHaveBeenCalledWith({
       name: 'logged_warn',

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^8.25.0",
-    "@jupiterone/integration-sdk-runtime": "^8.25.0",
+    "@jupiterone/integration-sdk-core": "^8.25.1",
+    "@jupiterone/integration-sdk-runtime": "^8.25.1",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^8.25.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^8.25.1",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
`logger.error` and `logger.warn` already write a log to the console and `publishMetric` _also_ writes a log to the console. We will now skip logging this metric data to avoid duplicate logs.