### PR TITLE
Batching persister calls by size

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -134,6 +134,7 @@ export interface CreatePersisterApiStepGraphObjectDataUploaderParams {
   uploadConcurrency: number;
   uploadBatchSize?: number;
   uploadRelationshipsBatchSize?: number;
+  uploadChunkInMb?: number;
 }
 
 export function createPersisterApiStepGraphObjectDataUploader({
@@ -142,6 +143,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
   uploadConcurrency,
   uploadBatchSize,
   uploadRelationshipsBatchSize,
+  uploadChunkInMb
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
   return createQueuedStepGraphObjectDataUploader({
     stepId,
@@ -159,6 +161,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
           graphObjectData,
           uploadBatchSize,
           uploadRelationshipsBatchSize,
+          uploadChunkInMb
         );
       } catch (err) {
         context.logger.error(

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -4,7 +4,6 @@ import { FlushedGraphObjectData } from '../storage/types';
 import {
   uploadGraphObjectData,
   SynchronizationJobContext,
-  BYTES_IN_MB,
 } from '../synchronization';
 import { randomUUID as uuid } from 'crypto';
 import { MAX_BATCH_SIZE } from '../synchronization/shrinkBatchRawData';
@@ -136,7 +135,7 @@ export interface CreatePersisterApiStepGraphObjectDataUploaderParams {
   uploadConcurrency: number;
   uploadBatchSize?: number;
   uploadRelationshipsBatchSize?: number;
-  uploadChunkInMb?: number;
+  uploadChunkInBytes?: number;
 }
 
 export function createPersisterApiStepGraphObjectDataUploader({
@@ -145,10 +144,10 @@ export function createPersisterApiStepGraphObjectDataUploader({
   uploadConcurrency,
   uploadBatchSize,
   uploadRelationshipsBatchSize,
-  uploadChunkInMb,
+  uploadChunkInBytes,
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
-  if (uploadChunkInMb && uploadChunkInMb * BYTES_IN_MB > MAX_BATCH_SIZE) {
-    uploadChunkInMb = MAX_BATCH_SIZE;
+  if (uploadChunkInBytes && uploadChunkInBytes > MAX_BATCH_SIZE) {
+    uploadChunkInBytes = MAX_BATCH_SIZE;
   }
   return createQueuedStepGraphObjectDataUploader({
     stepId,
@@ -166,7 +165,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
           graphObjectData,
           uploadBatchSize,
           uploadRelationshipsBatchSize,
-          uploadChunkInMb,
+          uploadChunkInBytes,
         );
       } catch (err) {
         context.logger.error(

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -143,7 +143,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
   uploadConcurrency,
   uploadBatchSize,
   uploadRelationshipsBatchSize,
-  uploadChunkInMb
+  uploadChunkInMb,
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
   return createQueuedStepGraphObjectDataUploader({
     stepId,
@@ -161,7 +161,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
           graphObjectData,
           uploadBatchSize,
           uploadRelationshipsBatchSize,
-          uploadChunkInMb
+          uploadChunkInMb,
         );
       } catch (err) {
         context.logger.error(

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -4,8 +4,10 @@ import { FlushedGraphObjectData } from '../storage/types';
 import {
   uploadGraphObjectData,
   SynchronizationJobContext,
+  BYTES_IN_MB,
 } from '../synchronization';
 import { randomUUID as uuid } from 'crypto';
+import { MAX_BATCH_SIZE } from '../synchronization/shrinkBatchRawData';
 
 export interface StepGraphObjectDataUploader {
   stepId: string;
@@ -145,6 +147,9 @@ export function createPersisterApiStepGraphObjectDataUploader({
   uploadRelationshipsBatchSize,
   uploadChunkInMb,
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
+  if (uploadChunkInMb && uploadChunkInMb * BYTES_IN_MB > MAX_BATCH_SIZE) {
+    uploadChunkInMb = MAX_BATCH_SIZE;
+  }
   return createQueuedStepGraphObjectDataUploader({
     stepId,
     uploadConcurrency,

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -135,7 +135,7 @@ export interface CreatePersisterApiStepGraphObjectDataUploaderParams {
   uploadConcurrency: number;
   uploadBatchSize?: number;
   uploadRelationshipsBatchSize?: number;
-  uploadChunkInBytes?: number;
+  uploadBatchSizeInBytes?: number;
 }
 
 export function createPersisterApiStepGraphObjectDataUploader({
@@ -144,10 +144,13 @@ export function createPersisterApiStepGraphObjectDataUploader({
   uploadConcurrency,
   uploadBatchSize,
   uploadRelationshipsBatchSize,
-  uploadChunkInBytes,
+  uploadBatchSizeInBytes,
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
-  if (uploadChunkInBytes && uploadChunkInBytes > MAX_BATCH_SIZE_IN_BYTES) {
-    uploadChunkInBytes = MAX_BATCH_SIZE_IN_BYTES;
+  if (
+    uploadBatchSizeInBytes &&
+    uploadBatchSizeInBytes > MAX_BATCH_SIZE_IN_BYTES
+  ) {
+    uploadBatchSizeInBytes = MAX_BATCH_SIZE_IN_BYTES;
   }
   return createQueuedStepGraphObjectDataUploader({
     stepId,
@@ -165,7 +168,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
           graphObjectData,
           uploadBatchSize,
           uploadRelationshipsBatchSize,
-          uploadChunkInBytes,
+          uploadBatchSizeInBytes,
         );
       } catch (err) {
         context.logger.error(

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -6,7 +6,7 @@ import {
   SynchronizationJobContext,
 } from '../synchronization';
 import { randomUUID as uuid } from 'crypto';
-import { MAX_BATCH_SIZE } from '../synchronization/shrinkBatchRawData';
+import { MAX_BATCH_SIZE_IN_BYTES } from '../synchronization/shrinkBatchRawData';
 
 export interface StepGraphObjectDataUploader {
   stepId: string;
@@ -146,8 +146,8 @@ export function createPersisterApiStepGraphObjectDataUploader({
   uploadRelationshipsBatchSize,
   uploadChunkInBytes,
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
-  if (uploadChunkInBytes && uploadChunkInBytes > MAX_BATCH_SIZE) {
-    uploadChunkInBytes = MAX_BATCH_SIZE;
+  if (uploadChunkInBytes && uploadChunkInBytes > MAX_BATCH_SIZE_IN_BYTES) {
+    uploadChunkInBytes = MAX_BATCH_SIZE_IN_BYTES;
   }
   return createQueuedStepGraphObjectDataUploader({
     stepId,

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -7,7 +7,11 @@ import { randomUUID as uuid } from 'crypto';
 import { createApiClient, getApiBaseUrl } from '../../api';
 import { generateSynchronizationJob } from './util/generateSynchronizationJob';
 import { createMockIntegrationLogger } from '../../../test/util/fixtures';
-import { Entity, EntityRawData, Relationship } from '@jupiterone/integration-sdk-core';
+import {
+  Entity,
+  EntityRawData,
+  Relationship,
+} from '@jupiterone/integration-sdk-core';
 import {
   BYTES_IN_MB,
   SynchronizationJobContext,
@@ -192,7 +196,13 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
         job,
       };
       const mbNumber: number = 0.001 * i;
-      await uploadGraphObjectData(synchronizationJobContext, flushedObjectData,250,250,mbNumber);
+      await uploadGraphObjectData(
+        synchronizationJobContext,
+        flushedObjectData,
+        250,
+        250,
+        mbNumber,
+      );
 
       const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
       const relationshipsCalls = postSpy.mock.calls.filter(
@@ -201,12 +211,12 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       for (const call of entityCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].entities)),
-        ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber );
+        ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
       }
       for (const call of relationshipsCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].relationships)),
-        ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber );
+        ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
       }
     }
   });
@@ -227,34 +237,47 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       apiClient,
       job,
     };
-    const mbNumber: number =5;
-    await uploadGraphObjectData(synchronizationJobContext, bigObjectData,250,250,mbNumber);
+    const mbNumber: number = 5;
+    await uploadGraphObjectData(
+      synchronizationJobContext,
+      bigObjectData,
+      250,
+      250,
+      mbNumber,
+    );
 
     const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
     const relationshipsCalls = postSpy.mock.calls.filter(
       (c) => c[1].relationships,
     );
-    expect(entityCalls.length).toBe(3)
-    expect(relationshipsCalls.length).toBe(4)
-    let entitySentToSync:string[] = []
-    let relationshipSentToSync:string[] = []
+    expect(entityCalls.length).toBe(3);
+    expect(relationshipsCalls.length).toBe(4);
+    let entitySentToSync: string[] = [];
+    let relationshipSentToSync: string[] = [];
     for (const call of entityCalls) {
-      entitySentToSync = entitySentToSync.concat((call[1].entities as Entity[]).map(item => item._key) )
+      entitySentToSync = entitySentToSync.concat(
+        (call[1].entities as Entity[]).map((item) => item._key),
+      );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].entities)),
-      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber); 
+      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
     }
     for (const call of relationshipsCalls) {
-      relationshipSentToSync = relationshipSentToSync.concat((call[1].relationships as Relationship[]).map(item => item._key) )
+      relationshipSentToSync = relationshipSentToSync.concat(
+        (call[1].relationships as Relationship[]).map((item) => item._key),
+      );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
       ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
     }
     //Check that all elements that we wanted to sync were called
-    expect(bigObjectData.entities.map(item => item._key).sort() ).toEqual(entitySentToSync.sort())
-    expect(bigObjectData.relationships.map(item => item._key).sort() ).toEqual(relationshipSentToSync.sort())
+    expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
+      entitySentToSync.sort(),
+    );
+    expect(bigObjectData.relationships.map((item) => item._key).sort()).toEqual(
+      relationshipSentToSync.sort(),
+    );
   });
-
 
   test('should batch a small ammount of big entities 10x(7MB each)', async () => {
     const apiClient = createApiClient({
@@ -262,12 +285,15 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       account: uuid(),
     });
     const bigObjectData = createFlushedGraphObjectData(10, 0);
-    for(const entity of bigObjectData.entities){
-      const bigRawData:EntityRawData = {name:'rawData',rawData:'rawData'.repeat(1000000)};
-      
-      entity._rawData=[bigRawData]
+    for (const entity of bigObjectData.entities) {
+      const bigRawData: EntityRawData = {
+        name: 'rawData',
+        rawData: 'rawData'.repeat(1000000),
+      };
+
+      entity._rawData = [bigRawData];
     }
- 
+
     const postSpy = jest.spyOn(apiClient, 'post') as any;
 
     postSpy.mockResolvedValue({});
@@ -278,26 +304,36 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       apiClient,
       job,
     };
-    const mbNumber: number =5;
-    await uploadGraphObjectData(synchronizationJobContext, bigObjectData,250,250,mbNumber);
+    const mbNumber: number = 5;
+    await uploadGraphObjectData(
+      synchronizationJobContext,
+      bigObjectData,
+      250,
+      250,
+      mbNumber,
+    );
 
     const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
     const relationshipsCalls = postSpy.mock.calls.filter(
       (c) => c[1].relationships,
     );
-    expect(entityCalls.length).toBe(10)
-    let sentToSync:string[] = []
+    expect(entityCalls.length).toBe(10);
+    let sentToSync: string[] = [];
     for (const call of entityCalls) {
-      sentToSync = sentToSync.concat((call[1].entities as Entity[]).map(item => item._key) )
+      sentToSync = sentToSync.concat(
+        (call[1].entities as Entity[]).map((item) => item._key),
+      );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].entities)),
-      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber); 
+      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
     }
     for (const call of relationshipsCalls) {
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
       ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
     }
-    expect(bigObjectData.entities.map(item => item._key).sort() ).toEqual(sentToSync.sort())
+    expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
+      sentToSync.sort(),
+    );
   });
 });

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -207,12 +207,12 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       for (const call of entityCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].entities)),
-        ).toBeLessThanOrEqual(bytesToBatch *1.01);
+        ).toBeLessThanOrEqual(bytesToBatch * 1.01);
       }
       for (const call of relationshipsCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].relationships)),
