### PR TITLE
remove normalizeGraphObjectKey function from SDK

### DIFF
--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -53,7 +53,6 @@ export interface InvocationConfig<
   validateInvocation?: InvocationValidationFunction<TExecutionContext>;
   getStepStartStates?: GetStepStartStatesFunction<TExecutionContext>;
   integrationSteps: Step<TStepExecutionContext>[];
-  normalizeGraphObjectKey?: KeyNormalizationFunction;
   beforeAddEntity?: BeforeAddEntityHookFunction<TExecutionContext>;
   beforeAddRelationship?: BeforeAddRelationshipHookFunction<TExecutionContext>;
   loadExecutionConfig?: LoadExecutionConfigFunction;

--- a/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.test.ts
@@ -9,14 +9,14 @@ describe('DuplicateKeyTracker', () => {
   test('has key returns true when key is present', () => {
     const duplicateKeyTracker = new DuplicateKeyTracker();
     const _key = 'test-key-1';
-    duplicateKeyTracker.registerKey(_key, { _key, _type: 'entity' });
+    duplicateKeyTracker.registerKey(_key);
     expect(duplicateKeyTracker.hasKey(_key)).toBeTrue();
   });
 
   test('has key returns false when key is not present', () => {
     const duplicateKeyTracker = new DuplicateKeyTracker();
     const _key = 'test-key-1';
-    duplicateKeyTracker.registerKey(_key, { _key, _type: 'entity' });
+    duplicateKeyTracker.registerKey(_key);
     expect(duplicateKeyTracker.hasKey('not-found')).toBeFalse();
   });
 });

--- a/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.ts
+++ b/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.ts
@@ -2,15 +2,9 @@ import {
   Entity,
   GraphObjectStore,
   IntegrationDuplicateKeyError,
-  KeyNormalizationFunction,
 } from '@jupiterone/integration-sdk-core';
 import { deepStrictEqual } from 'assert';
 import { BigMap } from './utils/bigMap';
-
-export interface DuplicateKeyTrackerGraphObjectMetadata {
-  _type: string;
-  _key: string;
-}
 
 const DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE = 2000000;
 
