### PR TITLE
Update executeStepWithDependencies to allow dependencyGraphId

### DIFF
--- a/packages/integration-sdk-testing/src/__tests__/executeStepWithDependencies.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/executeStepWithDependencies.test.ts
@@ -67,7 +67,7 @@ describe('executeStepWithDependencies', () => {
           instanceConfig: getMockInstanceConfig(),
         }),
       ).rejects.toThrow(
-        'executeStepWithDependencies does not currently support steps with a dependencyGraphId',
+        'stepId: "step-1" has dependencyGraphId: "last" but dependencyStepIds is undefined.',
       );
     });
 

--- a/packages/integration-sdk-testing/src/__tests__/getStepExecutionOrder.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/getStepExecutionOrder.test.ts
@@ -1,0 +1,121 @@
+import { getMockIntegrationStep } from '@jupiterone/integration-sdk-private-test-utils';
+import { getStepExecutionOrder } from '../getStepExecutionOrder';
+
+const testSteps = [
+  getMockIntegrationStep({ id: 'graph-1-step-1' }),
+  getMockIntegrationStep({ id: 'graph-1-step-2' }),
+  getMockIntegrationStep({
+    id: 'graph-1-step-3',
+    dependsOn: ['graph-1-step-2'],
+  }),
+  getMockIntegrationStep({ id: 'graph-2-step-1', dependencyGraphId: 'two' }),
+  getMockIntegrationStep({
+    id: 'graph-2-step-2',
+    dependsOn: ['graph-2-step-1'],
+    dependencyGraphId: 'two',
+  }),
+  getMockIntegrationStep({ id: 'graph-3-step-1', dependencyGraphId: 'three' }),
+  getMockIntegrationStep({ id: 'graph-5-step-1', dependencyGraphId: 'five' }),
+];
+const dependencyGraphOrder = ['two', 'three', 'four', 'five'];
+
+describe('getStepExecutionOrder', () => {
+  describe('empty dependencyStepIds', () => {
+    test('should not run any steps if dependencyStepIds is empty', () => {
+      expect(
+        getStepExecutionOrder({
+          integrationSteps: testSteps,
+          dependencyGraphOrder,
+          dependencyStepIds: [],
+        }).size,
+      ).toBe(0);
+    });
+  });
+
+  describe('valid', () => {
+    test('should run steps only in dependencyGraphs which have a dependencyStepId', () => {
+      expect([
+        ...getStepExecutionOrder({
+          integrationSteps: testSteps,
+          dependencyGraphOrder,
+          dependencyStepIds: ['graph-3-step-1', 'graph-1-step-1'],
+        }),
+      ]).toEqual(['graph-1-step-1', 'graph-3-step-1']);
+    });
+
+    test('should run dependencies of steps in dependencyStepIds', () => {
+      expect([
+        ...getStepExecutionOrder({
+          integrationSteps: testSteps,
+          dependencyGraphOrder,
+          dependencyStepIds: ['graph-1-step-3', 'graph-3-step-1'],
+        }),
+      ]).toEqual(['graph-1-step-2', 'graph-1-step-3', 'graph-3-step-1']);
+    });
+
+    test('should not run steps multiple times if duplicated dependencyStepIds', () => {
+      expect([
+        ...getStepExecutionOrder({
+          integrationSteps: testSteps,
+          dependencyGraphOrder,
+          dependencyStepIds: ['graph-3-step-1', 'graph-3-step-1'],
+        }),
+      ]).toEqual(['graph-3-step-1']);
+    });
+
+    test('should not run steps multiple times if already added from dependency', () => {
+      expect([
+        ...getStepExecutionOrder({
+          integrationSteps: testSteps,
+          dependencyGraphOrder,
+          dependencyStepIds: ['graph-1-step-3', 'graph-1-step-2'],
+        }),
+      ]).toEqual(['graph-1-step-2', 'graph-1-step-3']);
+    });
+
+    test('should run all steps in order', () => {
+      expect([
+        ...getStepExecutionOrder({
+          integrationSteps: testSteps,
+          dependencyGraphOrder,
+          dependencyStepIds: [
+            'graph-1-step-1',
+            'graph-1-step-3',
+            'graph-2-step-2',
+            'graph-3-step-1',
+            'graph-5-step-1',
+          ],
+        }),
+      ]).toEqual([
+        'graph-1-step-1',
+        'graph-1-step-2',
+        'graph-1-step-3',
+        'graph-2-step-1',
+        'graph-2-step-2',
+        'graph-3-step-1',
+        'graph-5-step-1',
+      ]);
+    });
+
+    test('should only run steps with dependencyGraphOrder given or default', () => {
+      expect([
+        ...getStepExecutionOrder({
+          integrationSteps: testSteps,
+          dependencyGraphOrder: ['five'],
+          dependencyStepIds: [
+            'graph-1-step-1',
+            'graph-1-step-3',
+            'graph-2-step-2',
+            'graph-3-step-1',
+            'graph-5-step-1',
+          ],
+        }),
+      ]).toEqual([
+        'graph-1-step-1',
+        'graph-1-step-2',
+        'graph-1-step-3',
+        'graph-5-step-1',
+      ]);
+    });
+  });
+});

