### PR TITLE
Increase Alpha default credential provider retries from 0 to 3

### DIFF
--- a/packages/integration-sdk-runtime/src/api/index.ts
+++ b/packages/integration-sdk-runtime/src/api/index.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance } from 'axios';
 import { Alpha, AlphaOptions } from '@lifeomic/alpha';
+import { isLambdaUrl } from '@lifeomic/alpha/src/utils/url';
 import { IntegrationError } from '@jupiterone/integration-sdk-core';
 import dotenv from 'dotenv';
 import dotenvExpand from 'dotenv-expand';
@@ -8,6 +9,7 @@ import {
   IntegrationAccountRequiredError,
   IntegrationApiKeyRequiredError,
 } from './error';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
 
 export type ApiClient = AxiosInstance;
 
@@ -54,6 +56,10 @@ export function createApiClient({
     headers,
     retry: retryOptions ?? {},
   };
+
+  if (isLambdaUrl(apiBaseUrl)) {
+    opts.signAwsV4 = { credentials: defaultProvider({ maxRetries: 3 }) };
+  }
 
   return new Alpha(opts) as ApiClient;
 }


### PR DESCRIPTION
Sometimes, loading AWS credentials from inside an ECS container fails and needs to be re-tried. The AWS SDK js v2 used a default of 3 retries, but the new AWS SDK js v3 uses a default of zero retries. 

The `@lifeomic/alpha` package was updated in https://github.com/JupiterOne/sdk/pull/903, and part of this update included bumping the AWS SDK version from v2 to v3 - removing default retries for these credential providers. As a result, integrations running on the SDK >v9.4.0 (including AWS, Jira, Google Workspace, and Okta) are experiencing frequent upload failures with `Could not load credentials from any provider`. In contrast, the second and third largest integrations, Google Cloud and Azure (which use an older version of the SDK), do not experience these types of upload failures.

There are four retries on `.upload()` by default, but given the amount of API calls made by the AWS integration, there are times when four retries are not enough, and steps fail. This PR restores the original behavior of 3 default retries when loading credentials from AWS. **This change only affects integrations running in ECS**.

Please read https://jptrone.slack.com/archives/G01GWQF4TGQ/p1689884102434319?thread_ts=1689880720.812569&cid=G01GWQF4TGQ for more context.

