### PR TITLE
Revert "INT-7562 - add steps using the ingestion source id to childIngestionSources"

### DIFF
--- a/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.test.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.test.ts
@@ -26,7 +26,7 @@ describe('#generateIngestionSourcesConfig', () => {
     },
   };
 
-  it('should return the ingestionConfig with steps using the ingestion source id in the childIngestionSources.', () => {
+  it('should return the ingestionConfig with empty childIngestionSources', () => {
     const integrationSteps: IntegrationStep<IntegrationInstanceConfig>[] = [
       {
         id: 'fetch-vulnerability-alerts',
@@ -55,7 +55,7 @@ describe('#generateIngestionSourcesConfig', () => {
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS]
         .childIngestionSources,
-    ).toEqual(['fetch-vulnerability-alerts']);
+    ).toBeEmpty();
     // ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS] is undefined because there are no steps using that ingestionSourceId
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS],
@@ -131,27 +131,15 @@ describe('#generateIngestionSourcesConfig', () => {
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS],
     ).toMatchObject(ingestionConfig[INGESTION_SOURCE_IDS.FETCH_REPOS]);
-    // New property added with the right child ingestion sources
+    // New property added
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS]
         .childIngestionSources,
-    ).toEqual(
-      expect.arrayContaining([
-        'fetch-repos',
-        'fetch-vulnerability-alerts',
-        'fetch-issues',
-      ]),
-    );
-    // For FINDING_ALERTS:
-    // Original object doesn't change
+    ).toEqual(['fetch-vulnerability-alerts', 'fetch-issues']);
+    // For FINDING_ALERTS the ingestionConfig keep exactly the same
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS],
     ).toMatchObject(ingestionConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS]);
-    // New property added with only 'fetch-vulnerability-alerts' added as child ingestion source
-    expect(
-      ingestionSourcesConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS]
-        .childIngestionSources,
-    ).toEqual(['fetch-vulnerability-alerts']);
   });
 
   it('should not add the source if it does not exist in the ingestionConfig', () => {

--- a/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.ts
@@ -92,18 +92,13 @@ export function generateIngestionSourcesConfig<
         return;
       }
       // Get the stepIds that have any dependencies on the matched step ids
-      const dependentSteps = integrationSteps
+      const childIngestionSources = integrationSteps
         .filter((step) =>
           step.dependsOn?.some((value) =>
             matchedIntegrationStepIds.includes(value),
           ),
         )
         .map(({ id }) => id);
-
-      const childIngestionSources = Array.from(
-        new Set([...dependentSteps, ...matchedIntegrationStepIds]),
-      );
-
       // Generate ingestionConfig with the childIngestionSources
       newIngestionConfig[key] = {
         ...ingestionConfig[key],


### PR DESCRIPTION
Reverts JupiterOne/sdk#886

I'm reverting this PR because we don't need the steps pointing to the `ingestionSourceId` in the `childIngestionSources`, we just want the children steps or steps that depends on the disabled steps.