### PR TITLE
Release 9.8.0 - add new log entry for each disabled child step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## Unreleased
 
+## 9.7.0 - 2023-07-04
+
+Add log for skipped steps for each disabled child step.
+
 ## 9.6.2 - 2023-06-30
 
 Adds logging when an integration fails to initialize or finalize a

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/cli"
   ],
   "useWorkspaces": true,
-  "version": "9.7.0"
+  "version": "9.8.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/cli"
   ],
   "useWorkspaces": true,
-  "version": "9.6.2"
+  "version": "9.7.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.7.0",
-    "@jupiterone/integration-sdk-runtime": "^9.7.0",
+    "@jupiterone/integration-sdk-core": "^9.8.0",
+    "@jupiterone/integration-sdk-runtime": "^9.8.0",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.6.2",
-    "@jupiterone/integration-sdk-runtime": "^9.6.2",
+    "@jupiterone/integration-sdk-core": "^9.7.0",
+    "@jupiterone/integration-sdk-runtime": "^9.7.0",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do yarn prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.7.0",
-    "@jupiterone/integration-sdk-runtime": "^9.7.0",
+    "@jupiterone/integration-sdk-core": "^9.8.0",
+    "@jupiterone/integration-sdk-runtime": "^9.8.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do yarn prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.6.2",
-    "@jupiterone/integration-sdk-runtime": "^9.6.2",
+    "@jupiterone/integration-sdk-core": "^9.7.0",
+    "@jupiterone/integration-sdk-runtime": "^9.7.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.54.0",
-    "@jupiterone/integration-sdk-core": "^9.6.2",
-    "@jupiterone/integration-sdk-runtime": "^9.6.2",
+    "@jupiterone/integration-sdk-core": "^9.7.0",
+    "@jupiterone/integration-sdk-runtime": "^9.7.0",
     "chalk": "^4",
     "commander": "^9.4.0",
     "fs-extra": "^10.1.0",
@@ -44,7 +44,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.6.2",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.7.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.54.0",
-    "@jupiterone/integration-sdk-core": "^9.7.0",
-    "@jupiterone/integration-sdk-runtime": "^9.7.0",
+    "@jupiterone/integration-sdk-core": "^9.8.0",
+    "@jupiterone/integration-sdk-runtime": "^9.8.0",
     "chalk": "^4",
     "commander": "^9.4.0",
     "fs-extra": "^10.1.0",
@@ -44,7 +44,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.7.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.8.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-core/src/types/logger.ts
+++ b/packages/integration-sdk-core/src/types/logger.ts
@@ -10,10 +10,15 @@ interface ChildLogFunction {
   (options: object): IntegrationLogger;
 }
 
+export interface StepLogAdditionalContext {
+  parentStep?: StepMetadata;
+}
+
 type StepLogFunction = (step: StepMetadata) => void;
 type StepLogFunctionWithReason = (
   step: StepMetadata,
   reason: DisabledStepReason,
+  additionalContext?: StepLogAdditionalContext,
 ) => void;
 type StepLogFunctionWithError = (step: StepMetadata, err: Error) => void;
 type SynchronizationLogFunction = (job: SynchronizationJob) => void;

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -18,6 +18,7 @@ export enum DisabledStepReason {
   CONFIG = 'config', // Step was disabled via config that is controlled by J1
   USER_CONFIG = 'user_config', // Step was disabled via config that is controlled by the user
   API_VERSION = 'api_version', // Step is disabled due to lack of support in an API version
+  PARENT_DISABLED = 'parent_disabled', // Step is disabled because its parent is also disabled
 }
 
 export interface StepStartState {

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^9.6.2",
-    "@jupiterone/integration-sdk-testing": "^9.6.2",
+    "@jupiterone/integration-sdk-cli": "^9.7.0",
+    "@jupiterone/integration-sdk-testing": "^9.7.0",
     "@types/jest": "^27.1.0",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.29.3",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^9.7.0",
-    "@jupiterone/integration-sdk-testing": "^9.7.0",
+    "@jupiterone/integration-sdk-cli": "^9.8.0",
+    "@jupiterone/integration-sdk-testing": "^9.8.0",
     "@types/jest": "^27.1.0",
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^4.29.3",

--- a/packages/integration-sdk-entities/package.json
+++ b/packages/integration-sdk-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-entities",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "Generated types for the JupiterOne data-model",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -26,8 +26,8 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^9.7.0",
-    "@jupiterone/integration-sdk-private-test-utils": "^9.7.0",
+    "@jupiterone/integration-sdk-dev-tools": "^9.8.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.8.0",
     "fetch-mock-jest": "^1.5.1"
   },
   "bugs": {

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -26,8 +26,8 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^9.6.2",
-    "@jupiterone/integration-sdk-private-test-utils": "^9.6.2",
+    "@jupiterone/integration-sdk-dev-tools": "^9.7.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.7.0",
     "fetch-mock-jest": "^1.5.1"
   },
   "bugs": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.6.2",
