### PR TITLE
Log raw (unparsed) JSON response from UPLOAD_ERROR

### DIFF
--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -451,6 +451,7 @@ function handleUploadDataChunkError({
       systemErrorResponseData,
       attemptsRemaining: attemptContext.attemptsRemaining,
       uploadCorrelationId,
+      'err.$response': (err as any)?.$response,
     },
     'Handling upload error...',
   );


### PR DESCRIPTION
Troubleshooting these `UPLOAD_ERROR`s coming back from persister API. 

```
SyntaxError: Unexpected token < in JSON at position 0 
 Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
    at JSON.parse (<anonymous>)
    at /opt/jupiterone/app/src/ecs/index.js:667257:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async parseErrorBody (/opt/jupiterone/app/src/ecs/index.js:667262:21)
    at async de_InvokeCommandError (/opt/jupiterone/app/src/ecs/index.js:664777:15)
    at async /opt/jupiterone/app/src/ecs/index.js:1441:24
    at async /opt/jupiterone/app/src/ecs/index.js:5359:22
    at async /opt/jupiterone/app/src/ecs/index.js:2843:42
    at async /opt/jupiterone/app/src/ecs/index.js:1657:26
    at async execute (/opt/jupiterone/app/src/ecs/index.js:886531:27)
--
```