### PR TITLE
INT-5717 - Publish custom graph data collection metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to
 
 ## Unreleased
 
+## 8.28.0 - 2022-10-18
+
+- Publish the following new custom metrics when entities, relationships, and
+  mapped relationships are added to the `JobState` respectively:
+  - `collected_entities`
+  - `collected_relationships`
+  - `collected_mapped_relationships`
+
 ## 8.27.1 - 2022-10-16
 
 - Added log in `uploadDataChunk` to capture successful completion of an upload

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -33,6 +33,14 @@ export type BeforeAddRelationshipHookFunction<
   relationship: Relationship,
 ) => Promise<Relationship> | Relationship;
 
+export type AfterAddEntityHookFunction<
+  TExecutionContext extends ExecutionContext,
+> = (context: TExecutionContext, entity: Entity) => Entity;
+
+export type AfterAddRelationshipHookFunction<
+  TExecutionContext extends ExecutionContext,
+> = (context: TExecutionContext, relationship: Relationship) => Relationship;
+
 export type LoadExecutionConfigFunction<
   TInstanceConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,
   TExecutionConfig extends IntegrationExecutionConfig = IntegrationExecutionConfig,

--- a/packages/integration-sdk-core/src/types/logger.ts
+++ b/packages/integration-sdk-core/src/types/logger.ts
@@ -87,7 +87,19 @@ export interface PublishErrorEventInput extends PublishEventInput {
   name: IntegrationErrorEventName;
 }
 
-type PublishMetricFunction = (metric: Omit<Metric, 'timestamp'>) => void;
+export interface PublishMetricOptions {
+  /**
+   * Whether the metric data should be logged or not.
+   *
+   * Default: `true`
+   */
+  logMetric?: boolean;
+}
+
+type PublishMetricFunction = (
+  metric: Omit<Metric, 'timestamp'>,
+  publishMetricOptions?: PublishMetricOptions,
+) => void;
 
 interface BaseLogger {
   // traditional functions for regular logging

--- a/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
@@ -369,6 +369,40 @@ describe('#getData/#setData/#deleteData', () => {
   });
 });
 
