### PR TITLE
Introduce `afterExecution` hook to integration invocation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,22 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Introduce `afterExecution` integration execution hook. See
+  [development documentation](./docs/integrations/development.md) for more
+  information.
+
 ## 9.6.2 - 2023-06-30
+
+### Updated
 
 Adds logging when an integration fails to initialize or finalize a
 synchronization job
 
 ## 9.6.0 - 2023-06-30
+
+### Added
 
 Introduces a new feature to `j1-integration` that allows generating a new
 integration using a series of inputs.

--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -22,6 +22,7 @@ that was sent up will be diffed against JupiterOne's understanding of the
       - [`beforeAddEntity(context: IntegrationExecutionContext<IntegrationConfig>, e: Entity): Entity`](#beforeaddentitycontext-integrationexecutioncontextintegrationconfig-e-entity-entity)
       - [`beforeAddRelationship(context: IntegrationExecutionContext<IntegrationConfig>, r: Relationship): Promise<Relationship> | Relationship`](#beforeaddrelationshipcontext-integrationexecutioncontextintegrationconfig-r-relationship-promiserelationship--relationship)
       - [`ingestionConfig`](#ingestionconfig)
+      - [`afterExecution(context: IntegrationExecutionContext<IntegrationConfig>): Promise<void>`](#afterexecutioncontext-integrationexecutioncontextintegrationconfig-promisevoid)
     - [How integrations are executed](#how-integrations-are-executed)
       - [Validation](#validation)
       - [Collection](#collection)
@@ -497,6 +498,29 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
     instanceConfigFields: {},
     integrationSteps,
     ingestionConfig,
+  };
+```
+
+#### `afterExecution(context: IntegrationExecutionContext<IntegrationConfig>): Promise<void>`
+
+`afterExecution` is an optional hook function that can be provided. The function
+is called after an integration has executed, regardless of whether the execution
+was successful or not. An example of when you may decide to use this function is
+when you need to close out a globally configured client in an integration.
+
+Example:
+
+```typescript
+import { IntegrationInvocationConfig } from '@jupiterone/integration-sdk-core';
+import { IntegrationConfig } from './types';
+
+export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
+  {
+    instanceConfigFields: {},
+    integrationSteps: [],
+    async afterExecution(context) {
+      context.logger.info('Integration execution completed...');
+    },
   };
 ```
 

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -46,11 +46,20 @@ export type LoadExecutionConfigFunction<
   TExecutionConfig extends IntegrationExecutionConfig = IntegrationExecutionConfig,
 > = (options: { config: TInstanceConfig }) => TExecutionConfig;
 
+export type AfterExecutionFunction<TExecutionContext extends ExecutionContext> =
+  (context: TExecutionContext) => Promise<void>;
+
 export interface InvocationConfig<
   TExecutionContext extends ExecutionContext,
   TStepExecutionContext extends StepExecutionContext,
 > {
   validateInvocation?: InvocationValidationFunction<TExecutionContext>;
+  /**
+   * Called after an integration execution has completed. You may this this hook
+   * for performing operations such as closing out open clients in an
+   * integration.
+   */
+  afterExecution?: AfterExecutionFunction<TExecutionContext>;
   getStepStartStates?: GetStepStartStatesFunction<TExecutionContext>;
   integrationSteps: Step<TStepExecutionContext>[];
   normalizeGraphObjectKey?: KeyNormalizationFunction;

--- a/packages/integration-sdk-runtime/src/execution/__tests__/executeIntegration.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/executeIntegration.test.ts
@@ -255,6 +255,62 @@ describe('executeIntegrationInstance', () => {
     );
   });
 
+  test('calls "afterExecution" hook when integration execution completes successfully', async () => {
+    const afterExecutionFn = jest.fn().mockResolvedValueOnce(Promise.resolve());
+
+    await executeIntegrationInstanceWithConfig(
+      createInstanceConfiguration({
+        invocationConfig: {
+          integrationSteps: [],
+          afterExecution: afterExecutionFn,
+        },
+      }),
+    );
+
+    const expectedContext: IntegrationExecutionContext = {
+      instance: LOCAL_INTEGRATION_INSTANCE,
+      logger: expect.any(IntegrationLoggerImpl),
+      executionHistory: {
+        current: {
+          startedOn: executionStartedOn,
+        },
+      },
+      executionConfig: {},
+    };
+
+    expect(afterExecutionFn).toHaveBeenCalledTimes(1);
+    expect(afterExecutionFn).toHaveBeenCalledWith(expectedContext);
+  });
+
+  test('does not throw if "afterExecution" hook throws', async () => {
+    const afterExecutionFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('expected error'));
+
+    await executeIntegrationInstanceWithConfig(
+      createInstanceConfiguration({
+        invocationConfig: {
+          integrationSteps: [],
+          afterExecution: afterExecutionFn,
+        },
+      }),
+    );
+
+    const expectedContext: IntegrationExecutionContext = {
+      instance: LOCAL_INTEGRATION_INSTANCE,
+      logger: expect.any(IntegrationLoggerImpl),
+      executionHistory: {
+        current: {
+          startedOn: executionStartedOn,
+        },
+      },
+      executionConfig: {},
+    };
+
+    expect(afterExecutionFn).toHaveBeenCalledTimes(1);
+    expect(afterExecutionFn).toHaveBeenCalledWith(expectedContext);
+  });
+
   test('runs multiple dependency graphs in order and returns integration step results and metadata about partial datasets', async () => {
     const firstStepExecutionHandler = jest.fn();
     const secondStepExecutionHandler = jest.fn();


### PR DESCRIPTION
`afterExecution` is an optional hook function that can be provided. The function is called after an integration has executed, regardless of whether the execution was successful or not. An example of when you may decide to use this function is when you need to close out a globally configured client in an integration.

Example:

```typescript
import { IntegrationInvocationConfig } from '@jupiterone/integration-sdk-core';
import { IntegrationConfig } from './types';

export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
  {
    instanceConfigFields: {},
    integrationSteps: [],
    afterExecution(context) {
      context.logger.info('Integration execution completed...');
    },
  };
```