### PR TITLE
[INT-8424] - modify generateIngestionSourcesConfigCommand to include child steps metadata in the childIngestionSources property 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to
 
 ### Updated
 
-- modify `generateIngestionSourcesConfigCommand` to include child steps metadata in the `childIngestionSources` property
+- modify `generateIngestionSourcesConfigCommand` to include child steps metadata
+  in the `childIngestionSources` property
 
 ## 9.4.1 - 2023-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to
 
 ## Unreleased
 
+## 9.5.0 - 2023-06-19
+
+### Updated
+
+- modify `generateIngestionSourcesConfigCommand` to include child steps metadata in the `childIngestionSources` property
+
 ## 9.4.1 - 2023-06-07
 
 ### Updated

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/cli"
   ],
   "useWorkspaces": true,
-  "version": "9.4.1"
+  "version": "9.5.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.4.1",
-    "@jupiterone/integration-sdk-runtime": "^9.4.1",
+    "@jupiterone/integration-sdk-core": "^9.5.0",
+    "@jupiterone/integration-sdk-runtime": "^9.5.0",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do yarn prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.4.1",
-    "@jupiterone/integration-sdk-runtime": "^9.4.1",
+    "@jupiterone/integration-sdk-core": "^9.5.0",
+    "@jupiterone/integration-sdk-runtime": "^9.5.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-runtime": "^9.4.1",
+    "@jupiterone/integration-sdk-runtime": "^9.5.0",
     "chalk": "^4",
     "commander": "^9.4.0",
     "fs-extra": "^10.1.0",