-        ).toBeLessThanOrEqual(bytesToBatch *1.01);
+        ).toBeLessThanOrEqual(bytesToBatch * 1.01);
       }
     }
   });
@@ -256,7 +256,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].entities)),
-      ).toBeLessThanOrEqual(bytesToBatch *1.01);
+      ).toBeLessThanOrEqual(bytesToBatch * 1.01);
     }
     for (const call of relationshipsCalls) {
       relationshipSentToSync = relationshipSentToSync.concat(
@@ -264,7 +264,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
-      ).toBeLessThanOrEqual(bytesToBatch *1.01);
+      ).toBeLessThanOrEqual(bytesToBatch * 1.01);
     }
     //Check that all elements that we wanted to sync were called
     expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
@@ -321,12 +321,12 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].entities)),
-      ).toBeLessThanOrEqual(bytesToBatch *1.01);
+      ).toBeLessThanOrEqual(bytesToBatch * 1.01);
     }
     for (const call of relationshipsCalls) {
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
-      ).toBeLessThanOrEqual(bytesToBatch *1.01);
+      ).toBeLessThanOrEqual(bytesToBatch * 1.01);
     }
     expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
       sentToSync.sort(),

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -207,12 +207,12 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       for (const call of entityCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].entities)),
-        ).toBeLessThanOrEqual(bytesToBatch);
+        ).toBeLessThanOrEqual(bytesToBatch *1.01);
       }
       for (const call of relationshipsCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].relationships)),
-        ).toBeLessThanOrEqual(bytesToBatch);
+        ).toBeLessThanOrEqual(bytesToBatch *1.01);
       }
     }
   });
