### PR TITLE
INT-7803 Fallback to syncJob.integrationJobId in logger if needed

### DIFF
--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -180,6 +180,8 @@ export async function initiateSynchronization(
     job,
     logger: logger.child({
       ...jobConfiguration,
+      integrationJobId:
+        jobConfiguration.integrationJobId ?? job.integrationJobId,
       synchronizationJobId: job.id,
     }),
     uploadBatchSize,


### PR DESCRIPTION
When we create and return the synchronizationContext during initialization, in the logger, set the integrationJobId to the syncJob's integrationJobId if a job id was not passed in in the jobConfiguration.