### PR TITLE
Adding API_VERSION to DisabledStepReason enum

### DIFF
--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -16,6 +16,7 @@ export enum DisabledStepReason {
   PERMISSION = 'permission', // Missing permission disabled this step
   BETA = 'beta', // Step is in beta and only enabled on request
   CONFIG = 'config', // Step was disabled via config
+  API_VERSION = 'api_version', // Step is disabled due to lack of support in an API version
 }
 
 export interface StepStartState {

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -313,6 +313,7 @@ describe('step event publishing', () => {
 
     logger.stepStart(step);
     logger.stepSuccess(step);
+    logger.stepSkip(step, DisabledStepReason.API_VERSION);
     logger.stepSkip(step, DisabledStepReason.BETA);
     logger.stepSkip(step, DisabledStepReason.PERMISSION);
     logger.stepSkip(step, DisabledStepReason.CONFIG);
@@ -322,7 +323,7 @@ describe('step event publishing', () => {
     const error = new IntegrationLocalConfigFieldMissingError('ripperoni');
     logger.stepFailure(step, error);
 
-    expect(onEmitEvent).toHaveBeenCalledTimes(6);
+    expect(onEmitEvent).toHaveBeenCalledTimes(7);
     expect(onEmitEvent).toHaveBeenNthCalledWith(1, {
       name: 'step_start',
       level: PublishEventLevel.Info,
@@ -337,21 +338,27 @@ describe('step event publishing', () => {
       name: 'step_skip',
       level: PublishEventLevel.Info,
       description:
-        'Skipped step "Mochi". Beta feature, please contact support to enable.',
+        'Skipped step "Mochi". This step is disabled due to a limitation in the third party API version that is being used.  Please review documentation for this integration for further information.',
     });
     expect(onEmitEvent).toHaveBeenNthCalledWith(4, {
       name: 'step_skip',
       level: PublishEventLevel.Info,
       description:
-        'Skipped step "Mochi". The required permission was not provided to perform this step.',
+        'Skipped step "Mochi". Beta feature, please contact support to enable.',
     });
     expect(onEmitEvent).toHaveBeenNthCalledWith(5, {
       name: 'step_skip',
       level: PublishEventLevel.Info,
       description:
-        'Skipped step "Mochi". This step is disabled via configuration. Please contact support to enabled.',
+        'Skipped step "Mochi". The required permission was not provided to perform this step.',
     });
     expect(onEmitEvent).toHaveBeenNthCalledWith(6, {
+      name: 'step_skip',
+      level: PublishEventLevel.Info,
+      description:
+        'Skipped step "Mochi". This step is disabled via configuration. Please contact support to enabled.',
+    });
+    expect(onEmitEvent).toHaveBeenNthCalledWith(7, {
       name: 'step_failure',
       level: PublishEventLevel.Error,
       description: expect.stringMatching(

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -321,6 +321,10 @@ export class IntegrationLogger
     let description = `Skipped step "${step.name}". `;
 
     switch (reason) {
+      case DisabledStepReason.API_VERSION: {
+        description += `This step is disabled due to a limitation in the third party API version that is being used.  Please review documentation for this integration for further information.`;
+        break;
+      }
       case DisabledStepReason.BETA: {
         description += `Beta feature, please contact support to enable.`;
         break;


### PR DESCRIPTION
Adding step disabled reason for when the step is unsupported due to a third party's API version.