### PR TITLE
Fix #823 - Do not modify `JUPITERONE_API_KEY` env var in CLI defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Fixed
+
+- Do not modify the value supplied to `JUPITERONE_API_KEY` when using the
+  integration CLI
+
 ## 8.29.2 - 2022-11-15
 
 ### Fixed

--- a/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/cli-run.test.ts
@@ -275,3 +275,25 @@ test('does not publish events for source "api" since there is no integrationJobI
   expect(log.displayExecutionResults).toHaveBeenCalledTimes(1);
   expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
 });
+
+test('should use JUPITERONE_API_KEY value in Authorization request header', async () => {
+  expect.assertions(1);
+  const job = generateSynchronizationJob();
+
+  setupSynchronizerApi({
+    polly,
+    job,
+    baseUrl: 'https://api.us.jupiterone.io',
+    onSyncJobCreateResponse(req, res) {
+      expect(req.headers['Authorization']).toEqual('Bearer testing-key');
+    },
+  });
+
+  await createCli().parseAsync([
+    'node',
+    'j1-integration',
+    'run',
+    '--integrationInstanceId',
+    'test',
+  ]);
+});

--- a/packages/integration-sdk-cli/src/__tests__/util/synchronization.ts
+++ b/packages/integration-sdk-cli/src/__tests__/util/synchronization.ts
@@ -1,4 +1,4 @@
-import { Polly } from '@pollyjs/core';
+import { Polly, Request, Response } from '@pollyjs/core';
 import {
   SynchronizationJob,
   SynchronizationJobStatus,
@@ -8,14 +8,22 @@ interface SetupOptions {
   baseUrl: string;
   polly: Polly;
   job: SynchronizationJob;
+  onSyncJobCreateResponse?: (req: Request<{}>, res: Response) => void;
 }
 
-export function setupSynchronizerApi({ polly, job, baseUrl }: SetupOptions) {
+export function setupSynchronizerApi({
+  polly,
+  job,
+  baseUrl,
+  onSyncJobCreateResponse,
+}: SetupOptions) {
   polly.server
     .post(`${baseUrl}/persister/synchronization/jobs`)
     .intercept((req, res) => {
       allowCrossOrigin(req, res);
       res.status(200).json({ job });
+
+      if (onSyncJobCreateResponse) onSyncJobCreateResponse(req, res);
     });
 
   polly.server

--- a/packages/integration-sdk-cli/src/commands/options.ts
+++ b/packages/integration-sdk-cli/src/commands/options.ts
@@ -5,7 +5,7 @@ import {
   JUPITERONE_DEV_API_BASE_URL,
   JUPITERONE_PROD_API_BASE_URL,
 } from '@jupiterone/integration-sdk-runtime';
-import { Command, OptionValues } from 'commander';
+import { Command, Option, OptionValues } from 'commander';
 import path from 'path';
 
 export interface PathOptions {
@@ -138,25 +138,32 @@ export interface ApiClientOptions {
 
 export function addApiClientOptionsToCommand(command: Command): Command {
   return command
-    .option(
-      '--api-base-url <url>',
-      'specify synchronization API base URL',
-      JUPITERONE_PROD_API_BASE_URL,
+    .addOption(
+      new Option(
+        '--api-base-url <url>',
+        'specify synchronization API base URL',
+      ).default(JUPITERONE_PROD_API_BASE_URL),
     )
-    .option(
-      '-d, --development',
-      '"true" to target apps.dev.jupiterone.io (JUPITERONE_DEV environment variable)',
-      !!process.env.JUPITERONE_DEV,
+    .addOption(
+      new Option(
+        '-d, --development',
+        '"true" to target apps.dev.jupiterone.io',
+      ).default(
+        !!process.env.JUPITERONE_DEV,
+        'JUPITERONE_DEV environment variable value',
+      ),
     )
-    .option(
-      '--account <account>',
-      'JupiterOne account ID (JUPITERONE_ACCOUNT environment variable)',
-      process.env.JUPITERONE_ACCOUNT,
+    .addOption(
+      new Option('--account <account>', 'JupiterOne account ID').default(
+        process.env.JUPITERONE_ACCOUNT,
+        'JUPITERONE_ACCOUNT environment variable value',
+      ),
     )
-    .option(
-      '--api-key <key>',
-      'JupiterOne API key (JUPITERONE_API_KEY environment variable)',
-      process.env.JUPITERONE_API_KEY?.replace(/./, '*'),
+    .addOption(
+      new Option('--api-key <key>', 'JupiterOne API key').default(
+        process.env.JUPITERONE_API_KEY,
+        'JUPITERONE_API_KEY environment variable value',
+      ),
     );
 }
 


### PR DESCRIPTION
The `j1-integration run` command accepts at `--api-key` CLI flag. Previously, this CLI flag had a default value that would read the value of the `JUPITERONE_API_KEY` environment variable and modify the value using a regex replace. The modification of the value of `JUPITERONE_API_KEY` resulted in an invalid value being supplied in request headers. The JupiterOne API was responding with 401 Unauthorized consistently.

After discussing with the team, it turns out that the regex replacement on `JUPITERONE_API_KEY` was put in place to prevent the value of `JUPITERONE_API_KEY` from being logged to the console in the CLI help text message.

The usage of the `commander` CLI options has been updated to include specific help text messages instead of just logging the current value of each respective environment variable.

**Help text before**:

Notice the default value in the `--api-key` help text  is`*bcdef` (incorrect and partially logged).

```
➜ JUPITERONE_API_KEY=abcdef ./bin/j1-integration run --integrationInstanceId abc --account j1dev --help
Usage: j1-integration run [options]

collect and sync to upload entities and relationships

Options:
  -p, --project-path <directory>                           path to integration project directory (default: "/Users/austinkelleher/Documents/open-source/sdk/packages/integration-sdk-cli")
  --api-base-url <url>                                     specify synchronization API base URL (default: "https://api.us.jupiterone.io")
  -d, --development                                        "true" to target apps.dev.jupiterone.io (JUPITERONE_DEV environment variable) (default: false)
  --account <account>                                      JupiterOne account ID (JUPITERONE_ACCOUNT environment variable)
  --api-key <key>                                          JupiterOne API key (JUPITERONE_API_KEY environment variable) (default: "*bcdef")
  -i, --integrationInstanceId <id>                         _integrationInstanceId assigned to uploaded entities and relationships
  --source <integration-managed|integration-external|api>  specify synchronization job source value (default: "integration-managed")
  --scope <anystring>                                      specify synchronization job scope value
  -u, --upload-batch-size <number>                         specify number of entities and relationships per upload batch (default: 250)
  -ur, --upload-relationship-batch-size <number>           specify number of relationships per upload batch, overrides --upload-batch-size (default: 250)
  --skip-finalize                                          skip synchronization finalization to leave job open for additional uploads (default: false)
  -V, --disable-schema-validation                          disable schema validation
  -h, --help                                               display help for command
```

**Help text after**:

```
➜ JUPITERONE_API_KEY=abcdef ./bin/j1-integration run --integrationInstanceId abc --account j1dev --help
Usage: j1-integration run [options]

collect and sync to upload entities and relationships

Options:
  -p, --project-path <directory>                           path to integration project directory (default: "/Users/austinkelleher/Documents/open-source/sdk/packages/integration-sdk-cli")
  --api-base-url <url>                                     specify synchronization API base URL (default: "https://api.us.jupiterone.io")
  -d, --development                                        "true" to target apps.dev.jupiterone.io (default: JUPITERONE_DEV environment variable value)
  --account <account>                                      JupiterOne account ID
  --api-key <key>                                          JupiterOne API key (default: JUPITERONE_API_KEY environment variable value)
  -i, --integrationInstanceId <id>                         _integrationInstanceId assigned to uploaded entities and relationships
  --source <integration-managed|integration-external|api>  specify synchronization job source value (default: "integration-managed")
  --scope <anystring>                                      specify synchronization job scope value
  -u, --upload-batch-size <number>                         specify number of entities and relationships per upload batch (default: 250)
  -ur, --upload-relationship-batch-size <number>           specify number of relationships per upload batch, overrides --upload-batch-size (default: 250)
  --skip-finalize                                          skip synchronization finalization to leave job open for additional uploads (default: false)
  -V, --disable-schema-validation                          disable schema validation
  -h, --help                                               display help for command
```