+describe('#afterAddEntity', () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  test('should call "afterAddEntity" hook after entity has been added', async () => {
+    const entity = createTestEntity();
+    const afterAddEntity = jest.fn().mockReturnValueOnce(entity);
+
+    const jobState = createTestStepJobState({ afterAddEntity });
+    await jobState.addEntity(entity);
+
+    expect(afterAddEntity).toHaveBeenCalledTimes(1);
+    expect(afterAddEntity).toHaveBeenCalledWith(entity);
+  });
+});
+
+describe('#afterAddRelationship', () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  test('should call "afterAddRelationship" hook after relationship has been added', async () => {
+    const relationship = createTestRelationship();
+    const afterAddRelationship = jest.fn().mockReturnValueOnce(relationship);
+
+    const jobState = createTestStepJobState({ afterAddRelationship });
+    await jobState.addRelationship(relationship);
+
+    expect(afterAddRelationship).toHaveBeenCalledTimes(1);
+    expect(afterAddRelationship).toHaveBeenCalledWith(relationship);
+  });
+});
+
 describe('#TypeTracker', () => {
   describe('#getEncounteredTypesForStep', () => {
     test('should allow getting encountered graph object types by step', () => {

--- a/packages/integration-sdk-runtime/src/execution/step.ts
+++ b/packages/integration-sdk-runtime/src/execution/step.ts
@@ -5,6 +5,8 @@ import uniq from 'lodash/uniq';
 import { pick } from 'lodash';
 
 import {
+  AfterAddEntityHookFunction,
+  AfterAddRelationshipHookFunction,
   BeforeAddEntityHookFunction,
   BeforeAddRelationshipHookFunction,
   ExecutionContext,
@@ -42,6 +44,8 @@ export async function executeSteps<
   createStepGraphObjectDataUploader,
   beforeAddEntity,
   beforeAddRelationship,
+  afterAddEntity,
+  afterAddRelationship,
   dependencyGraphOrder,
 }: {
   executionContext: TExecutionContext;
@@ -53,6 +57,8 @@ export async function executeSteps<
   createStepGraphObjectDataUploader?: CreateStepGraphObjectDataUploaderFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
   beforeAddRelationship?: BeforeAddRelationshipHookFunction<TExecutionContext>;
+  afterAddEntity?: AfterAddEntityHookFunction<TExecutionContext>;
+  afterAddRelationship?: AfterAddRelationshipHookFunction<TExecutionContext>;
   dependencyGraphOrder?: string[];
 }): Promise<IntegrationStepResult[]> {
   const stepsByGraphId = seperateStepsByDependencyGraph(integrationSteps);
@@ -84,6 +90,8 @@ export async function executeSteps<
         createStepGraphObjectDataUploader,
         beforeAddEntity,
         beforeAddRelationship,
+        afterAddEntity,
+        afterAddRelationship,
       }),
     );
   }

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -28,6 +28,7 @@ import {
   PublishInfoEventInput,
   PublishErrorEventInput,
   DisabledStepReason,
+  PublishMetricOptions,
 } from '@jupiterone/integration-sdk-core';
 
 export * from './registerEventHandlers';
@@ -58,15 +59,6 @@ interface CreateIntegrationLoggerInput<
     IntegrationStepExecutionContext<TIntegrationConfig>
   > {
   invocationConfig?: IntegrationInvocationConfig<TIntegrationConfig>;
-}
-
-interface PublishMetricOptions {
-  /**
-   * Whether the metric data should be logged or not.
-   *
-   * Default: `true`
-   */
-  logMetric?: boolean;
 }
 
 export function createLogger<

--- a/packages/integration-sdk-runtime/src/metrics/index.ts
+++ b/packages/integration-sdk-runtime/src/metrics/index.ts
@@ -1,11 +1,21 @@
 import { IntegrationLogger, Metric } from '@jupiterone/integration-sdk-core';
 
+/**
+ * Custom metrics that are published from the integration SDK runtime
+ */
+export enum IntegrationRuntimeMetric {
+  COLLECTED_ENTITIES = 'collected_entities',
+  COLLECTED_RELATIONSHIPS = 'collected_relationships',
+  COLLECTED_MAPPED_RELATIONSHIPS = 'collected_mapped_relationships',
+}
+
 interface TimeOperationInput<T extends () => any> {
   logger: IntegrationLogger;
   metricName: string;
   operation: T;
   dimensions?: Metric['dimensions'];
 }
+
 export async function timeOperation<T extends () => any>({
   logger,
   metricName,
@@ -23,4 +33,73 @@ export async function timeOperation<T extends () => any>({
       value: duration,
     });
   });
+}
+
+export function publishEntitiesCollectedMetric({
+  logger,
+  entityType,
+  total = 1,
+}: {
+  logger: IntegrationLogger;
+  entityType: string;
+  total?: number;
+}) {
+  logger.publishMetric(
+    {
+      name: IntegrationRuntimeMetric.COLLECTED_ENTITIES,
+      value: total,
+      dimensions: {
+        entity_type: entityType,
+      },
+    },
+    {
+      logMetric: false,
+    },
+  );
+}
+
+export function publishRelationshipsCollectedMetric({
+  logger,
+  relationshipType,
+  total = 1,
+}: {
+  logger: IntegrationLogger;
+  relationshipType: string;
+  total?: number;
+}) {
+  logger.publishMetric(
+    {
+      name: IntegrationRuntimeMetric.COLLECTED_RELATIONSHIPS,
+      value: total,
+      dimensions: {
+        relationship_type: relationshipType,
+      },
+    },
+    {
+      logMetric: false,
+    },
+  );
+}
+
+export function publishMappedRelationshipsCollectedMetric({
+  logger,
+  relationshipType,
+  total = 1,
+}: {
+  logger: IntegrationLogger;
+  relationshipType: string;
+  total?: number;
+}) {
+  logger.publishMetric(
+    {
+      name: IntegrationRuntimeMetric.COLLECTED_MAPPED_RELATIONSHIPS,
+      value: total,
+      dimensions: {
+        relationship_type: relationshipType,
+      },
+    },
+    {
+      logMetric: false,
+    },
+  );
 }


### PR DESCRIPTION
After graph data has been successfully added to the `JobState`, a custom metric is emitted that allows us to track the count of each graph object by `_type`.

The following new custom metrics have been added:

- `collected_entities`
- `collected_relationships`
- `collected_mapped_relationships`