### PR TITLE
Add tags with value: '' to .tags property

### DIFF
--- a/packages/integration-sdk-core/src/data/__tests__/tagging.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/tagging.test.ts
@@ -73,6 +73,14 @@ describe('assignTags', () => {
     });
   });
 
+  test('tags with "" value have property name added to .tags', () => {
+    assignTags(entity, [{ key: 'Production', value: '' }]);
+    expect(entity).toMatchObject({
+      'tag.Production': '',
+      tags: ['Production'],
+    });
+  });
+
   test('tags with "true" value are assigned as boolean', () => {
     assignTags(entity, [
       { key: 'Production', value: 'true' },

--- a/packages/integration-sdk-core/src/data/tagging.ts
+++ b/packages/integration-sdk-core/src/data/tagging.ts
@@ -115,7 +115,7 @@ function assignTagMap(
   for (const key of Object.keys(tagMap)) {
     const value = tagMap[key];
     if (value != null) {
-      if (TRUE_BOOLEAN_REGEX.test(value)) {
+      if (TRUE_BOOLEAN_REGEX.test(value) || value === '') {
         tags.push(key);
       }
 


### PR DESCRIPTION
The AWS integration (and, I suspect, other integrations), upload allow tags to have empty values (`''`). In this case, JupiterOne's `assignTags` functionality basically skips these tags altogether, preventing any useful querying capabilities for these types of tags.

<img width="384" alt="Screenshot 2023-02-20 at 1 39 06 PM" src="https://user-images.githubusercontent.com/15333061/220179503-178cbf42-1784-4a75-851e-3a6785b25388.png">

This PR checks for tags with empty string values (`''`) and assigns them to the `.tags` array. 

In the future, I think we should consider adding _every_ tag name to the `.tags` property, instead of selectively choosing just those that match `/^true$/i`.