@@ -38,7 +38,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.4.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.5.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.test.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.test.ts
@@ -63,6 +63,33 @@ describe('#generateIngestionSourcesConfig', () => {
   });
 
   it('should return the ingestionConfig with childIngestionSources', () => {
+    const stepFetchVulnerabilityAlerts = {
+      id: 'fetch-vulnerability-alerts',
+      name: 'Fetch Vulnerability Alerts',
+      entities: [
+        {
+          resourceName: 'GitHub Vulnerability Alerts',
+          _type: 'github_finding',
+          _class: ['Finding'],
+        },
+      ],
+      relationships: [],
+      dependsOn: ['fetch-repos'],
+      ingestionSourceId: INGESTION_SOURCE_IDS.FINDING_ALERTS,
+    };
+    const stepFetchIssues = {
+      id: 'fetch-issues',
+      name: 'Fetch Issues',
+      entities: [
+        {
+          resourceName: 'GitHub Issue',
+          _type: 'github_issue',
+          _class: ['Issue'],
+        },
+      ],
+      relationships: [],
+      dependsOn: ['fetch-repos', 'fetch-users', 'fetch-collaborators'],
+    };
     const integrationSteps: IntegrationStep<IntegrationInstanceConfig>[] = [
       {
         id: 'fetch-repos',
@@ -80,32 +107,11 @@ describe('#generateIngestionSourcesConfig', () => {
         executionHandler: jest.fn(),
       },
       {
-        id: 'fetch-vulnerability-alerts',
-        name: 'Fetch Vulnerability Alerts',
-        entities: [
-          {
-            resourceName: 'GitHub Vulnerability Alerts',
-            _type: 'github_finding',
-            _class: ['Finding'],
-          },
-        ],
-        relationships: [],
-        dependsOn: ['fetch-repos'],
-        ingestionSourceId: INGESTION_SOURCE_IDS.FINDING_ALERTS,
+        ...stepFetchVulnerabilityAlerts,
         executionHandler: jest.fn(),
       },
       {
-        id: 'fetch-issues',
-        name: 'Fetch Issues',
-        entities: [
-          {
-            resourceName: 'GitHub Issue',
-            _type: 'github_issue',
-            _class: ['Issue'],
-          },
-        ],
-        relationships: [],
-        dependsOn: ['fetch-repos', 'fetch-users', 'fetch-collaborators'],
+        ...stepFetchIssues,
         executionHandler: jest.fn(),
       },
       {
@@ -135,7 +141,9 @@ describe('#generateIngestionSourcesConfig', () => {
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FETCH_REPOS]
         .childIngestionSources,
-    ).toEqual(['fetch-vulnerability-alerts', 'fetch-issues']);
+    ).toEqual(
+      expect.arrayContaining([stepFetchVulnerabilityAlerts, stepFetchIssues]),
+    );
     // For FINDING_ALERTS the ingestionConfig keep exactly the same
     expect(
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.FINDING_ALERTS],

--- a/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.ts
@@ -4,6 +4,7 @@ import {
   IntegrationSourceId,
   Step,
   StepExecutionContext,
+  StepMetadata,
 } from '@jupiterone/integration-sdk-core';
 import { createCommand } from 'commander';
 import { loadConfigFromTarget } from '../config';
@@ -59,7 +60,7 @@ export function generateIngestionSourcesConfigCommand() {
 
 export type EnhancedIntegrationIngestionConfigFieldMap = Record<
   IntegrationSourceId,
-  IntegrationIngestionConfigField & { childIngestionSources?: string[] }
+  IntegrationIngestionConfigField & { childIngestionSources?: StepMetadata[] }
 >;
 
 /**
@@ -91,18 +92,19 @@ export function generateIngestionSourcesConfig<
         // Skip iteration if there are no steps pointing to the current ingestionSourceId
         return;
       }
-      // Get the stepIds that have any dependencies on the matched step ids
-      const childIngestionSources = integrationSteps
-        .filter((step) =>
-          step.dependsOn?.some((value) =>
-            matchedIntegrationStepIds.includes(value),
-          ),
-        )
-        .map(({ id }) => id);
+      // Get the dependent steps for the given matchedIntegrationStepIds
+      const childIngestionSources = integrationSteps.filter((step) =>
+        step.dependsOn?.some((value) =>
+          matchedIntegrationStepIds.includes(value),
+        ),
+      );
       // Generate ingestionConfig with the childIngestionSources
       newIngestionConfig[key] = {
         ...ingestionConfig[key],
-        childIngestionSources,
+        // Drop execution handler from returned object
+        childIngestionSources: childIngestionSources.map(
+          ({ executionHandler, ...keepAttrs }) => keepAttrs,
+        ),
       };
     } else {
       log.warn(`The key ${key} does not exist in the ingestionConfig`);

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^9.4.1",
-    "@jupiterone/integration-sdk-testing": "^9.4.1",
+    "@jupiterone/integration-sdk-cli": "^9.5.0",
+    "@jupiterone/integration-sdk-testing": "^9.5.0",
     "@types/jest": "^27.1.0",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.29.3",

--- a/packages/integration-sdk-entities/package.json
+++ b/packages/integration-sdk-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-entities",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "Generated types for the JupiterOne data-model",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -26,8 +26,8 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^9.4.1",
-    "@jupiterone/integration-sdk-private-test-utils": "^9.4.1",
+    "@jupiterone/integration-sdk-dev-tools": "^9.5.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.5.0",
     "fetch-mock-jest": "^1.5.1"
   },
   "bugs": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.4.1",
+    "@jupiterone/integration-sdk-core": "^9.5.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.4.1",
+    "@jupiterone/integration-sdk-core": "^9.5.0",
     "@lifeomic/alpha": "^5.1.1",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.4.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.5.0",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",
     "ts-node": "^9.1.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.4.1",
-    "@jupiterone/integration-sdk-runtime": "^9.4.1",
+    "@jupiterone/integration-sdk-core": "^9.5.0",
+    "@jupiterone/integration-sdk-runtime": "^9.5.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.4.1",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.5.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
## Summary
Before this PR, the `generateIngestionSourcesConfigCommand` function only returned the stepIds in the `childIngestionSources` property. This implementation was fine, but now we want to show additional data related to the `childIngestionSources` on the frontend. To meet this requirement, I have modified the function to also return the `StepMetadata` (excluding the `executionHandler`).