### PR TITLE
[NO-TICKET] - Converting schema validation errors to warnings

### DIFF
--- a/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
+++ b/packages/integration-sdk-core/src/data/__tests__/createIntegrationEntity.test.ts
@@ -329,7 +329,8 @@ describe('schema validation on', () => {
     delete process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION;
   });
 
-  test('throws if an a required property is not set', () => {
+  test('warns if an a required property is not set', () => {
+    const consoleSpy = jest.spyOn(console, 'warn');
     expect(() =>
       createIntegrationEntity({
         entityData: {
@@ -340,7 +341,8 @@ describe('schema validation on', () => {
           },
         },
       }),
-    ).toThrow(/required property 'name'/);
+    ).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalled();
   });
 });
 
@@ -349,7 +351,8 @@ describe('schema validation off', () => {
     delete process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION;
   });
 
-  test('does not throw if class is not in data model', () => {
+  test('does not warn if class is not in data model', () => {
+    const consoleSpy = jest.spyOn(console, 'warn');
     expect(() =>
       createIntegrationEntity({
         entityData: {
@@ -361,5 +364,6 @@ describe('schema validation off', () => {
         },
       }),
     ).not.toThrow();
+    expect(consoleSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
@@ -103,7 +103,11 @@ export function createIntegrationEntity(
   validateRawData(generatedEntity);
 
   if (process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION) {
-    validateEntityWithSchema(generatedEntity);
+    try {
+      validateEntityWithSchema(generatedEntity);
+    } catch (err) {
+      console.warn(err);
+    }
   }
 
   return generatedEntity;

--- a/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
@@ -106,6 +106,7 @@ export function createIntegrationEntity(
     try {
       validateEntityWithSchema(generatedEntity);
     } catch (err) {
+      /* eslint-disable no-console */
       console.warn(err);
     }
   }


### PR DESCRIPTION
It's been a persistent issue that schema validation checks can be more of a hindrance than a help in integration development.  The information is valuable in helping maintain compliance with the data model, but it sometimes forces developers into the unpleasant decision between forcing in hardcoded values or using the `--disable-schema-validation` flag in instances where some required data simply isn't available.