### PR TITLE
reduce logging in document command

### DIFF
--- a/packages/integration-sdk-cli/src/commands/document.ts
+++ b/packages/integration-sdk-cli/src/commands/document.ts
@@ -48,7 +48,6 @@ async function executeDocumentAction(
   const projectPath = path.resolve(options.projectPath);
   const documentationFilePath = path.join(projectPath, outputFile);
 
-  log.info('\nCollecting metadata types from steps...\n');
   const metadata = await getSortedJupiterOneTypes({
     projectPath,
     duplicateTypes: true,
@@ -61,27 +60,17 @@ async function executeDocumentAction(
     return;
   }
 
-  log.info(
-    `\nAttempting to load existing documentation file (path=${documentationFilePath})!\n`,
-  );
   const oldDocumentationFile = await getDocumentationFile(
     documentationFilePath,
   );
-  log.info('\nExisting documentation file successfully loaded!\n');
 
   const newGeneratedDocumentationSection =
     generateGraphObjectDocumentationFromStepsMetadata(metadata);
-
-  log.info('\nGenerated integration documentation section:');
-  log.info('---------------------------------------------\n');
-  log.info(newGeneratedDocumentationSection);
 
   const newDocumentationFile = replaceBetweenDocumentMarkers(
     oldDocumentationFile,
     newGeneratedDocumentationSection,
   );
-
-  log.info('Attempting to write new documentation...');
 
   await fs.writeFile(documentationFilePath, newDocumentationFile, {
     encoding: 'utf-8',


### PR DESCRIPTION
# Description

This PR reduces the logging in the cli's document command. Since this command is run on every `git commit` in graph repos, it generates a lot of extra noise
while going through normal workflows.