@@ -256,7 +256,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].entities)),
-      ).toBeLessThanOrEqual(bytesToBatch);
+      ).toBeLessThanOrEqual(bytesToBatch *1.01);
     }
     for (const call of relationshipsCalls) {
       relationshipSentToSync = relationshipSentToSync.concat(
@@ -264,7 +264,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
-      ).toBeLessThanOrEqual(bytesToBatch);
+      ).toBeLessThanOrEqual(bytesToBatch *1.01);
     }
     //Check that all elements that we wanted to sync were called
     expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
@@ -313,7 +313,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
     const relationshipsCalls = postSpy.mock.calls.filter(
       (c) => c[1].relationships,
     );
-    expect(entityCalls.length).toBe(10);
+    expect(entityCalls.length).toBe(1);
     let sentToSync: string[] = [];
     for (const call of entityCalls) {
       sentToSync = sentToSync.concat(
@@ -321,12 +321,12 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].entities)),
-      ).toBeLessThanOrEqual(bytesToBatch);
+      ).toBeLessThanOrEqual(bytesToBatch *1.01);
     }
     for (const call of relationshipsCalls) {
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
-      ).toBeLessThanOrEqual(bytesToBatch);
+      ).toBeLessThanOrEqual(bytesToBatch *1.01);
     }
     expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
       sentToSync.sort(),

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -7,8 +7,12 @@ import { randomUUID as uuid } from 'crypto';
 import { createApiClient, getApiBaseUrl } from '../../api';
 import { generateSynchronizationJob } from './util/generateSynchronizationJob';
 import { createMockIntegrationLogger } from '../../../test/util/fixtures';
-import { Entity, Relationship } from '@jupiterone/integration-sdk-core';
-import { SynchronizationJobContext, uploadGraphObjectData } from '..';
+import { Entity, EntityRawData, Relationship } from '@jupiterone/integration-sdk-core';
+import {
+  BYTES_IN_MB,
+  SynchronizationJobContext,
+  uploadGraphObjectData,
+} from '..';
 
 function createFlushedGraphObjectData(
   numEntity: number,
@@ -168,5 +172,132 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
     for (const call of relationshipsCalls) {
       expect(call[1].relationships.length).toBe(20);
     }
+  });
+
+  test('should use batchSizeInMB if provided', async () => {
+    const apiClient = createApiClient({
+      apiBaseUrl: getApiBaseUrl(),
+      account: uuid(),
+    });
+
+    for (let i = 1; i < 100; i++) {
+      const postSpy = jest.spyOn(apiClient, 'post') as any;
+
+      postSpy.mockResolvedValue({});
+
+      const job = generateSynchronizationJob();
+      const synchronizationJobContext: SynchronizationJobContext = {
+        logger: createMockIntegrationLogger(),
+        apiClient,
+        job,
+      };
+      const mbNumber: number = 0.001 * i;
+      await uploadGraphObjectData(synchronizationJobContext, flushedObjectData,250,250,mbNumber);
+
+      const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
+      const relationshipsCalls = postSpy.mock.calls.filter(
+        (c) => c[1].relationships,
+      );
+      for (const call of entityCalls) {
+        expect(
+          Buffer.byteLength(JSON.stringify(call[1].entities)),
+        ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber );
+      }
+      for (const call of relationshipsCalls) {
+        expect(
+          Buffer.byteLength(JSON.stringify(call[1].relationships)),
+        ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber );
+      }
+    }
+  });
+
+  test('should batch a really big ammount of entities-relationships 50k entities + 50k relationships', async () => {
+    const apiClient = createApiClient({
+      apiBaseUrl: getApiBaseUrl(),
+      account: uuid(),
+    });
+    const bigObjectData = createFlushedGraphObjectData(50000, 50000);
+    const postSpy = jest.spyOn(apiClient, 'post') as any;
+
+    postSpy.mockResolvedValue({});
+
+    const job = generateSynchronizationJob();
+    const synchronizationJobContext: SynchronizationJobContext = {
+      logger: createMockIntegrationLogger(),
+      apiClient,
+      job,
+    };
+    const mbNumber: number =5;
+    await uploadGraphObjectData(synchronizationJobContext, bigObjectData,250,250,mbNumber);
+
+    const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
+    const relationshipsCalls = postSpy.mock.calls.filter(
+      (c) => c[1].relationships,
+    );
+    expect(entityCalls.length).toBe(3)
+    expect(relationshipsCalls.length).toBe(4)
+    let entitySentToSync:string[] = []
+    let relationshipSentToSync:string[] = []
+    for (const call of entityCalls) {
+      entitySentToSync = entitySentToSync.concat((call[1].entities as Entity[]).map(item => item._key) )
+      expect(
+        Buffer.byteLength(JSON.stringify(call[1].entities)),
+      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber); 
+    }
+    for (const call of relationshipsCalls) {
+      relationshipSentToSync = relationshipSentToSync.concat((call[1].relationships as Relationship[]).map(item => item._key) )
+      expect(
+        Buffer.byteLength(JSON.stringify(call[1].relationships)),
+      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
+    }
+    //Check that all elements that we wanted to sync were called
+    expect(bigObjectData.entities.map(item => item._key).sort() ).toEqual(entitySentToSync.sort())
+    expect(bigObjectData.relationships.map(item => item._key).sort() ).toEqual(relationshipSentToSync.sort())
+  });
+
+
+  test('should batch a small ammount of big entities 10x(7MB each)', async () => {
+    const apiClient = createApiClient({
+      apiBaseUrl: getApiBaseUrl(),
+      account: uuid(),
+    });
+    const bigObjectData = createFlushedGraphObjectData(10, 0);
+    for(const entity of bigObjectData.entities){
+      const bigRawData:EntityRawData = {name:'rawData',rawData:'rawData'.repeat(1000000)};
+      
+      entity._rawData=[bigRawData]
+    }
+ 
+    const postSpy = jest.spyOn(apiClient, 'post') as any;
+
+    postSpy.mockResolvedValue({});
+
+    const job = generateSynchronizationJob();
+    const synchronizationJobContext: SynchronizationJobContext = {
+      logger: createMockIntegrationLogger(),
+      apiClient,
+      job,
+    };
+    const mbNumber: number =5;
+    await uploadGraphObjectData(synchronizationJobContext, bigObjectData,250,250,mbNumber);
+
+    const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
+    const relationshipsCalls = postSpy.mock.calls.filter(
+      (c) => c[1].relationships,
+    );
+    expect(entityCalls.length).toBe(10)
+    let sentToSync:string[] = []
+    for (const call of entityCalls) {
+      sentToSync = sentToSync.concat((call[1].entities as Entity[]).map(item => item._key) )
+      expect(
+        Buffer.byteLength(JSON.stringify(call[1].entities)),
+      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber); 
+    }
+    for (const call of relationshipsCalls) {
+      expect(
+        Buffer.byteLength(JSON.stringify(call[1].relationships)),
+      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
+    }
+    expect(bigObjectData.entities.map(item => item._key).sort() ).toEqual(sentToSync.sort())
   });
 });

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -12,10 +12,7 @@ import {
   EntityRawData,
   Relationship,
 } from '@jupiterone/integration-sdk-core';
