### PR TITLE
Remove error id from log message description

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -817,7 +817,7 @@ describe('executeStepDependencyGraph', () => {
       { err: error, errorId: expect.any(String), code: 'ABC-123' },
       expect.stringMatching(
         new RegExp(
-          `Step "a" failed to complete due to error. \\(errorCode="ABC-123", errorId="(.*)"\\)$`,
+          `Step "a" failed to complete due to error. \\(errorCode="ABC-123", reason="oopsie"\\)$`,
         ),
       ),
     );

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -554,10 +554,7 @@ describe('createErrorEventDescription', () => {
   test('supplies default reason if an error without a code is provided', () => {
     const error = new Error('soba');
 
-    const { description, errorId } = createErrorEventDescription(
-      error,
-      'testing',
-    );
+    const { description } = createErrorEventDescription(error, 'testing');
     expect(description).toEqual(
       `testing (errorCode="${UNEXPECTED_ERROR_CODE}", reason="${UNEXPECTED_ERROR_REASON}")`,
     );
@@ -566,10 +563,7 @@ describe('createErrorEventDescription', () => {
   test('displays code and message from error if error is an integration error', () => {
     const error = new IntegrationValidationError('soba');
 
-    const { description, errorId } = createErrorEventDescription(
-      error,
-      'testing',
-    );
+    const { description } = createErrorEventDescription(error, 'testing');
     expect(description).toEqual(
       `testing (errorCode="${error.code}", reason="soba")`,
     );

--- a/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
+++ b/packages/integration-sdk-runtime/src/logger/__tests__/index.test.ts
@@ -370,7 +370,7 @@ describe('step event publishing', () => {
       level: PublishEventLevel.Error,
       description: expect.stringMatching(
         new RegExp(
-          `Step "Mochi" failed to complete due to error. \\(errorCode="${error.code}", errorId="(.*)"\\)$`,
+          `Step "Mochi" failed to complete due to error. \\(errorCode="${error.code}", reason="ripperoni"\\)$`,
         ),
       ),
     });
@@ -427,7 +427,7 @@ describe('provider auth error details', () => {
           new RegExp(
             '^Step "Mochi" failed to complete due to error.' +
               PROVIDER_AUTH_ERROR_HELP +
-              ` \\(errorCode="${error.code}", errorId="[^"]*", reason="${expectedReason}"\\)$`,
+              ` \\(errorCode="${error.code}", reason="${expectedReason}"\\)$`,
           ),
         ),
       });
@@ -443,7 +443,7 @@ describe('provider auth error details', () => {
           new RegExp(
             '^Error occurred while validating integration configuration.' +
               PROVIDER_AUTH_ERROR_HELP +
-              ` \\(errorCode="${error.code}", errorId="[^"]*", reason="${expectedReason}"\\)$`,
+              ` \\(errorCode="${error.code}", reason="${expectedReason}"\\)$`,
           ),
         ),
       });
@@ -494,7 +494,7 @@ describe('validation failure logging', () => {
 
     const error = new Error('WAT?');
     const expectedDescriptionRegex = new RegExp(
-      `Error occurred while validating integration configuration. \\(errorCode="UNEXPECTED_ERROR", errorId="(.*)", reason="Unexpected error .*?"\\)$`,
+      `Error occurred while validating integration configuration. \\(errorCode="UNEXPECTED_ERROR", reason="Unexpected error .*?"\\)$`,
     );
 
     logger.validationFailure(error);
@@ -526,7 +526,7 @@ describe('validation failure logging', () => {
 
     const error = new IntegrationValidationError('Bad Mochi');
     const expectedDescriptionRegex = new RegExp(
-      `Error occurred while validating integration configuration. \\(errorCode="${error.code}", errorId="(.*)", reason="Bad Mochi"\\)$`,
+      `Error occurred while validating integration configuration. \\(errorCode="${error.code}", reason="Bad Mochi"\\)$`,
     );
 
     logger.validationFailure(error);
@@ -559,7 +559,7 @@ describe('createErrorEventDescription', () => {
       'testing',
     );
     expect(description).toEqual(
-      `testing (errorCode="${UNEXPECTED_ERROR_CODE}", errorId="${errorId}", reason="${UNEXPECTED_ERROR_REASON}")`,
+      `testing (errorCode="${UNEXPECTED_ERROR_CODE}", reason="${UNEXPECTED_ERROR_REASON}")`,
     );
   });
 
@@ -571,7 +571,7 @@ describe('createErrorEventDescription', () => {
       'testing',
     );
     expect(description).toEqual(
-      `testing (errorCode="${error.code}", errorId="${errorId}", reason="soba")`,
+      `testing (errorCode="${error.code}", reason="soba")`,
     );
   });
 });

--- a/packages/integration-sdk-runtime/src/logger/index.ts
+++ b/packages/integration-sdk-runtime/src/logger/index.ts
@@ -510,7 +510,6 @@ export function createErrorEventDescription(
 
   const nameValuePairs: NameValuePair[] = [
     ['errorCode', errorCode],
-    ['errorId', errorId],
     ['reason', errorReason],
   ];
 


### PR DESCRIPTION
Removes eventId from error description so that errors can be more easily grouped. Changes

```diff
- Step "Fetch IAM Users" failed to complete due to error. (errorCode="Throttling", errorId="2926a071-b776-4c6f-9449-c21062ecdb56", reason="Provider API failed at https://iam.amazonaws.com/?Action=GetAccessKeyLastUsed: 400 Rate exceeded")
+ Step "Fetch IAM Users" failed to complete due to error. (errorCode="Throttling", reason="Provider API failed at https://iam.amazonaws.com/?Action=GetAccessKeyLastUsed: 400 Rate exceeded")
```

The eventId will still be present on the logged payload, this just removes it from the description.