### PR TITLE
INT-7562 - add steps using the ingestion source id to childIngestionSources

### DIFF
--- a/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.test.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.test.ts
@@ -26,7 +26,7 @@ describe('#generateIngestionSourcesConfig', () => {
     },
   };
 
-  it('should return the ingestionConfig with empty childIngestionSources', () => {
+  it('should return the ingestionConfig with steps using the ingestion source id in the childIngestionSources.', () => {
     const integrationSteps: IntegrationStep<IntegrationInstanceConfig>[] = [
       {
         id: 'fetch-vulnerability-alerts',
@@ -55,7 +55,7 @@ describe('#generateIngestionSourcesConfig', () => {
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS]
         .childIngestionSources,
-    ).toBeEmpty();
+    ).toEqual(['fetch-vulnerability-alerts']);
     // ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS] is undefined because there are no steps using that ingestionSourceId
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS],
@@ -131,15 +131,27 @@ describe('#generateIngestionSourcesConfig', () => {
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS],
     ).toMatchObject(ingestionConfig[INGESTION_SOURCE_IDS.FETCH_REPOS]);
-    // New property added
+    // New property added with the right child ingestion sources
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS]
         .childIngestionSources,
-    ).toEqual(['fetch-vulnerability-alerts', 'fetch-issues']);
-    // For FINDING_ALERTS the ingestionConfig keep exactly the same
+    ).toEqual(
+      expect.arrayContaining([
+        'fetch-repos',
+        'fetch-vulnerability-alerts',
+        'fetch-issues',
+      ]),
+    );
+    // For FINDING_ALERTS:
+    // Original object doesn't change
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS],
     ).toMatchObject(ingestionConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS]);
+    // New property added with only 'fetch-vulnerability-alerts' added as child ingestion source
+    expect(
+      ingestionSourcesConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS]
+        .childIngestionSources,
+    ).toEqual(['fetch-vulnerability-alerts']);
   });
 
   it('should not add the source if it does not exist in the ingestionConfig', () => {

--- a/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.ts
@@ -92,13 +92,18 @@ export function generateIngestionSourcesConfig<
         return;
       }
       // Get the stepIds that have any dependencies on the matched step ids
-      const childIngestionSources = integrationSteps
+      const dependentSteps = integrationSteps
         .filter((step) =>
           step.dependsOn?.some((value) =>
             matchedIntegrationStepIds.includes(value),
           ),
         )
         .map(({ id }) => id);
+
+      const childIngestionSources = Array.from(
+        new Set([...dependentSteps, ...matchedIntegrationStepIds]),
+      );
+
       // Generate ingestionConfig with the childIngestionSources
       newIngestionConfig[key] = {
         ...ingestionConfig[key],


### PR DESCRIPTION
## Summary
Before this PR, I was only adding the child sources to the array `childIngestionSources`, that means, I was not adding the steps that actually points to the ingestionSourceId in that array. With the previous implementation, there was no way to identify those steps in the UI. e.g.

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/10051456/235198437-53e6ddf2-f7f1-4fde-abf7-fe0e9607c5e9.png">

Based on that image we were not able to obtain the `AWS Backup service` but `AWS Backup vault`. This PR adds the changes to obtain both in the command `generate-ingestion-sources-config`: 
1. The steps pointing to the `ingestionSourceId` 
2. The child steps or steps that depends on it.