-import {
-  SynchronizationJobContext,
-  uploadGraphObjectData,
-} from '..';
+import { SynchronizationJobContext, uploadGraphObjectData } from '..';
 export const BYTES_IN_MB = 1048576;
 function createFlushedGraphObjectData(
   numEntity: number,
@@ -210,7 +207,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       for (const call of entityCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].entities)),
-        ).toBeLessThanOrEqual( bytesToBatch);
+        ).toBeLessThanOrEqual(bytesToBatch);
       }
       for (const call of relationshipsCalls) {
         expect(
@@ -267,7 +264,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
-      ).toBeLessThanOrEqual( bytesToBatch);
+      ).toBeLessThanOrEqual(bytesToBatch);
     }
     //Check that all elements that we wanted to sync were called
     expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
@@ -329,7 +326,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
     for (const call of relationshipsCalls) {
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
-      ).toBeLessThanOrEqual( bytesToBatch);
+      ).toBeLessThanOrEqual(bytesToBatch);
     }
     expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
       sentToSync.sort(),

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -13,11 +13,10 @@ import {
   Relationship,
 } from '@jupiterone/integration-sdk-core';
 import {
-  BYTES_IN_MB,
   SynchronizationJobContext,
   uploadGraphObjectData,
 } from '..';
-
+export const BYTES_IN_MB = 1048576;
 function createFlushedGraphObjectData(
   numEntity: number,
   numRelationship: number,
@@ -195,13 +194,13 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
         apiClient,
         job,
       };
-      const mbNumber: number = 0.001 * i;
+      const bytesToBatch: number = 0.001 * i * BYTES_IN_MB;
       await uploadGraphObjectData(
         synchronizationJobContext,
         flushedObjectData,
         250,
         250,
-        mbNumber,
+        bytesToBatch,
       );
 
       const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
@@ -211,12 +210,12 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       for (const call of entityCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].entities)),
-        ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
+        ).toBeLessThanOrEqual( bytesToBatch);
       }
       for (const call of relationshipsCalls) {
         expect(
           Buffer.byteLength(JSON.stringify(call[1].relationships)),
-        ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
+        ).toBeLessThanOrEqual(bytesToBatch);
       }
     }
   });
@@ -237,13 +236,13 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       apiClient,
       job,
     };
-    const mbNumber: number = 5;
+    const bytesToBatch: number = 5 * BYTES_IN_MB;
     await uploadGraphObjectData(
       synchronizationJobContext,
       bigObjectData,
       250,
       250,
-      mbNumber,
+      bytesToBatch,
     );
 
     const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
@@ -260,7 +259,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].entities)),
-      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
+      ).toBeLessThanOrEqual(bytesToBatch);
     }
     for (const call of relationshipsCalls) {
       relationshipSentToSync = relationshipSentToSync.concat(
@@ -268,7 +267,7 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
-      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
+      ).toBeLessThanOrEqual( bytesToBatch);
     }
     //Check that all elements that we wanted to sync were called
     expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
@@ -304,13 +303,13 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       apiClient,
       job,
     };
-    const mbNumber: number = 5;
+    const bytesToBatch: number = 5 * BYTES_IN_MB;
     await uploadGraphObjectData(
       synchronizationJobContext,
       bigObjectData,
       250,
       250,
-      mbNumber,
+      bytesToBatch,
     );
 
     const entityCalls = postSpy.mock.calls.filter((c) => c[1].entities);
@@ -325,12 +324,12 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       );
       expect(
         Buffer.byteLength(JSON.stringify(call[1].entities)),
-      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
+      ).toBeLessThanOrEqual(bytesToBatch);
     }
     for (const call of relationshipsCalls) {
       expect(
         Buffer.byteLength(JSON.stringify(call[1].relationships)),
-      ).toBeLessThanOrEqual(BYTES_IN_MB * mbNumber);
+      ).toBeLessThanOrEqual( bytesToBatch);
     }
     expect(bigObjectData.entities.map((item) => item._key).sort()).toEqual(
       sentToSync.sort(),

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -1,0 +1,98 @@
+import {
+  Entity,
+  IntegrationLogger,
+  Relationship,
+} from '@jupiterone/integration-sdk-core';
+import { UploadDataLookup } from '.';
+import { MAX_BATCH_SIZE } from './shrinkBatchRawData';
+const BATCH_THRESHOLD = 0.9; //will stop chunking if chunk size is between BATCH_THRESHOLD*sizeInBytes and sizeInBytes
+
+export function chunkBySize<T extends UploadDataLookup, K extends keyof T>(
+  data: T[K][],
+  sizeInBytes: number,
+  logger: IntegrationLogger,
+): T[K][][] {
+  if (sizeInBytes > MAX_BATCH_SIZE) {
+    logger.error({}, 'batch size is too big');
+    throw Error();
+  }
+  return chunk(data, sizeInBytes, logger);
+}
+export function chunk<T extends UploadDataLookup, K extends keyof T>(
+  data: T[K][],
+  sizeInBytes: number,
+  logger: IntegrationLogger,
+): T[K][][] {
+  let chunkedData: T[K][][] = [];
+  if (getSizeOfObject(data) < sizeInBytes) {
+    return [data]; //Just one chunk of all data
+  }
+  let bestIndex = binarySearch(data, sizeInBytes);
+  if (bestIndex <= 0) {
+    handleBinarySearchError(data, sizeInBytes, logger);
+    bestIndex = 1;
+  }
+  chunkedData.push(data.slice(0, bestIndex));
+  if (bestIndex !== data.length)
+    chunkedData = chunkedData.concat(
+      chunk(data.slice(bestIndex), sizeInBytes, logger),
+    );
+  return chunkedData;
+}
+//If the batch doesnt fit, we try with half, and then half of half ... until it fits.
+//We repeat until we reach the Threshold or until the while condition.
+function binarySearch<T extends UploadDataLookup, K extends keyof T>(
+  data: T[K][],
+  targetSize: number,
+): number {
+  let left: number = 0;
+  let right: number = data.length - 1;
+  let bestIndex = -1;
+  while (left <= right) {
+    const mid: number = Math.floor((left + right) / 2);
+    const size = getSizeOfObject(data.slice(0, right));
+    if (size <= targetSize) {
+      bestIndex = mid;
+      if (size >= targetSize * BATCH_THRESHOLD) {
+        return mid;
+      }
+    }
+    if (targetSize < size) right = mid - 1;
+    else left = mid + 1;
+  }
+  return bestIndex;
+}
+function handleBinarySearchError<T extends UploadDataLookup, K extends keyof T>(
+  data: T[K][],
+  sizeInBytes: number,
+  logger: IntegrationLogger,
+) {
+  const bigBatch = data.slice(0, 1) as Entity[] | Relationship[];
+  if (bigBatch[0] && bigBatch[0]._rawData) {
+    logger.info(
+      bigBatch[0].key,
+      'Entity/Relationship is too big to ingest. Will remove _rawData',
+    );
+    bigBatch[0]._rawData = [];
+  }
+  if (getSizeOfObject(bigBatch) > sizeInBytes) {
+    logger.error(
+      bigBatch[0].key,
+      'Entity/Relationship is too big to ingest. This usually happens when item has a lot of long attributes.',
+    );
+    throw Error();
+  }
+}
+export function getSizeOfObject<T extends UploadDataLookup, K extends keyof T>(
+  object: T[K][],
+): number {
+  try {
+    return JSON.stringify(object).length;
+  } catch (error) {
+    if (error instanceof RangeError) {
+      //If object is too large to size we fallback to the max batchSize
+      return MAX_BATCH_SIZE;
+    }
+    throw error;
+  }
+}

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -1,11 +1,20 @@
 import {
   Entity,
   IntegrationLogger,
+  IntegrationWarnEventName,
   Relationship,
 } from '@jupiterone/integration-sdk-core';
 import { UploadDataLookup } from '.';
 import { MAX_BATCH_SIZE_IN_BYTES } from './shrinkBatchRawData';
 
+/**
+Converts an array of graphObjects into an array of groups of this objects.
+@param graphObjects  Entities or relationships to group.
+
+@param maximumBatchSizeInBytes The maximum size of the group of objects.
+
+@param logger 
+ */
 export function batchGraphObjectsBySizeInBytes<
   T extends UploadDataLookup,
   K extends keyof T,
@@ -42,6 +51,11 @@ export function batchGraphObjectsBySizeInBytes<
           },
           'Graph object is larger than batch size in bytes; cannot upload graph object.',
         );
