### PR TITLE
Add suppport for string[] environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Added support for `string[]` environment variables. Example:
+
+`.env` file:
+
+```
+// .env
+SEVERITIES='HIGH,CRITICAL'
+```
+
+Code: 
+```ts
+import { Client } from './client';
+import { createVulnEntity } from './converter';
+
+type IntegrationConfig = { apiKey: string, severities: string[] };
+const invocationConfig: IntegrationInvocationConfig = {
+  instanceConfigFields: [{
+    apiKey: { type: 'string', mask: true },
+    severities: { type: 'string[]' },
+  }],
+  integrationSteps: [{
+    id: 'fetch-vulnerabilities',
+    name: 'Fetch Vulnerabilities',
+    entities: [{ resourceName: 'Vuln', _type: 'vuln', _class: 'Finding' }],
+    relationships: [],
+    executionHandler: ({ instance }) => {
+      const { apiKey, severities } = instance.config;
+      const client = new Client({ apiKey });
+
+      await iterateVulnerabilitiesForSeverity(
+        { severities },
+        async (vuln) => {
+          await jobState.addEntity(createVulnEntity(vuln));
+        }
+      )
+    }
+  }]
+}
+```
+
 ## 8.33.1 - 2023-04-03
 
 ### Fixed

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -78,7 +78,7 @@ export interface IntegrationInvocationConfig<
 }
 
 export interface IntegrationInstanceConfigField {
-  type?: 'string' | 'boolean';
+  type?: 'string' | 'string[]' | 'boolean';
   mask?: boolean;
   optional?: boolean;
 }

--- a/packages/integration-sdk-runtime/src/execution/__tests__/config.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/config.test.ts
@@ -13,24 +13,29 @@ jest.mock('fs');
 beforeEach(() => {
   process.env.STRING_VARIABLE = 'string';
   process.env.BOOLEAN_VARIABLE = 'true';
+  process.env.STRING_ARRAY_VARIABLE = ' string1, string2 ';
 });
 
 afterEach(() => {
   delete process.env.STRING_VARIABLE;
   delete process.env.BOOLEAN_VARIABLE;
+  delete process.env.STRING_ARRAY_VARIABLE;
 
   vol.reset();
 });
 
 test('loads config fields from environment variables', () => {
   const instanceConfigFields: IntegrationInstanceConfigFieldMap<
-    Record<'stringVariable' | 'booleanVariable', IntegrationInstanceConfigField>
+    Record<'stringVariable' | 'booleanVariable' | 'stringArrayVariable', IntegrationInstanceConfigField>
   > = {
     stringVariable: {
       type: 'string',
     },
     booleanVariable: {
       type: 'boolean',
+    },
+    stringArrayVariable: {
+      type: 'string[]',
     },
   };
 
@@ -39,6 +44,7 @@ test('loads config fields from environment variables', () => {
   expect(config).toEqual({
     stringVariable: 'string',
     booleanVariable: true,
+    stringArrayVariable: ['string1', 'string2'],
   });
 });
 

--- a/packages/integration-sdk-runtime/src/execution/config.ts
+++ b/packages/integration-sdk-runtime/src/execution/config.ts
@@ -21,7 +21,7 @@ export function loadConfigFromEnvironmentVariables<
   dotenvExpand(dotenv.config());
 
   return Object.entries(configMap)
-    .map(([field, config]): [string, string | boolean | undefined] => {
+    .map(([field, config]): [string, string | string[] | boolean | undefined] => {
       const environmentVariableName = snakeCase(field).toUpperCase();
 
       const environmentVariableValue = process.env[environmentVariableName];
@@ -41,7 +41,7 @@ export function loadConfigFromEnvironmentVariables<
 
       return [field, convertedValue];
     })
-    .reduce((acc: Record<string, string | boolean>, [field, value]) => {
+    .reduce((acc: Record<string, string | string[] | boolean>, [field, value]) => {
       if (value !== undefined) {
         acc[field] = value;
       }
@@ -53,8 +53,8 @@ function convertEnvironmentVariableValueForField(
   field: string,
   fieldConfig: IntegrationInstanceConfigField,
   environmentVariableValue: string,
-): string | boolean {
-  let convertedValue: string | boolean;
+): string | string[] | boolean {
+  let convertedValue: string | string[] | boolean;
 
   switch (fieldConfig.type) {
     case 'boolean': {
@@ -68,6 +68,13 @@ function convertEnvironmentVariableValueForField(
           `Expected boolean value for field "${field}" but received "${environmentVariableValue}".`,
         );
       }
+      break;
+    }
+    case 'string[]': {
+      convertedValue = environmentVariableValue
+        ?.split(',')
+        .map((v) => v.trim())
+        .filter((v) => v.length > 0) || []
       break;
     }
     case 'string':


### PR DESCRIPTION
### Added

- Added support for `string[]` environment variables. Example:

`.env` file:

```
// .env
SEVERITIES='HIGH,CRITICAL'
```

Code: 
```ts
import { Client } from './client';
import { createVulnEntity } from './converter';

type IntegrationConfig = { apiKey: string, severities: string[] };
const invocationConfig: IntegrationInvocationConfig = {
  instanceConfigFields: [{
    apiKey: { type: 'string', mask: true },
    severities: { type: 'string[]' },
  }],
  integrationSteps: [{
    id: 'fetch-vulnerabilities',
    name: 'Fetch Vulnerabilities',
    entities: [{ resourceName: 'Vuln', _type: 'vuln', _class: 'Finding' }],
    relationships: [],
    executionHandler: ({ instance }) => {
      const { apiKey, severities } = instance.config;
      const client = new Client({ apiKey });

      await iterateVulnerabilitiesForSeverity(
        { severities },
        async (vuln) => {
          await jobState.addEntity(createVulnEntity(vuln));
        }
      )
    }
  }]
}
```