@@ -22,38 +16,26 @@ const DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE = 2000000;
  * table.
  */
 export class DuplicateKeyTracker {
-  private readonly graphObjectKeyMap: BigMap<
-    string,
-    DuplicateKeyTrackerGraphObjectMetadata
-  >;
-  private readonly normalizationFunction: KeyNormalizationFunction;
+  private readonly graphObjectKeyMap: BigMap<string, boolean>;
 
-  constructor(normalizationFunction?: KeyNormalizationFunction) {
-    this.normalizationFunction = normalizationFunction || ((_key) => _key);
-
-    this.graphObjectKeyMap = new BigMap<
-      string,
-      DuplicateKeyTrackerGraphObjectMetadata
-    >(DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE);
+  constructor() {
+    this.graphObjectKeyMap = new BigMap<string, boolean>(
+      DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE,
+    );
   }
 
-  registerKey(_key: string, metadata: DuplicateKeyTrackerGraphObjectMetadata) {
-    const normalizedKey = this.normalizationFunction(_key);
-    if (this.graphObjectKeyMap.has(normalizedKey)) {
+  registerKey(_key: string) {
+    if (this.graphObjectKeyMap.has(_key)) {
       throw new IntegrationDuplicateKeyError(
         `Duplicate _key detected (_key=${_key})`,
       );
     }
 
-    this.graphObjectKeyMap.set(normalizedKey, metadata);
-  }
-
-  getGraphObjectMetadata(_key: string) {
-    return this.graphObjectKeyMap.get(this.normalizationFunction(_key));
+    this.graphObjectKeyMap.set(_key, true);
   }
 
   hasKey(_key: string) {
-    return this.graphObjectKeyMap.has(this.normalizationFunction(_key));
+    return this.graphObjectKeyMap.has(_key);
   }
 }
 

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -245,9 +245,7 @@ export async function executeWithContext<
       executionContext: context,
       integrationSteps: config.integrationSteps,
       stepStartStates,
-      duplicateKeyTracker: new DuplicateKeyTracker(
-        config.normalizeGraphObjectKey,
-      ),
+      duplicateKeyTracker: new DuplicateKeyTracker(),
       graphObjectStore,
       dataStore: new MemoryDataStore(),
       createStepGraphObjectDataUploader,

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -156,10 +156,7 @@ export function createStepJobState({
 
     for (const [index, entity] of entities.entries()) {
       try {
-        duplicateKeyTracker.registerKey(entity._key, {
-          _type: entity._type,
-          _key: entity._key,
-        });
+        duplicateKeyTracker.registerKey(entity._key);
       } catch (err) {
         const duplicateEntityReport = await createDuplicateEntityReport({
           duplicateEntity: entity,
@@ -193,10 +190,7 @@ export function createStepJobState({
   };
 
   function registerRelationshipInTrackers(r: Relationship) {
-    duplicateKeyTracker.registerKey(r._key, {
-      _type: r._type,
-      _key: r._key,
-    });
+    duplicateKeyTracker.registerKey(r._key);
 
     typeTracker.addStepGraphObjectType({
       stepId,
@@ -267,16 +261,13 @@ export function createStepJobState({
 
     findEntity: async (_key: string | undefined) => {
       if (!_key) return null;
-      const graphObjectMetadata =
-        duplicateKeyTracker.getGraphObjectMetadata(_key);
+      const keyExists = duplicateKeyTracker.hasKey(_key);
 
-      if (!graphObjectMetadata) {
+      if (!keyExists) {
         return null;
       }
 
-      return (
-        (await graphObjectStore.findEntity(graphObjectMetadata._key)) || null
-      );
+      return (await graphObjectStore.findEntity(_key)) || null;
     },
 
     hasKey: (_key: string | undefined) => {

--- a/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jobState.test.ts
@@ -108,20 +108,6 @@ describe('entities', () => {
     expect(result).toEqual(inputEntities[0]);
   });
 
-  test('findEntity returns initialized entity from jobState when _key matches with key normalization', async () => {
-    const jobState = createMockJobState({
-      normalizeGraphObjectKey: (_key) => _key.toLowerCase(),
-    });
-    const inputEntity = {
-      _type: 'test',
-      _class: 'Resource',
-      _key: 'INCONSISTENT-casing',
-    };
-    await jobState.addEntities([inputEntity]);
-    const result = await jobState.findEntity('inconsistent-CASING');
-    expect(result).toEqual(inputEntity);
-  });
-
   test('findEntity returns null when entity cannot be found in jobState', async () => {
     const jobState = createMockJobState();
     expect(await jobState.findEntity('does-not-exist')).toEqual(null);


### PR DESCRIPTION
# Description

This PR removes the `normalizeGraphObjectKey` from the invocation config.

It also reworks the `DuplicateKeyTracker` to potentially save a large amount of memory.

**This is a breaking change to the SDK and would require a major version bump**.

# Justification

The DuplicateKeyTracker currently has a method called `getGraphObjectMetadata`. This method retrieves the `_type` and `_key` of an entity. The `_type` and `_key` for each entity is stored in an Map with the following type signature:
```ts
BigMap<
    string,
   { _type: string, _key: string }
  >;
```

The key in this map is the `normalizedKey` of the graph object. The map serves as a link between `normalizeKey` -> `plainKey`. The `plainKey` is what the key is stored as in the `FileSystemGraphObjectStore`. The `_type` from this object is never used.

If we estimate that the average key is 100 characters and the average type is 100 characters than in an integration with 1,000,000 graph objects using this map costs us: (70 bytes _key + 50 bytes _type) * 1,000,000 = 120,000,000 Bytes ~= 120MB.

We could find additional savings via having the graph object store handling `hasKey`.