--- a/packages/integration-sdk-testing/src/config.ts
+++ b/packages/integration-sdk-testing/src/config.ts
@@ -8,6 +8,7 @@ export interface StepTestConfig<
   TInstanceConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,
 > {
   stepId: string;
+  dependencyStepIds?: string[];
   invocationConfig: TInvocationConfig;
   instanceConfig: TInstanceConfig;
 }

--- a/packages/integration-sdk-testing/src/getStepExecutionOrder.ts
+++ b/packages/integration-sdk-testing/src/getStepExecutionOrder.ts
@@ -1,0 +1,40 @@
+import { Step } from '@jupiterone/integration-sdk-core';
+import { buildStepDependencyGraph } from '@jupiterone/integration-sdk-runtime';
+import {
+  DEFAULT_DEPENDENCY_GRAPH_IDENTIFIER,
+  seperateStepsByDependencyGraph,
+} from '@jupiterone/integration-sdk-runtime/src/execution/utils/seperateStepsByDependencyGraph';
+
+export function getStepExecutionOrder(params: {
+  integrationSteps: Step<any>[];
+  dependencyStepIds: string[];
+  dependencyGraphOrder: string[];
+}): Set<string> {
+  const { integrationSteps, dependencyGraphOrder, dependencyStepIds } = params;
+  const stepDependencyGraph = buildStepDependencyGraph(integrationSteps);
+  const stepsByDependencyGraph =
+    seperateStepsByDependencyGraph(integrationSteps);
+
+  // Filter the stepIds by only the ones we wish to run
+  for (const dependencyGraph in stepsByDependencyGraph) {
+    stepsByDependencyGraph[dependencyGraph] = stepsByDependencyGraph[
+      dependencyGraph
+    ].filter((step) => dependencyStepIds?.includes(step.id));
+  }
+
+  // Gets the set of all dependency steps
+  const dependencySteps = new Set<string>();
+  for (const dependencyGraphId of [
+    DEFAULT_DEPENDENCY_GRAPH_IDENTIFIER,
+    ...dependencyGraphOrder,
+  ]) {
+    for (const step of stepsByDependencyGraph[dependencyGraphId] || []) {
+      stepDependencyGraph
+        .dependenciesOf(step.id)
+        .forEach((id) => dependencySteps.add(id));
+      dependencySteps.add(step.id);
+    }
+  }
+
+  return dependencySteps;
+}

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -658,7 +658,7 @@ export function toMatchStepMetadata(
     collectedRelationships: Relationship[];
     encounteredEntityKeys?: Set<string>;
   },
-  testConfig: Omit<StepTestConfig, 'instanceConfig'>,
+  testConfig: Omit<StepTestConfig, 'instanceConfig' | 'dependencyStepIds'>,
 ): SyncExpectationResult {
   const { stepId, invocationConfig } = testConfig;
   const stepDependencyGraph = buildStepDependencyGraph(


### PR DESCRIPTION
I have had this change partially implemented for a while and was reminded of it when implementing #815 

Should keep current functionality and only changes how the function works if you define `dependencyStepIds`