### PR TITLE
Increase jest default timeout to 20 seconds

### DIFF
--- a/packages/integration-sdk-dev-tools/config/jest.js
+++ b/packages/integration-sdk-dev-tools/config/jest.js
@@ -18,4 +18,5 @@ module.exports = {
   setupFilesAfterEnv: [
     '<rootDir>/node_modules/@jupiterone/integration-sdk-dev-tools/config/setupJestTestFramework.js',
   ],
+  testTimeout: 20000,
 };


### PR DESCRIPTION
As test suites grow bigger we are in the need of increasing the default timeout of Jest, this prevents setting `jest.setTimeout` on each tests that times out.