+        logger.publishWarnEvent({
+          name: IntegrationWarnEventName.IngestionLimitEncountered,
+          description:
+            'Graph object is larger than batch size in bytes; cannot upload graph object. Will skip graph object.',
+        });
         continue;
       } else {
         logger.info(

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -14,7 +14,7 @@ export function chunkBySize<T extends UploadDataLookup, K extends keyof T>(
 ): T[K][][] {
   if (sizeInBytes > MAX_BATCH_SIZE) {
     logger.error({}, 'batch size is too big');
-    throw Error();
+    throw new Error('batch size is too big');
   }
   return chunk(data, sizeInBytes, logger);
 }
@@ -95,7 +95,7 @@ function handleBinarySearchError<T extends UploadDataLookup, K extends keyof T>(
       bigBatch[0].key,
       'Entity/Relationship is too big to ingest. This usually happens when item has a lot of long attributes.',
     );
-    throw Error();
+    throw new Error('Entity/Relationship is too big to ingest. This usually happens when item has a lot of long attributes.',);
   }
 }
 

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -1,78 +1,59 @@
 import {
-  Entity,
+    Entity,
   IntegrationLogger,
   Relationship,
 } from '@jupiterone/integration-sdk-core';
 import { UploadDataLookup } from '.';
 import { MAX_BATCH_SIZE_IN_BYTES } from './shrinkBatchRawData';
-const BATCH_THRESHOLD = 0.9; //will stop chunking if chunk size is between BATCH_THRESHOLD*sizeInBytes and sizeInBytes
 
