### PR TITLE
Allow duplicated relationship types on steps

### DIFF
--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -707,7 +707,7 @@ export function toMatchStepMetadata(
   } = filterGraphObjects(results.collectedRelationships, isMappedRelationship);
 
   let restDirectRelationships = collectedDirectRelationships;
-  const alreadyValidatedTypes = [];
+  const alreadyValidatedTypes: string[] = [];
   for (const relationshipMetadata of step.relationships) {
     if (alreadyValidatedTypes.includes(relationshipMetadata._type)) continue;
     alreadyValidatedTypes.push(relationshipMetadata._type);

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -709,7 +709,7 @@ export function toMatchStepMetadata(
   let restDirectRelationships = collectedDirectRelationships;
   const alreadyValidatedTypes = [];
   for (const relationshipMetadata of step.relationships) {
-    if (alreadyValidatedTypes.includes(relationshipMetadata._type) continue;
+    if (alreadyValidatedTypes.includes(relationshipMetadata._type)) continue;
     alreadyValidatedTypes.push(relationshipMetadata._type);
     const { targets, rest } = filterGraphObjects(
       restDirectRelationships,

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -707,7 +707,10 @@ export function toMatchStepMetadata(
   } = filterGraphObjects(results.collectedRelationships, isMappedRelationship);
 
   let restDirectRelationships = collectedDirectRelationships;
+  const alreadyValidatedTypes = [];
   for (const relationshipMetadata of step.relationships) {
+    if (alreadyValidatedTypes.includes(relationshipMetadata._type) continue;
+    alreadyValidatedTypes.push(relationshipMetadata._type);
     const { targets, rest } = filterGraphObjects(
       restDirectRelationships,
       (r) => r._type === relationshipMetadata._type,


### PR DESCRIPTION
In graph-aws and other projects maybe we have a step that creates relationships with the same type:
```ts
  buildWafWebAclResourceRelationships: {
    id: Wafv2Steps.BUILD_WAFV2_WEB_ACL_RESOURCE_RELATIONSHIPS.id,
    name: Wafv2Steps.BUILD_WAFV2_WEB_ACL_RESOURCE_RELATIONSHIPS.name,
    entities: [],
    relationships: [
      Wafv2Relationships.AWS_WAFV2_WEB_ACL_PROTECTS_CLOUDFRONT_DISTRIBUTION,
      Wafv2Relationships.AWS_WAFV2_WEB_ACL_PROTECTS_APPLICATION_LOAD_BALANCER,
    ],
    dependsOn: [
      Wafv2Steps.FETCH_WAFV2_WEB_ACLS.id,
      ElbSteps.FETCH_ELB_LOAD_BALANCERS.id,
      CloudfrontSteps.FETCH_CLOUDFRONT_DISTRIBUTIONS.id,
    ],
    executionHandler: buildWafv2WebAclResourceRelationships,
    permissions: ['wafv2:ListResourcesForWebACL'],
  },
  ```
  
  ```ts
    AWS_WAFV2_WEB_ACL_PROTECTS_CLOUDFRONT_DISTRIBUTION: {
    _type: 'aws_waf_v2_protects_resource',
    sourceType: 'aws_waf_v2_web_acl',
    _class: RelationshipClass.PROTECTS,
    targetType: CloudfrontEntities.AWS_CLOUDFRONT_DISTRIBUTION._type,
  },
  AWS_WAFV2_WEB_ACL_PROTECTS_APPLICATION_LOAD_BALANCER: {
    _type: 'aws_waf_v2_protects_resource',
    sourceType: 'aws_waf_v2_web_acl',
    _class: RelationshipClass.PROTECTS,
    targetType: ElbEntities.ELB_APPLICATION_LOAD_BALANCER._type,
  },
  ```
  
When we use `toMatchStepMetadata` it fails because `aws_waf_v2_protects_resource` was already processed, but the relationship is there. I know that for more control it should be manually handled by the test it self and validate that the targetEntity _type is the one as expected.

We kinda do it somehow here: https://github.com/jupiterone/graph-aws/blob/59558e1e27f654984101b42e33e994aac551b4ad/src/utils/test.ts#L10


