### PR TITLE
INT-7594 - switch `uuid` module to native `crypto` `randomUUID`

### DIFF
--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -161,7 +161,7 @@ Example:
 
 ```typescript
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 interface InstanceConfig extends IntegrationInstanceConfig {
   roleArn: string;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "bin": {
     "j1": "./bin/j1"
@@ -34,8 +34,7 @@
     "ora": "^4.0.4",
     "p-all": "^3.0.0",
     "rimraf": "^3.0.2",
-    "upath": "^1.2.0",
-    "uuid": "^8.1.0"
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "@types/json2csv": "^5.0.1",

--- a/packages/cli/src/__tests__/cli-import.test.ts
+++ b/packages/cli/src/__tests__/cli-import.test.ts
@@ -2,7 +2,7 @@ import * as runtime from '@jupiterone/integration-sdk-runtime';
 import axios from 'axios';
 import { mocked } from 'jest-mock';
 import { vol } from 'memfs';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import globby from 'globby';
 
 import {

--- a/packages/cli/src/export/__tests__/bulkDownloadToJson.test.ts
+++ b/packages/cli/src/export/__tests__/bulkDownloadToJson.test.ts
@@ -1,7 +1,7 @@
 import * as runtime from '@jupiterone/integration-sdk-runtime';
 import { mocked } from 'jest-mock';
 import axios, { AxiosInstance } from 'axios';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 import * as fileSystem from '../../fileSystem';
 import {

--- a/packages/cli/src/export/__tests__/exportJsonAssetsToCsv.test.ts
+++ b/packages/cli/src/export/__tests__/exportJsonAssetsToCsv.test.ts
@@ -1,6 +1,6 @@
 import ora from 'ora';
 import { vol } from 'memfs';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import csvToJson from 'csvtojson';
 
 import { DEFAULT_EXPORT_DIRECTORY } from '../../commands';

--- a/packages/cli/src/export/__tests__/groupJsonAssetsByType.test.ts
+++ b/packages/cli/src/export/__tests__/groupJsonAssetsByType.test.ts
@@ -1,5 +1,5 @@
 import { vol } from 'memfs';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 import { groupJsonAssetsByType } from '../groupJsonAssetsByType';
 import { DEFAULT_EXPORT_DIRECTORY } from '../../commands';

--- a/packages/cli/src/export/__tests__/writeAssetsToCsv.test.ts
+++ b/packages/cli/src/export/__tests__/writeAssetsToCsv.test.ts
@@ -1,5 +1,5 @@
 import { vol } from 'memfs';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 import { groupJsonAssetsByType } from '../groupJsonAssetsByType';
 import { TEST_STORAGE_LOCATION } from '../../__tests__/utils';

--- a/packages/cli/src/export/bulkDownloadToJson.ts
+++ b/packages/cli/src/export/bulkDownloadToJson.ts
@@ -3,7 +3,7 @@ import {
   getApiBaseUrl,
 } from '@jupiterone/integration-sdk-runtime';
 import _ from 'lodash';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { Entity, Relationship } from '@jupiterone/integration-sdk-core';
 
 import { ensureDirectoryExists, writeFileToPath } from '../fileSystem';

--- a/packages/cli/src/export/writeAssetsToCsv.ts
+++ b/packages/cli/src/export/writeAssetsToCsv.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import jsonexport from 'jsonexport';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import _ from 'lodash';
 
 import {

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -8,7 +8,7 @@
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "scripts": {
     "prebenchmark": "rm -rf .j1-integration",

--- a/packages/integration-sdk-benchmark/src/util/entity.js
+++ b/packages/integration-sdk-benchmark/src/util/entity.js
@@ -1,5 +1,5 @@
 const { createIntegrationEntity } = require('@jupiterone/integration-sdk-core');
-const { v4: uuid } = require('uuid');
+const { randomUUID: uuid } = require('crypto');
 
 function createMockEntity(_key) {
   return createIntegrationEntity({

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -8,7 +8,7 @@
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "bin": {
     "j1-integration": "./bin/j1-integration"
@@ -48,7 +48,6 @@
     "@types/lodash": "^4.14.158",
     "@types/vis": "^4.21.20",
     "memfs": "^3.2.0",
-    "neo-forgery": "^2.0.0",
-    "uuid": "^8.2.0"
+    "neo-forgery": "^2.0.0"
   }
 }

--- a/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.test.ts
+++ b/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.test.ts
@@ -7,7 +7,7 @@ import {
   StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 import { collectGraphObjectMetadataFromSteps } from './getSortedJupiterOneTypes';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 function createIntegrationStep({
   entities = [],

--- a/packages/integration-sdk-cli/src/visualization/utils.ts
+++ b/packages/integration-sdk-cli/src/visualization/utils.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { Entity } from '@jupiterone/integration-sdk-core';
 
 export type NodeEntity = Partial<Entity> & { nodeId: string };

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "publishConfig": {
     "access": "public"
@@ -24,8 +24,7 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.54.0",
-    "lodash": "^4.17.21",
-    "uuid": "^8.3.2"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.168"

--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 import {
   createIntegrationEntity,

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -6,7 +6,7 @@
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "files": [
     "config"

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -9,15 +9,14 @@
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "scripts": {
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
     "@jupiterone/integration-sdk-core": "^8.31.1",
-    "lodash": "^4.17.15",
-    "uuid": "^7.0.3"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.149"

--- a/packages/integration-sdk-private-test-utils/src/graphObject.ts
+++ b/packages/integration-sdk-private-test-utils/src/graphObject.ts
@@ -1,6 +1,6 @@
 import { Entity, ExplicitRelationship } from '@jupiterone/integration-sdk-core';
 import { times } from 'lodash';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 export function createTestEntity(partial?: Partial<Entity>): Entity {
   return {

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "publishConfig": {
     "access": "public"
@@ -39,12 +39,10 @@
     "lodash": "^4.17.15",
     "p-map": "^4.0.0",
     "p-queue": "^6.3.0",
-    "rimraf": "^3.0.2",
-    "uuid": "^7.0.3"
+    "rimraf": "^3.0.2"
   },
   "devDependencies": {
     "@jupiterone/integration-sdk-private-test-utils": "^8.31.1",
-    "@types/uuid": "^7.0.2",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",
     "ts-node": "^9.1.0",

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import times from 'lodash/times';
 import { vol } from 'memfs';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import waitForExpect from 'wait-for-expect';
 
 import {

--- a/packages/integration-sdk-runtime/src/execution/__tests__/instance.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/instance.test.ts
@@ -2,7 +2,7 @@ import {
   createIntegrationInstanceForLocalExecution,
   LOCAL_INTEGRATION_INSTANCE,
 } from '../instance';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 describe('createIntegrationInstanceForLocalExecution', () => {
   beforeEach(() => {

--- a/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
@@ -9,7 +9,7 @@ import {
   DuplicateEntityReport,
   DuplicateKeyTracker,
 } from '../duplicateKeyTracker';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { FileSystemGraphObjectStore } from '../../storage';
 import { vol } from 'memfs';
 import { Entity } from '@jupiterone/integration-sdk-core';

--- a/packages/integration-sdk-runtime/src/execution/uploader.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.test.ts
@@ -10,7 +10,7 @@ import {
   createTestRelationship,
 } from '@jupiterone/integration-sdk-private-test-utils';
 import times from 'lodash/times';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { SynchronizationJobContext } from '../synchronization';
 import { createApiClient, getApiBaseUrl } from '../api';
 import { generateSynchronizationJob } from '../synchronization/__tests__/util/generateSynchronizationJob';

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -5,7 +5,7 @@ import {
   uploadGraphObjectData,
   SynchronizationJobContext,
 } from '../synchronization';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 export interface StepGraphObjectDataUploader {
   stepId: string;

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -1,6 +1,6 @@
 import Logger from 'bunyan';
 import { EventEmitter } from 'events';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 import {
   ExecutionContext,

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { promises as fs } from 'fs';
 
 import { vol } from 'memfs';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import times from 'lodash/times';
 
 import { getRootStorageDirectory } from '../../../fileSystem';

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/flushDataToDisk.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/flushDataToDisk.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 
 import { vol } from 'memfs';
 import pMap from 'p-map';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import times from 'lodash/times';
 import sortBy from 'lodash/sortBy';
 import flatten from 'lodash/flatten';

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/flushDataToDisk.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/flushDataToDisk.ts
@@ -1,5 +1,5 @@
 import pMap from 'p-map';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import groupBy from 'lodash/groupBy';
 
 import { Entity, Relationship } from '@jupiterone/integration-sdk-core';

--- a/packages/integration-sdk-runtime/src/storage/memory.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/memory.test.ts
@@ -1,6 +1,6 @@
 import { Entity, Relationship } from '@jupiterone/integration-sdk-core';
 import { InMemoryGraphObjectStore } from './memory';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import {
   createTestEntity,
   createTestRelationship,

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -3,7 +3,7 @@ import {
   createTestEntity,
   createTestRelationship,
 } from '@jupiterone/integration-sdk-private-test-utils';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { createApiClient, getApiBaseUrl } from '../../api';
 import { generateSynchronizationJob } from './util/generateSynchronizationJob';
 import { createMockIntegrationLogger } from '../../../test/util/fixtures';

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -20,7 +20,7 @@ import { ApiClient } from '../api';
 import { timeOperation } from '../metrics';
 import { FlushedGraphObjectData } from '../storage/types';
 import { AttemptContext, retry } from '@lifeomic/attempt';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { createEventPublishingQueue } from './events';
 import { AxiosInstance } from 'axios';
 import { iterateParsedGraphFiles } from '..';

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "engines": {
-    "node": "14.x"
+    "node": ">=14.17.0 <15.x"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/integration-sdk-testing/src/__tests__/context.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/context.test.ts
@@ -21,7 +21,7 @@ import {
   createMockExecutionContext,
   createMockStepExecutionContext,
 } from '../context';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 interface Config {
   myBooleanConfig: boolean;

--- a/packages/integration-sdk-testing/src/__tests__/executeStepWithDependencies.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/executeStepWithDependencies.test.ts
@@ -6,7 +6,7 @@ import {
   Relationship,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { executeStepWithDependencies } from '../executeStepWithDependencies';
 import { getMockIntegrationStep } from '@jupiterone/integration-sdk-private-test-utils';
 

--- a/packages/integration-sdk-testing/src/__tests__/jest.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jest.test.ts
@@ -18,7 +18,7 @@ import {
   registerMatchers,
   toImplementSpec,
 } from '../jest';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { toMatchStepMetadata } from '..';
 import { getMockIntegrationStep } from '@jupiterone/integration-sdk-private-test-utils';
 

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -9,7 +9,7 @@ import {
   MemoryDataStore,
   TypeTracker,
 } from '@jupiterone/integration-sdk-runtime';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 export interface CreateMockJobStateOptions {
   entities?: Entity[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,11 +1916,6 @@
   resolved "https://registry.yarnpkg.com/@types/traverse/-/traverse-0.6.32.tgz#f9fdfa40cd4898deaa975a14511aec731de8235e"
   integrity sha512-RBz2uRZVCXuMg93WD//aTS5B120QlT4lR/gL+935QtGsKHLS6sCtZBaKfWjIfk7ZXv/r8mtGbwjVIee6/3XTow==
 
-"@types/uuid@^7.0.2":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.5.tgz#b1d2f772142a301538fae9bdf9cf15b9f2573a29"
-  integrity sha512-hKB88y3YHL8oPOs/CNlaXtjWn93+Bs48sDQR37ZUqG2tLeCS7EA1cmnkKsuQsub9OKEB/y/Rw9zqJqqNSbqVlQ==
-
 "@types/vis@^4.21.20":
   version "4.21.23"
   resolved "https://registry.yarnpkg.com/@types/vis/-/vis-4.21.23.tgz#03b2d7b079bfda67093a39668f6a889ffd26d2a2"
@@ -9006,16 +9001,6 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
-uuid@^8.1.0, uuid@^8.2.0, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
The native `crypto` `randomUUID` module was introduced in Node.js 14.17.0. The `engines` field in each package has been updated to reflect the new Node.js version requirement. This is technically a breaking change. Additional changes are necessary before we can update the `engines` field to support new versions of Node.js.