### PR TITLE
Introduce validateCredentials.

### DIFF
--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -1,6 +1,9 @@
 import { IntegrationInstanceConfig } from './instance';
 import { GetStepStartStatesFunction, Step } from './step';
-import { InvocationValidationFunction } from './validation';
+import {
+  CredentialValidationFunction,
+  InvocationValidationFunction,
+} from './validation';
 import {
   ExecutionContext,
   IntegrationExecutionContext,
@@ -54,6 +57,7 @@ export interface InvocationConfig<
   TStepExecutionContext extends StepExecutionContext,
 > {
   validateInvocation?: InvocationValidationFunction<TExecutionContext>;
+  validateCredentials: CredentialValidationFunction;
   /**
    * Called after an integration execution has completed. You may this this hook
    * for performing operations such as closing out open clients in an

--- a/packages/integration-sdk-core/src/types/context.ts
+++ b/packages/integration-sdk-core/src/types/context.ts
@@ -18,6 +18,11 @@ export interface ExecutionContext {
   executionHistory: ExecutionHistory;
 }
 
+export interface CredentialValidationContext {
+  logger: IntegrationLogger;
+  config: IntegrationInstanceConfig;
+}
+
 /**
  * A configuration object constructed by an integration just before the
  * integration is executed. This is distinct from the

--- a/packages/integration-sdk-core/src/types/context.ts
+++ b/packages/integration-sdk-core/src/types/context.ts
@@ -20,7 +20,7 @@ export interface ExecutionContext {
 
 export interface CredentialValidationContext {
   logger: IntegrationLogger;
-  config: IntegrationInstanceConfig;
+  config: Record<string, any>;
 }
 
 /**

--- a/packages/integration-sdk-core/src/types/validation.ts
+++ b/packages/integration-sdk-core/src/types/validation.ts
@@ -1,6 +1,15 @@
-import { ExecutionContext, IntegrationExecutionContext } from './context';
+import {
+  CredentialValidationContext,
+  ExecutionContext,
+  IntegrationExecutionContext,
+} from './context';
 import { IntegrationInstanceConfig } from './instance';
 
+/**
+ * This function is called before an integration starts collecting data.
+ * It allows the integration to fail fast if credentials or other config
+ * is incorrect.
+ */
 export type InvocationValidationFunction<T extends ExecutionContext> = (
   context: T,
 ) => Promise<void> | void;
@@ -8,3 +17,24 @@ export type InvocationValidationFunction<T extends ExecutionContext> = (
 export type IntegrationInvocationValidationFunction<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig,
 > = InvocationValidationFunction<IntegrationExecutionContext<TConfig>>;
+
+export type CredentialValidationResult = {
+  /**
+   * Declares of authentication was successful.
+   * Does not determine if all permissions/scopes were correctly granted.
+   */
+  success: boolean;
+
+  /**
+   * Used to indicate if missing permissions/scopes were identified during validation.
+   */
+  missingPermissions?: Record<string, any>;
+};
+
+/**
+ * The function is made available to the credential verification system
+ * to test if credentials are valid prior to storing/using.
+ */
+export type CredentialValidationFunction = (
+  context: CredentialValidationContext,
+) => Promise<CredentialValidationResult> | void;


### PR DESCRIPTION
Proposal:

Add validateCredentials as a **required** function in the InvocationConfig interface

Why:
- validateInvocation remains a valid approach from more complicate pre-invocation validation. It's interface is too complicated for credential verification
- validateCredentials is called prior to an integration instance's creation and deserves a clear interface of parameters and return type.
- I believe this will lead to a desirable long term situation where the integration have a unique method to support this feature.

Rollout Approach:
- An integration can benefit from the Credential Verification button without upgrading the SDK to use the validateCredentials function. The validateInvocation method can be used until the upgrade takes place.



Note: tests will be updated once this approach is 👍 