### PR TITLE
Remove asynchronous hasKey

### DIFF
--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -89,7 +89,7 @@ export interface JobState {
    * @see findEntity when the entity, if present, is needed (there is no need to
    * use `hasKey` before `findEntity`).
    */
-  hasKey: (_key: string | undefined) => boolean | Promise<boolean>;
+  hasKey: (_key: string | undefined) => boolean;
 
   /**
    * Allows a step to iterate all entities collected into the job state, limited


### PR DESCRIPTION
The `hasKey` function has no asynchronous implementation, and awaiting `jobState.hasKey` can unexpectedly cause duplicate key errors in some specific edge cases (see https://github.com/JupiterOne/sdk/pull/694/files).

I believe this is a major version change, because it changes a public interface. Adopting projects should remove `await` anywhere this method is called.