### PR TITLE
fix(INT-6623): fix rawData of undefined

### DIFF
--- a/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
@@ -46,7 +46,7 @@ export function shrinkBatchRawData(
 
     // If we don't have any entities to shrink or the optional _rawData array is empty,
     // we have no other options than to throw an error.
-    if (entityWithLargestRawData?._rawData) {
+    if (entityWithLargestRawData?._rawData?.length) {
       // Find largest element of the _rawData array (typically at index 0, but check to be certain)
       const largestRawDataEntry = getLargestRawDataEntry(
         entityWithLargestRawData._rawData,


### PR DESCRIPTION
## Fix rawData of undefined

**Motivation and context:**

When `shrinkBatchRawData` is executed due to `RequestEntityTooLargeException` errors, in some cases, entities contain empty `_rawData` (`[]`).  The if condition that establishes if `entityWithLargestRawData` actually has `_rawData` was coded in the following way: 

```
if (entityWithLargestRawData?._rawData?) {
```

So in this case (that shouldn't be true), if rowData is an [], the condition results in a true, executing the code with empty rowData and throwing the following error in this function ` const largestItemLookup = getLargestItemKeyAndByteSize()`

```
Caused by: TypeError: Cannot read property 'rawData' of undefined
    at shrinkBatchRawData (/opt/jupiterone/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/synchronization/shrinkBatchRawData.js:38:88)
    at handleUploadDataChunkError (/opt/jupiterone/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/synchronization/index.js:232:53)
    at Object.handleError (/opt/jupiterone/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/synchronization/index.js:275:17)
    at onError (/opt/jupiterone/app/node_modules/@lifeomic/attempt/dist/src/index.js:93:31)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async uploadDataChunk (/opt/jupiterone/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/synchronization/index.js:245:5)
    at async concurrency (/opt/jupiterone/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/synchronization/index.js:295:13)
    at async /opt/jupiterone/app/node_modules/p-map/index.js:57:22
```

## Solution:

Added `.length ` to check if is an empty array. 