+    "@jupiterone/integration-sdk-core": "^9.7.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.7.0",
+    "@jupiterone/integration-sdk-core": "^9.8.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.6.2",
+    "@jupiterone/integration-sdk-core": "^9.7.0",
     "@lifeomic/alpha": "^5.1.1",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.6.2",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.7.0",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",
     "ts-node": "^9.1.0",

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.7.0",
+    "@jupiterone/integration-sdk-core": "^9.8.0",
     "@lifeomic/alpha": "^5.1.1",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.7.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.8.0",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",
     "ts-node": "^9.1.0",

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -5,6 +5,7 @@ import { randomUUID as uuid } from 'crypto';
 import waitForExpect from 'wait-for-expect';
 
 import {
+  DisabledStepReason,
   Entity,
   GraphObjectStore,
   IntegrationError,
@@ -1303,5 +1304,154 @@ describe('executeStepDependencyGraph', () => {
     expect(spyA).toHaveBeenCalledBefore(spyC);
     expect(spyC).toHaveBeenCalledBefore(spyD);
     expect(spyE).toHaveBeenCalledBefore(spyD);
+  });
+
+  test('should log parent and child skipped steps', async () => {
+    // Arrange
+    const stepSkipSpy = jest.spyOn(executionContext.logger, 'stepSkip');
+    jest
+      .spyOn(executionContext.logger, 'child')
+      .mockReturnValue(executionContext.logger);
+
+    const spyA = jest.fn();
+    const spyB = jest.fn();
+    const spyC = jest.fn();
+    const spyD = jest.fn();
+    const spyE = jest.fn();
+
+    const parentStep = {
+      id: 'b',
+      name: 'b',
+      entities: [],
+      relationships: [],
+      executionHandler: spyB,
+    };
+
+    const childStep = {
+      id: 'd',
+      name: 'd',
+      entities: [],
+      relationships: [],
+      dependsOn: ['b', 'c', 'e'],
+      executionHandler: spyD,
+    };
+
+    /**
+     *     e
+     *       \
+     * a - c - d
+     *       /
+     *     b
+     *
+     * In this situation, 'a', 'e', and 'b' are leaf nodes
+     * 'c' depends on 'a',
+     * 'd' depends on 'e', 'c', and 'b'
+     */
+    const steps: IntegrationStep[] = [
+      {
+        id: 'a',
+        name: 'a',
+        entities: [],
+        relationships: [],
+        executionHandler: spyA,
+      },
+      parentStep,
+      {
+        id: 'c',
+        name: 'c',
+        entities: [],
+        relationships: [],
+        dependsOn: ['a'],
+        executionHandler: spyC,
+      },
+      childStep,
+      {
+        id: 'e',
+        name: 'e',
+        entities: [],
+        relationships: [],
+        executionHandler: spyE,
+      },
+    ];
+
+    const stepStartStates = getDefaultStepStartStates(steps);
+    stepStartStates['b'] = {
+      disabled: true,
+      disabledReason: DisabledStepReason.CONFIG,
+    };
+
+    // Act
+    const results = await executeSteps(steps, stepStartStates);
+
+    // Assert
+    expect(results).toEqual(
+      expect.arrayContaining([
+        {
+          id: 'a',
+          name: 'a',
+          declaredTypes: [],
+          partialTypes: [],
+          encounteredTypes: [],
+          status: StepResultStatus.SUCCESS,
+        },
+        {
+          id: 'b',
+          name: 'b',
+          declaredTypes: [],
+          partialTypes: [],
+          encounteredTypes: [],
+          status: StepResultStatus.DISABLED,
+        },
+        {
+          id: 'c',
+          name: 'c',
+          declaredTypes: [],
+          partialTypes: [],
+          encounteredTypes: [],
+          dependsOn: ['a'],
+          status: StepResultStatus.SUCCESS,
+        },
+        {
+          id: 'd',
+          name: 'd',
+          declaredTypes: [],
+          partialTypes: [],
+          encounteredTypes: [],
+          dependsOn: ['b', 'c', 'e'],
+          status: StepResultStatus.DISABLED,
+        },
+        {
+          id: 'e',
+          name: 'e',
+          declaredTypes: [],
+          partialTypes: [],
+          encounteredTypes: [],
+          status: StepResultStatus.SUCCESS,
+        },
+      ]),
+    );
+
+    expect(spyA).toHaveBeenCalledTimes(1);
+    expect(spyC).toHaveBeenCalledTimes(1);
+    expect(spyE).toHaveBeenCalledTimes(1);
+
+    expect(spyB).toHaveBeenCalledTimes(0);
+    expect(spyD).toHaveBeenCalledTimes(0);
+
+    expect(spyA).toHaveBeenCalledBefore(spyC);
+    expect(spyC).toHaveBeenCalledBefore(spyD);
+    expect(spyE).toHaveBeenCalledBefore(spyD);
+
+    // Assert skipStep being called for parent and child steps
+    expect(stepSkipSpy).toHaveBeenCalledTimes(2);
+    // Child step "d" is just skipped once even though it depends on more steps
+    // As "b" is processed first, the "stepSkip" function is invoked for "d" with "b" acting as its parent.
+    // However, for the remaining steps, even though "d" is a child, it has already been logged.
+    expect(stepSkipSpy.mock.calls).toEqual([
+      // Parent step call
+      [parentStep, DisabledStepReason.CONFIG],
+      // Child step call
+      [childStep, DisabledStepReason.PARENT_DISABLED, { parentStep }],
+    ]);
   });
 });

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -273,6 +273,7 @@ export function executeStepDependencyGraph<
           } else {
             // Step is disabled
             if (!skippedStepTracker.has(stepId)) {
+              console.log('log parentStep ', stepId);
               executionContext.logger
                 .child({ stepId })
                 .stepSkip(
@@ -281,6 +282,24 @@ export function executeStepDependencyGraph<
                     DisabledStepReason.NONE,
                 );
               skippedStepTracker.add(stepId);
+              // Log child steps disabled
+              const stepDependencies = inputGraph.dependantsOf(stepId);
+              for (const childStepId of stepDependencies) {
+                if (!skippedStepTracker.has(childStepId)) {
+                  const childStep = inputGraph.getNodeData(childStepId);
+                  console.log('log childStep ', childStepId);
+                  console.log(
+                    'log executionContext.logger ',
+                    executionContext.logger,
+                  );
+                  executionContext.logger.stepSkip(
+                    childStep,
+                    DisabledStepReason.PARENT_DISABLED,
+                    { parentStep: step },
+                  );
+                  skippedStepTracker.add(childStepId);
+                }
+              }
             }
           }
         }

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -273,7 +273,6 @@ export function executeStepDependencyGraph<
           } else {
             // Step is disabled
             if (!skippedStepTracker.has(stepId)) {
-              console.log('log parentStep ', stepId);
               executionContext.logger
                 .child({ stepId })
                 .stepSkip(
@@ -287,11 +286,6 @@ export function executeStepDependencyGraph<
               for (const childStepId of stepDependencies) {
                 if (!skippedStepTracker.has(childStepId)) {
                   const childStep = inputGraph.getNodeData(childStepId);
-                  console.log('log childStep ', childStepId);
-                  console.log(
-                    'log executionContext.logger ',
-                    executionContext.logger,
-                  );
                   executionContext.logger.stepSkip(
                     childStep,
                     DisabledStepReason.PARENT_DISABLED,

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -347,11 +347,13 @@ export class IntegrationLogger
         break;
       }
       case DisabledStepReason.PARENT_DISABLED: {
-        if (!additionalContext?.parentStep?.name) {
-          this.validationFailure(new Error('Parent step not provided'));
-          return;
+        const parentStepName = additionalContext?.parentStep?.name;
+        if (!parentStepName) {
+          this.warn(`Parent step not provided for child step ${step.name}`);
         }
-        description += `Step was disabled because parent step "${additionalContext?.parentStep?.name}" was disabled. In order to enable this step, please check logs for more information about the parent step.`;
+        description += parentStepName
+          ? `Step was disabled because parent step "${parentStepName}" was disabled. In order to enable this step, please check logs for more information about the parent step.`
+          : 'Step was disabled because parent step was disabled. In order to enable this step, please check logs for more information about the parent step.';
         break;
       }
     }

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -347,6 +347,10 @@ export class IntegrationLogger
         break;
       }
       case DisabledStepReason.PARENT_DISABLED: {
+        if (!additionalContext?.parentStep?.name) {
+          this.validationFailure(new Error('Parent step not provided'));
+          return;
+        }
         description += `Step was disabled because parent step "${additionalContext?.parentStep?.name}" was disabled. In order to enable this step, please check logs for more information about the parent step.`;
         break;
       }

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -29,6 +29,7 @@ import {
   PublishErrorEventInput,
   DisabledStepReason,
   PublishMetricOptions,
+  StepLogAdditionalContext,
 } from '@jupiterone/integration-sdk-core';
 
 export * from './registerEventHandlers';
@@ -312,7 +313,11 @@ export class IntegrationLogger
     this.publishEvent({ name, description });
   }
 
-  stepSkip(step: StepMetadata, reason: DisabledStepReason) {
+  stepSkip(
+    step: StepMetadata,
+    reason: DisabledStepReason,
+    additionalContext?: StepLogAdditionalContext,
+  ) {
     if (!reason || reason === DisabledStepReason.NONE) {
       return;
     }
@@ -339,6 +344,10 @@ export class IntegrationLogger
       }
       case DisabledStepReason.USER_CONFIG: {
         description += `Step was disabled via configuration. Update instance config to enable.`;
+        break;
+      }
+      case DisabledStepReason.PARENT_DISABLED: {
+        description += `Step was disabled because parent step "${additionalContext?.parentStep?.name}" was disabled. In order to enable this step, please check logs for more information about the parent step.`;
         break;
       }
     }

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "9.6.2",
+  "version": "9.7.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.6.2",
-    "@jupiterone/integration-sdk-runtime": "^9.6.2",
+    "@jupiterone/integration-sdk-core": "^9.7.0",
+    "@jupiterone/integration-sdk-runtime": "^9.7.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.6.2",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.7.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^9.7.0",
-    "@jupiterone/integration-sdk-runtime": "^9.7.0",
+    "@jupiterone/integration-sdk-core": "^9.8.0",
+    "@jupiterone/integration-sdk-runtime": "^9.8.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^9.7.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^9.8.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
## Summary
This PR introduces a new log entry for each disabled child step to indicate that they have been skipped. To achieve this, a new `DisabledReason` has been implemented exclusively for child steps that are disabled. This `DisabledReason` provides a message like this:
```
Skipped step "{childStepName}". Step was disabled because parent step "{parentStepName}" was disabled. In order to enable this step, please check logs for more information about the parent step
```
when a child step is disabled.