### PR TITLE
Allow duplicate types in document command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- Added option to allow duplicate types in `getSortedJupiterOneTypes`
+- Changed `j1-integration document` command to allow duplicate types
+
 ## 8.28.0 - 2022-10-18
 
 - Publish the following new custom metrics when entities, relationships, and

--- a/packages/integration-sdk-cli/src/commands/document.ts
+++ b/packages/integration-sdk-cli/src/commands/document.ts
@@ -51,6 +51,7 @@ async function executeDocumentAction(
   log.info('\nCollecting metadata types from steps...\n');
   const metadata = await getSortedJupiterOneTypes({
     projectPath,
+    duplicateTypes: true,
   });
 
   if (!metadata.entities.length && !metadata.relationships.length) {

--- a/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.test.ts
+++ b/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.test.ts
@@ -1,0 +1,198 @@
+import {
+  RelationshipClass,
+  RelationshipDirection,
+  Step,
+} from '@jupiterone/integration-sdk-core';
+import { collectGraphObjectMetadataFromSteps } from './getSortedJupiterOneTypes';
+
+function createIntegrationStep(
+  stepNumber: number,
+  entityTypes: string[],
+  relationshipTypes: string[],
+  mappedRelationshipTypes?: string[],
+): Step<any> {
+  return {
+    id: `step-${stepNumber}`,
+    name: `Step ${stepNumber}`,
+    entities: entityTypes.map((type) => {
+      return {
+        resourceName: `${type} - ${stepNumber}`,
+        _class: [],
+        _type: type,
+      };
+    }),
+    relationships: relationshipTypes.map((type) => {
+      return {
+        sourceType: `${stepNumber}`,
+        targetType: `${stepNumber}`,
+        _type: type,
+        _class: RelationshipClass.HAS,
+      };
+    }),
+    mappedRelationships: mappedRelationshipTypes?.map((type) => {
+      return {
+        sourceType: `${stepNumber}`,
+        targetType: `${stepNumber}`,
+        _type: type,
+        _class: RelationshipClass.HAS,
+        direction: RelationshipDirection.FORWARD,
+      };
+    }),
+    executionHandler: () => undefined,
+  };
+}
+
+describe('collectGraphObjectMetadataFromSteps', () => {
+  test('should return unique entity types', () => {
+    const metadata = collectGraphObjectMetadataFromSteps([
+      createIntegrationStep(1, ['entity_a'], []),
+      createIntegrationStep(2, ['entity_a'], []),
+    ]);
+    expect(metadata.entities).toEqual([
+      {
+        resourceName: 'entity_a - 1',
+        _class: [],
+        _type: 'entity_a',
+      },
+    ]);
+  });
+
+  test('should return all entity types if duplicateTypes is `true`', () => {
+    const metadata = collectGraphObjectMetadataFromSteps(
+      [
+        createIntegrationStep(1, ['entity_a'], []),
+        createIntegrationStep(2, ['entity_a'], []),
+      ],
+      true,
+    );
+    expect(metadata.entities).toEqual([
+      {
+        resourceName: 'entity_a - 1',
+        _class: [],
+        _type: 'entity_a',
+      },
+      {
+        resourceName: 'entity_a - 2',
+        _class: [],
+        _type: 'entity_a',
+      },
+    ]);
+  });
+
+  test('should return unique relationship types', () => {
+    const metadata = collectGraphObjectMetadataFromSteps([
+      createIntegrationStep(1, [], ['relationship_a']),
+      createIntegrationStep(2, [], ['relationship_a', 'relationship_b']),
+    ]);
+    expect(metadata.relationships).toEqual([
+      {
+        sourceType: '1',
+        targetType: '1',
+        _type: 'relationship_a',
+        _class: RelationshipClass.HAS,
+      },
+      {
+        sourceType: '2',
+        targetType: '2',
+        _type: 'relationship_b',
+        _class: RelationshipClass.HAS,
+      },
+    ]);
+  });
+
+  test('should return all relationship types if duplicateTypes is `true`', () => {
+    const metadata = collectGraphObjectMetadataFromSteps(
+      [
+        createIntegrationStep(1, [], ['relationship_a']),
+        createIntegrationStep(2, [], ['relationship_a', 'relationship_b']),
+      ],
+      true,
+    );
+    expect(metadata.relationships).toEqual([
+      {
+        sourceType: '1',
+        targetType: '1',
+        _type: 'relationship_a',
+        _class: RelationshipClass.HAS,
+      },
+      {
+        sourceType: '2',
+        targetType: '2',
+        _type: 'relationship_a',
+        _class: RelationshipClass.HAS,
+      },
+      {
+        sourceType: '2',
+        targetType: '2',
+        _type: 'relationship_b',
+        _class: RelationshipClass.HAS,
+      },
+    ]);
+  });
+
+  test('should return unique mapped relationship types', () => {
+    const metadata = collectGraphObjectMetadataFromSteps([
+      createIntegrationStep(1, [], [], ['mapped_relationship_a']),
+      createIntegrationStep(
+        2,
+        [],
+        [],
+        ['mapped_relationship_a', 'mapped_relationship_b'],
+      ),
+    ]);
+    expect(metadata.mappedRelationships).toEqual([
+      {
+        sourceType: '1',
+        targetType: '1',
+        _type: 'mapped_relationship_a',
+        _class: RelationshipClass.HAS,
+        direction: RelationshipDirection.FORWARD,
+      },
+      {
+        sourceType: '2',
+        targetType: '2',
+        _type: 'mapped_relationship_b',
+        _class: RelationshipClass.HAS,
+        direction: RelationshipDirection.FORWARD,
+      },
+    ]);
+  });
+
+  test('should return all mapped relationship types if duplicateTypes is `true`', () => {
+    const metadata = collectGraphObjectMetadataFromSteps(
+      [
+        createIntegrationStep(1, [], [], ['mapped_relationship_a']),
+        createIntegrationStep(
+          2,
+          [],
+          [],
+          ['mapped_relationship_a', 'mapped_relationship_b'],
+        ),
+      ],
+      true,
+    );
+    expect(metadata.mappedRelationships).toEqual([
+      {
+        sourceType: '1',
+        targetType: '1',
+        _type: 'mapped_relationship_a',
+        _class: RelationshipClass.HAS,
+        direction: RelationshipDirection.FORWARD,
+      },
+      {
+        sourceType: '2',
+        targetType: '2',
+        _type: 'mapped_relationship_a',
+        _class: RelationshipClass.HAS,
+        direction: RelationshipDirection.FORWARD,
+      },
+      {
+        sourceType: '2',
+        targetType: '2',
+        _type: 'mapped_relationship_b',
+        _class: RelationshipClass.HAS,
+        direction: RelationshipDirection.FORWARD,
+      },
+    ]);
+  });
+});

--- a/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
+++ b/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
@@ -12,17 +12,21 @@ import {
 
 export interface TypesCommandArgs {
   projectPath: string;
+  duplicateTypes?: boolean;
 }
 
 export async function getSortedJupiterOneTypes(
   options: TypesCommandArgs,
 ): Promise<StepGraphObjectMetadataProperties> {
-  const { projectPath } = options;
+  const { projectPath, duplicateTypes } = options;
 
   const config = await loadConfig(path.join(projectPath, 'src'));
 
   return alphabetizeMetadataProperties(
-    collectGraphObjectMetadataFromSteps(config.integrationSteps),
+    collectGraphObjectMetadataFromSteps(
+      config.integrationSteps,
+      duplicateTypes,
+    ),
   );
 }
 
@@ -83,6 +87,7 @@ function alphabetizeMetadataProperties(
 
 function collectGraphObjectMetadataFromSteps(
   steps: Step<IntegrationStepExecutionContext<object>>[],
+  duplicateTypes?: boolean,
 ): StepGraphObjectMetadataProperties {
   const orderedStepNames = buildStepDependencyGraph(steps).overallOrder();
   const integrationStepMap = integrationStepsToMap(steps);
@@ -103,7 +108,7 @@ function collectGraphObjectMetadataFromSteps(
     >;
 
     for (const e of step.entities) {
-      if (entityTypeSet.has(e._type)) {
+      if (!duplicateTypes && entityTypeSet.has(e._type)) {
         continue;
       }
 
@@ -112,7 +117,7 @@ function collectGraphObjectMetadataFromSteps(
     }
 
     for (const r of step.relationships) {
-      if (relationshipTypeSet.has(r._type)) {
+      if (!duplicateTypes && relationshipTypeSet.has(r._type)) {
         continue;
       }
 
@@ -121,7 +126,7 @@ function collectGraphObjectMetadataFromSteps(
     }
 
     for (const r of step.mappedRelationships || []) {
-      if (mappedRelationshipTypeSet.has(r._type)) {
+      if (!duplicateTypes && mappedRelationshipTypeSet.has(r._type)) {
         continue;
       }
 

--- a/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
+++ b/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
@@ -85,7 +85,7 @@ function alphabetizeMetadataProperties(
   };
 }
 
-function collectGraphObjectMetadataFromSteps(
+export function collectGraphObjectMetadataFromSteps(
   steps: Step<IntegrationStepExecutionContext<object>>[],
   duplicateTypes?: boolean,
 ): StepGraphObjectMetadataProperties {


### PR DESCRIPTION
### Changed

- Added option to allow duplicate types in `getSortedJupiterOneTypes`
- Changed `j1-integration document` command to allow duplicate types