### PR TITLE
Fix long log message in runtime

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -284,18 +284,13 @@ export async function executeWithContext<
         data: summary,
       });
 
-      context.logger.info(
-        { collectionResult: summary },
-        'Integration data collection has completed.',
-      );
-
       processDeclaredTypesDiff(summary, (step, undeclaredTypes) => {
         if (
           step.status === StepResultStatus.SUCCESS &&
           undeclaredTypes.length
         ) {
           context.logger.error(
-            { undeclaredTypes },
+            { undeclaredTypes, stepId: step.id },
             `Undeclared types detected during execution. To prevent accidental data loss, please ensure that` +
               ` all known entity and relationship types are declared.`,
           );


### PR DESCRIPTION
This message can produce _very_ long results in collectionResult which ends up getting split into multiple log entries which are un-parsable. Most of the information in this log can be found at the step level and probably does not need to be aggregated.

The message gets split into 8 parts in AWS integration, 3 in GCP, and 4 in Azure. In each of those integrations the message is not queryable due to how it is split.
```json
{
    "name": "...",
    "hostname": "...",
    "pid": 1,
    "accountId": "...",
    "integrationInstanceId": "...",
    "integrationDefinitionId": "...",
    "source": "...",
    "integrationJobId": "...",
    "synchronizationJobId": "...",
    "level": 30,
    "collectionResult": {
        "integrationStepResults": [
            {
                "id": "create-base-aws-account",
                "name": "Create Base AWS Account",
                "dependsOn": [],
                "declaredTypes": [],
                "partialTypes": [],
                "encounteredTypes": [],
                "status": "success"
            },
            {
                "id": "create-aws-account",
                "name": "Create AWS Account",
                "dependsOn": [
                    "create-base-aws-account"
                ],
                "declaredTypes": [
                    "aws_account"
                ],
                "partialTypes": [],
                "encounteredTypes": [
                    "aws_account"
                ],
                "status": "success"
            },
            ...
        ]
    }
}
```