-export function chunkBySize<T extends UploadDataLookup, K extends keyof T>(
-  data: T[K][],
-  sizeInBytes: number,
-  logger: IntegrationLogger,
-): T[K][][] {
-  const chunkedData: T[K][][] = [];
-  let bestIndex = linearSearch(data, sizeInBytes);
-  if (bestIndex > 0 && bestIndex + 1 == data.length) {
-    //Are we at the end of the array?
-    chunkedData.push(data);
-    return chunkedData;
-  }
-  if (bestIndex <= 0) {
-    //If the first entity is too big
-    handleSearchError(data, sizeInBytes, logger); // we remove rawdata
-    bestIndex = 1; //and send it to the persister alone. TODO: find a way to avoid sending this entities as a single call. It shouldn't be an issue since this only happens if there is a single entity above sizeInBytes
-  }
-  chunkedData.push(data.slice(0, bestIndex));
-  if (bestIndex !== data.length)
-    chunkedData.push(
-      ...chunkBySize(data.slice(bestIndex), sizeInBytes, logger), //chunk the rest of the data
-    );
-  return chunkedData;
-}
-/** 
-    Linearly look for the best index to chunk
-**/
-function linearSearch<T extends UploadDataLookup, K extends keyof T>(
-  data: T[K][],
-  targetSize: number,
-): number {
-  let size = 0;
-  let index = 0;
-  const acceptedTargetSize = BATCH_THRESHOLD * targetSize;
-  while (size < acceptedTargetSize && index < data.length) {
-    size += getSizeOfObject([data[index]]);
-    index++;
-  }
-  return index - 1;
-}
-function handleSearchError<T extends UploadDataLookup, K extends keyof T>(
-  data: T[K][],
-  sizeInBytes: number,
-  logger: IntegrationLogger,
-) {
-  const bigBatch = data.slice(0, 1) as Entity[] | Relationship[];
-  if (bigBatch[0] && bigBatch[0]._rawData) {
-    logger.info(
-      bigBatch[0].key,
-      'Entity/Relationship is too big to ingest. Will remove _rawData',
-    );
-    bigBatch[0]._rawData = [];
-  }
-  if (getSizeOfObject(bigBatch) > sizeInBytes) {
-    logger.error(
-      bigBatch[0].key,
-      'Entity/Relationship is too big to ingest. This usually happens when item has a lot of long attributes.',
-    );
-    throw new Error(
-      'Entity/Relationship is too big to ingest. This usually happens when item has a lot of long attributes.',
-    );
-  }
-}
+export function batchGraphObjectsBySizeInBytes<T extends UploadDataLookup, K extends keyof T>(
+    graphObjects: T[K][],
+    maximumBatchSizeInBytes: number,
+    logger: IntegrationLogger,
+  ): T[K][][] {
+    const batches: T[K][][] = [];
+  
+    let currentBatch: T[K][] = [];
+    let currentBatchSize: number = 0;
+    for (const graphObject of graphObjects) {
+      const typedGraphObject = graphObject as Entity | Relationship
+      
+      let graphObjectSizeInBytes = getSizeOfObject(graphObject);
+      
+      if (graphObjectSizeInBytes > maximumBatchSizeInBytes) {
+        const rawDataSizeInBytes = typedGraphObject._rawData ? getSizeOfObject(typedGraphObject._rawData) : 0;
 
-export function getSizeOfObject<T extends UploadDataLookup, K extends keyof T>(
-  object: T[K][],
+        if (graphObjectSizeInBytes-rawDataSizeInBytes > maximumBatchSizeInBytes) {
+          logger.warn({ 
+            _key: typedGraphObject._key, _type: typedGraphObject.type, maximumBatchSizeInBytes, graphObjectSizeInBytes, rawDataSizeInBytes,
+           }, 'Graph object is larger than batch size in bytes; cannot upload graph object.');
+           continue;
+        } else {
+          logger.info({ 
+            _key: typedGraphObject._key, _type: typedGraphObject.type, maximumBatchSizeInBytes, graphObjectSizeInBytes, rawDataSizeInBytes,
+           }, 'Graph object is larger than batch size in bytes; removing raw data.');
+           graphObjectSizeInBytes -= rawDataSizeInBytes;
+           typedGraphObject._rawData = undefined;
+        }
+      }
+  
+      if (graphObjectSizeInBytes + currentBatchSize >= maximumBatchSizeInBytes) {
+        batches.push(currentBatch);
+        currentBatch = [];
+        currentBatchSize = 0;
+      }
+      currentBatch.push(graphObject);
+      currentBatchSize += graphObjectSizeInBytes;
+    }
+  
+    if (currentBatch.length > 0) {
+      batches.push(currentBatch);
+    }
+    return batches;
+  }
+
+export function getSizeOfObject(
+  object: any,
 ): number {
   try {
     return Buffer.byteLength(JSON.stringify(object), 'utf8');

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -4,7 +4,7 @@ import {
   Relationship,
 } from '@jupiterone/integration-sdk-core';
 import { UploadDataLookup } from '.';
-import { MAX_BATCH_SIZE } from './shrinkBatchRawData';
+import { MAX_BATCH_SIZE_IN_BYTES } from './shrinkBatchRawData';
 const BATCH_THRESHOLD = 0.9; //will stop chunking if chunk size is between BATCH_THRESHOLD*sizeInBytes and sizeInBytes
 
 export function chunkBySize<T extends UploadDataLookup, K extends keyof T>(
@@ -78,7 +78,7 @@ export function getSizeOfObject<T extends UploadDataLookup, K extends keyof T>(
   } catch (error) {
     if (error instanceof RangeError) {
       //If object is too large to size, stringify runs out of memory. We fallback to the max batchSize.
-      return MAX_BATCH_SIZE + 1;
+      return MAX_BATCH_SIZE_IN_BYTES + 1;
     }
     throw error;
   }

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -95,7 +95,9 @@ function handleBinarySearchError<T extends UploadDataLookup, K extends keyof T>(
       bigBatch[0].key,
       'Entity/Relationship is too big to ingest. This usually happens when item has a lot of long attributes.',
     );
-    throw new Error('Entity/Relationship is too big to ingest. This usually happens when item has a lot of long attributes.',);
+    throw new Error(
+      'Entity/Relationship is too big to ingest. This usually happens when item has a lot of long attributes.',
+    );
   }
 }
 

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -14,9 +14,10 @@ export function chunkBySize<T extends UploadDataLookup, K extends keyof T>(
 ): T[K][][] {
   const chunkedData: T[K][][] = [];
   let bestIndex = linearSearch(data, sizeInBytes);
-  if(bestIndex > 0 && bestIndex + 1 == data.length){//Are we at the end of the array?
-    chunkedData.push(data)
-    return chunkedData
+  if (bestIndex > 0 && bestIndex + 1 == data.length) {
+    //Are we at the end of the array?
+    chunkedData.push(data);
+    return chunkedData;
   }
   if (bestIndex <= 0) {
     //If the first entity is too big

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -31,7 +31,7 @@ export function chunk<T extends UploadDataLookup, K extends keyof T>(
   if (bestIndex <= 0) {
     //If the first entity is too big
     handleBinarySearchError(data, sizeInBytes, logger); // we remove rawdata
-    bestIndex = 1; //and send it to the persister alone. TODO: find a way to avoid sending this entities as a single call. It shouldn't be an issue since this only happens if there is a signle entity above sizeInBytes
+    bestIndex = 1; //and send it to the persister alone. TODO: find a way to avoid sending this entities as a single call. It shouldn't be an issue since this only happens if there is a single entity above sizeInBytes
   }
   chunkedData.push(data.slice(0, bestIndex));
   if (bestIndex !== data.length)
@@ -42,6 +42,7 @@ export function chunk<T extends UploadDataLookup, K extends keyof T>(
 }
 //If the batch doesnt fit, we try with half, and then half of half ... until it fits.
 //We repeat until we reach the Threshold or until the while condition.
+//We are binary-searching for the best spot to chunk
 function binarySearch<T extends UploadDataLookup, K extends keyof T>(
   data: T[K][],
   targetSize: number,

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -1,60 +1,80 @@
 import {
-    Entity,
+  Entity,
   IntegrationLogger,
   Relationship,
 } from '@jupiterone/integration-sdk-core';
 import { UploadDataLookup } from '.';
 import { MAX_BATCH_SIZE_IN_BYTES } from './shrinkBatchRawData';
 
-export function batchGraphObjectsBySizeInBytes<T extends UploadDataLookup, K extends keyof T>(
-    graphObjects: T[K][],
-    maximumBatchSizeInBytes: number,
-    logger: IntegrationLogger,
-  ): T[K][][] {
-    const batches: T[K][][] = [];
-  
-    let currentBatch: T[K][] = [];
-    let currentBatchSize: number = 0;
-    for (const graphObject of graphObjects) {
-      const typedGraphObject = graphObject as Entity | Relationship
-      
-      let graphObjectSizeInBytes = getSizeOfObject(graphObject);
-      
-      if (graphObjectSizeInBytes > maximumBatchSizeInBytes) {
-        const rawDataSizeInBytes = typedGraphObject._rawData ? getSizeOfObject(typedGraphObject._rawData) : 0;
+export function batchGraphObjectsBySizeInBytes<
+  T extends UploadDataLookup,
+  K extends keyof T,
+>(
+  graphObjects: T[K][],
+  maximumBatchSizeInBytes: number,
+  logger: IntegrationLogger,
+): T[K][][] {
+  const batches: T[K][][] = [];
 
-        if (graphObjectSizeInBytes-rawDataSizeInBytes > maximumBatchSizeInBytes) {
-          logger.warn({ 
-            _key: typedGraphObject._key, _type: typedGraphObject.type, maximumBatchSizeInBytes, graphObjectSizeInBytes, rawDataSizeInBytes,
-           }, 'Graph object is larger than batch size in bytes; cannot upload graph object.');
-           continue;
-        } else {
-          logger.info({ 
-            _key: typedGraphObject._key, _type: typedGraphObject.type, maximumBatchSizeInBytes, graphObjectSizeInBytes, rawDataSizeInBytes,
-           }, 'Graph object is larger than batch size in bytes; removing raw data.');
-           graphObjectSizeInBytes -= rawDataSizeInBytes;
-           typedGraphObject._rawData = undefined;
-        }
+  let currentBatch: T[K][] = [];
+  let currentBatchSize: number = 0;
+  for (const graphObject of graphObjects) {
+    const typedGraphObject = graphObject as Entity | Relationship;
+
+    let graphObjectSizeInBytes = getSizeOfObject(graphObject);
+
+    if (graphObjectSizeInBytes > maximumBatchSizeInBytes) {
+      const rawDataSizeInBytes = typedGraphObject._rawData
+        ? getSizeOfObject(typedGraphObject._rawData)
+        : 0;
+
+      if (
+        graphObjectSizeInBytes - rawDataSizeInBytes >
+        maximumBatchSizeInBytes
+      ) {
+        logger.warn(
+          {
+            _key: typedGraphObject._key,
+            _type: typedGraphObject.type,
+            maximumBatchSizeInBytes,
+            graphObjectSizeInBytes,
+            rawDataSizeInBytes,
+          },
+          'Graph object is larger than batch size in bytes; cannot upload graph object.',
+        );
+        continue;
+      } else {
+        logger.info(
+          {
+            _key: typedGraphObject._key,
+            _type: typedGraphObject.type,
+            maximumBatchSizeInBytes,
+            graphObjectSizeInBytes,
+            rawDataSizeInBytes,
+          },
+          'Graph object is larger than batch size in bytes; removing raw data.',
+        );
+        graphObjectSizeInBytes -= rawDataSizeInBytes;
+        typedGraphObject._rawData = undefined;
       }
-  
-      if (graphObjectSizeInBytes + currentBatchSize >= maximumBatchSizeInBytes) {
-        batches.push(currentBatch);
-        currentBatch = [];
-        currentBatchSize = 0;
-      }
-      currentBatch.push(graphObject);
-      currentBatchSize += graphObjectSizeInBytes;
     }
-  
-    if (currentBatch.length > 0) {
+
+    if (graphObjectSizeInBytes + currentBatchSize >= maximumBatchSizeInBytes) {
       batches.push(currentBatch);
+      currentBatch = [];
+      currentBatchSize = 0;
     }
-    return batches;
+    currentBatch.push(graphObject);
+    currentBatchSize += graphObjectSizeInBytes;
   }
 
-export function getSizeOfObject(
-  object: any,
-): number {
+  if (currentBatch.length > 0) {
+    batches.push(currentBatch);
+  }
+  return batches;
+}
+
+export function getSizeOfObject(object: any): number {
   try {
     return Buffer.byteLength(JSON.stringify(object), 'utf8');
   } catch (error) {

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -12,18 +12,12 @@ export function chunkBySize<T extends UploadDataLookup, K extends keyof T>(
   sizeInBytes: number,
   logger: IntegrationLogger,
 ): T[K][][] {
-  return chunk(data, sizeInBytes, logger);
-}
-export function chunk<T extends UploadDataLookup, K extends keyof T>(
-  data: T[K][],
-  sizeInBytes: number,
-  logger: IntegrationLogger,
-): T[K][][] {
   const chunkedData: T[K][][] = [];
-  if (getSizeOfObject(data) < sizeInBytes) {
-    return [data]; //Just one chunk of all data
-  }
   let bestIndex = linearSearch(data, sizeInBytes);
+  if(bestIndex > 0 && bestIndex + 1 == data.length){//Are we at the end of the array?
+    chunkedData.push(data)
+    return chunkedData
+  }
   if (bestIndex <= 0) {
     //If the first entity is too big
     handleSearchError(data, sizeInBytes, logger); // we remove rawdata
@@ -32,11 +26,13 @@ export function chunk<T extends UploadDataLookup, K extends keyof T>(
   chunkedData.push(data.slice(0, bestIndex));
   if (bestIndex !== data.length)
     chunkedData.push(
-      ...chunk(data.slice(bestIndex), sizeInBytes, logger), //chunk the rest of the data
+      ...chunkBySize(data.slice(bestIndex), sizeInBytes, logger), //chunk the rest of the data
     );
   return chunkedData;
 }
-//We are linearly searching for the best index
+/** 
+    Linearly look for the best index to chunk
+**/
 function linearSearch<T extends UploadDataLookup, K extends keyof T>(
   data: T[K][],
   targetSize: number,
@@ -82,7 +78,7 @@ export function getSizeOfObject<T extends UploadDataLookup, K extends keyof T>(
   } catch (error) {
     if (error instanceof RangeError) {
       //If object is too large to size, stringify runs out of memory. We fallback to the max batchSize.
-      return MAX_BATCH_SIZE;
+      return MAX_BATCH_SIZE + 1;
     }
     throw error;
   }

--- a/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/batchBySize.ts
@@ -60,6 +60,7 @@ export function getSizeOfObject(
   } catch (error) {
     if (error instanceof RangeError) {
       //If object is too large to size, stringify runs out of memory. We fallback to the max batchSize.
+      //This is highly unlikely since it should only happen after ~500MB.
       return MAX_BATCH_SIZE_IN_BYTES + 1;
     }
     throw error;

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -556,7 +556,7 @@ export async function uploadData<T extends UploadDataLookup, K extends keyof T>(
   try {
     if (batchSizeInMB) {
       batches = chunkBySize(data, batchSizeInMB * BYTES_IN_MB, logger);
-      logger.info(
+      logger.debug(
         {
           batches: batches.map((b) => ({
             length: b.length,

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -282,7 +282,7 @@ export async function uploadGraphObjectData(
   graphObjectData: FlushedGraphObjectData,
   uploadBatchSize?: number,
   uploadRelationshipsBatchSize?: number,
-  mbToChunk?: number,
+  uploadBatchSizeInMb?: number,
 ) {
   const entityBatchSize = uploadBatchSize;
   const relationshipsBatchSize =
@@ -305,7 +305,7 @@ export async function uploadGraphObjectData(
         'entities',
         graphObjectData.entities,
         entityBatchSize,
-        mbToChunk,
+        uploadBatchSizeInMb,
       );
 
       synchronizationJobContext.logger.debug(
@@ -332,7 +332,7 @@ export async function uploadGraphObjectData(
         'relationships',
         graphObjectData.relationships,
         relationshipsBatchSize,
-        mbToChunk,
+        uploadBatchSizeInMb,
       );
 
       synchronizationJobContext.logger.debug(
@@ -569,6 +569,7 @@ export async function uploadData<T extends UploadDataLookup, K extends keyof T>(
       batches = chunk(data, uploadBatchSize || DEFAULT_UPLOAD_BATCH_SIZE);
     }
   } catch (error) {
+    logger.warn({ error }, 'Batching by size failed');
     batches = chunk(data, uploadBatchSize || DEFAULT_UPLOAD_BATCH_SIZE);
   }
   await pMap(

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -556,10 +556,13 @@ export async function uploadData<T extends UploadDataLookup, K extends keyof T>(
   try {
     if (batchSizeInMB) {
       batches = chunkBySize(data, batchSizeInMB * BYTES_IN_MB, logger);
-      logger.info({ batches: batches.map((b) => ({
-        length:b.length, sizeInBytes: getSizeOfObject(b)
-      }))}
-       ,
+      logger.info(
+        {
+          batches: batches.map((b) => ({
+            length: b.length,
+            sizeInBytes: getSizeOfObject(b),
+          })),
+        },
         'Sending Batches',
       );
     } else {

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -25,7 +25,7 @@ import { createEventPublishingQueue } from './events';
 import { AxiosInstance } from 'axios';
 import { iterateParsedGraphFiles } from '..';
 import { shrinkBatchRawData } from './shrinkBatchRawData';
-import { chunkBySize, getSizeOfObject } from './batchBySize';
+import { batchGraphObjectsBySizeInBytes } from './batchBySize';
 
 export { synchronizationApiError };
 export { createEventPublishingQueue } from './events';
@@ -555,16 +555,7 @@ export async function uploadData<T extends UploadDataLookup, K extends keyof T>(
   let batches: T[K][][];
   try {
     if (batchSizeInBytes) {
-      batches = chunkBySize(data, batchSizeInBytes, logger);
-      logger.debug(
-        {
-          batches: batches.map((b) => ({
-            length: b.length,
-            sizeInBytes: getSizeOfObject(b),
-          })),
-        },
-        'Sending Batches',
-      );
+      batches = batchGraphObjectsBySizeInBytes(data, batchSizeInBytes, logger);
     } else {
       batches = chunk(data, uploadBatchSize || DEFAULT_UPLOAD_BATCH_SIZE);
     }

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -556,7 +556,12 @@ export async function uploadData<T extends UploadDataLookup, K extends keyof T>(
   try {
     if (batchSizeInMB) {
       batches = chunkBySize(data, batchSizeInMB * BYTES_IN_MB, logger);
-      logger.info(batches.map((b)=>{b.length,getSizeOfObject(b)}),'Sending Batches')
+      logger.info(
+        batches.map((b) => {
+          b.length, getSizeOfObject(b);
+        }),
+        'Sending Batches',
+      );
     } else {
       batches = chunk(data, uploadBatchSize || DEFAULT_UPLOAD_BATCH_SIZE);
     }

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -31,7 +31,7 @@ export { synchronizationApiError };
 export { createEventPublishingQueue } from './events';
 
 export const DEFAULT_UPLOAD_BATCH_SIZE = 250;
-export const BYTES_IN_MB = 1048576;
+
 const UPLOAD_CONCURRENCY = 6;
 
 export enum RequestHeaders {
@@ -282,7 +282,7 @@ export async function uploadGraphObjectData(
   graphObjectData: FlushedGraphObjectData,
   uploadBatchSize?: number,
   uploadRelationshipsBatchSize?: number,
-  uploadBatchSizeInMb?: number,
+  uploadBatchSizeInBytes?: number,
 ) {
   const entityBatchSize = uploadBatchSize;
   const relationshipsBatchSize =
@@ -305,7 +305,7 @@ export async function uploadGraphObjectData(
         'entities',
         graphObjectData.entities,
         entityBatchSize,
-        uploadBatchSizeInMb,
+        uploadBatchSizeInBytes,
       );
 
       synchronizationJobContext.logger.debug(
@@ -332,7 +332,7 @@ export async function uploadGraphObjectData(
         'relationships',
         graphObjectData.relationships,
         relationshipsBatchSize,
-        uploadBatchSizeInMb,
+        uploadBatchSizeInBytes,
       );
 
       synchronizationJobContext.logger.debug(
@@ -550,12 +550,12 @@ export async function uploadData<T extends UploadDataLookup, K extends keyof T>(
   type: K,
   data: T[K][],
   uploadBatchSize?: number,
-  batchSizeInMB?: number,
+  batchSizeInBytes?: number,
 ) {
   let batches: T[K][][];
   try {
-    if (batchSizeInMB) {
-      batches = chunkBySize(data, batchSizeInMB * BYTES_IN_MB, logger);
+    if (batchSizeInBytes) {
+      batches = chunkBySize(data, batchSizeInBytes, logger);
       logger.debug(
         {
           batches: batches.map((b) => ({

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -556,10 +556,10 @@ export async function uploadData<T extends UploadDataLookup, K extends keyof T>(
   try {
     if (batchSizeInMB) {
       batches = chunkBySize(data, batchSizeInMB * BYTES_IN_MB, logger);
-      logger.info(
-        batches.map((b) => {
-          b.length, getSizeOfObject(b);
-        }),
+      logger.info({ batches: batches.map((b) => ({
+        length:b.length, sizeInBytes: getSizeOfObject(b)
+      }))}
+       ,
         'Sending Batches',
       );
     } else {

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -550,12 +550,16 @@ export async function uploadData<T extends UploadDataLookup, K extends keyof T>(
   type: K,
   data: T[K][],
   uploadBatchSize?: number,
-  batchSizeInBytes?: number,
+  uploadBatchSizeInBytes?: number,
 ) {
   let batches: T[K][][];
   try {
-    if (batchSizeInBytes) {
-      batches = batchGraphObjectsBySizeInBytes(data, batchSizeInBytes, logger);
+    if (uploadBatchSizeInBytes) {
+      batches = batchGraphObjectsBySizeInBytes(
+        data,
+        uploadBatchSizeInBytes,
+        logger,
+      );
     } else {
       batches = chunk(data, uploadBatchSize || DEFAULT_UPLOAD_BATCH_SIZE);
     }

--- a/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
@@ -14,7 +14,7 @@ import { IntegrationLogger } from '../logger';
 // however, we do have to consider the size of whatever aws sdk wraps
 // our payload in. In practice we have seen batches as small as 5800000
 // fail. To be completely safe, we are using 5500000 bytes as default
-const MAX_BATCH_SIZE = 5500000;
+export const MAX_BATCH_SIZE = 5500000;
 
 // TODO [INT-3707]: uncomment and use when implementing method
 // to shrink single entity's rawData until that entity is < 1MB

--- a/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
@@ -14,7 +14,7 @@ import { IntegrationLogger } from '../logger';
 // however, we do have to consider the size of whatever aws sdk wraps
 // our payload in. In practice we have seen batches as small as 5800000
 // fail. To be completely safe, we are using 5500000 bytes as default
-export const MAX_BATCH_SIZE = 5500000;
+export const MAX_BATCH_SIZE_IN_BYTES = 5_500_000;
 
 // TODO [INT-3707]: uncomment and use when implementing method
 // to shrink single entity's rawData until that entity is < 1MB
@@ -30,7 +30,7 @@ export const MAX_BATCH_SIZE = 5500000;
 export function shrinkBatchRawData(
   batchData: UploadDataLookup[keyof UploadDataLookup][],
   logger: IntegrationLogger,
-  maxBatchSize = MAX_BATCH_SIZE,
+  maxBatchSize = MAX_BATCH_SIZE_IN_BYTES,
 ): void {
   logger.info(`Attempting to shrink rawData`);
   const startTimeInMilliseconds = Date.now();


### PR DESCRIPTION
Currently we allow integrations to tune the size of the batches of entities/relationships uploaded to the persister api by setting the # of entities/relationships they’d like in each batch. Seeing as we’d like to keep our batched uploads sized  5MB  we should build our batches until they are adequately sized.

We will find that some integrations simply do not produce this much data, in which case we should upload everything for the job in single batch.

In the event that we cannot chunk by size, remove the raw data instead.

This will also prevent some UPLOAD_ERRORS or even UNEXPECTED_SYNCRONIZATION_ERROR since the batching will only allow chunks to be below 5MB.

