### PR TITLE
introduce disable typescript flag in cli

### DIFF
--- a/packages/integration-sdk-cli/src/config.ts
+++ b/packages/integration-sdk-cli/src/config.ts
@@ -17,13 +17,21 @@ export class IntegrationInvocationConfigLoadError extends IntegrationError {
   }
 }
 
+export interface LoadConfigOptions {
+  disableTypescript?: boolean;
+}
+
 /**
  * Loads integration invocation configuration.
  */
 export async function loadConfig(
   projectSourceDirectory: string = path.join(process.cwd(), 'src'),
+  opts?: LoadConfigOptions,
 ): Promise<IntegrationInvocationConfig> {
-  if (await isTypescriptPresent(projectSourceDirectory)) {
+  if (
+    opts?.disableTypescript !== true &&
+    (await isTypescriptPresent(projectSourceDirectory))
+  ) {
     log.debug('TypeScript files detected. Registering ts-node.');
     registerTypescript();
   }


### PR DESCRIPTION
# Description

Sometimes I'm running commands against the js buid, which includes typescript defintion files, but not actual typescript.

It's annoying to wait 3 seconds to register typescript for nothing. I'm specifically looking for this command to have the flag, but if we like this approach I'll do them all.
