### PR TITLE
Release 10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## 10.1.0 - 2023-08-28
+
+- 'InMemoryGraphObjectStore' no longer stores a set amount of entities or relationships, rather it works by measuring size by default. 
 
 ## 10.0.0 - 2023-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ## 10.1.0 - 2023-08-28
 
-- 'InMemoryGraphObjectStore' no longer stores a set amount of entities or relationships, rather it works by measuring size in bytes of graph objects by default. 
+- 'InMemoryGraphObjectStore' no longer stores a set amount of entities or
+  relationships, rather it works by measuring size in bytes of graph objects by
+  default.
 
 ## 10.0.0 - 2023-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 ## Unreleased
 ## 10.1.0 - 2023-08-28
 
-- 'InMemoryGraphObjectStore' no longer stores a set amount of entities or relationships, rather it works by measuring size by default. 
+- 'InMemoryGraphObjectStore' no longer stores a set amount of entities or relationships, rather it works by measuring size in bytes of graph objects by default. 
 
 ## 10.0.0 - 2023-08-03
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/integration-sdk-*",
     "packages/cli"
   ],
-  "version": "10.0.0"
+  "version": "10.1.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^10.0.0",
-    "@jupiterone/integration-sdk-runtime": "^10.0.0",
+    "@jupiterone/integration-sdk-core": "^10.1.0",
+    "@jupiterone/integration-sdk-runtime": "^10.1.0",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do yarn prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^10.0.0",
-    "@jupiterone/integration-sdk-runtime": "^10.0.0",
+    "@jupiterone/integration-sdk-core": "^10.1.0",
+    "@jupiterone/integration-sdk-runtime": "^10.1.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.54.0",
-    "@jupiterone/integration-sdk-core": "^10.0.0",
-    "@jupiterone/integration-sdk-runtime": "^10.0.0",
+    "@jupiterone/integration-sdk-core": "^10.1.0",
+    "@jupiterone/integration-sdk-runtime": "^10.1.0",
     "chalk": "^4",
     "commander": "^9.4.0",
     "fs-extra": "^10.1.0",
@@ -44,7 +44,7 @@
     "vis": "^4.21.0-EOL"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^10.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^10.1.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^10.0.0",
-    "@jupiterone/integration-sdk-testing": "^10.0.0",
+    "@jupiterone/integration-sdk-cli": "^10.1.0",
+    "@jupiterone/integration-sdk-testing": "^10.1.0",
     "@types/jest": "^29.5.3",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6.2.1",

--- a/packages/integration-sdk-entities/package.json
+++ b/packages/integration-sdk-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-entities",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Generated types for the JupiterOne data-model",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -26,8 +26,8 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^10.0.0",
-    "@jupiterone/integration-sdk-private-test-utils": "^10.0.0",
+    "@jupiterone/integration-sdk-dev-tools": "^10.1.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^10.1.0",
     "fetch-mock-jest": "^1.5.1"
   },
   "bugs": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^10.0.0",
+    "@jupiterone/integration-sdk-core": "^10.1.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^10.0.0",
+    "@jupiterone/integration-sdk-core": "^10.1.0",
     "@lifeomic/alpha": "^5.1.1",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^10.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^10.1.0",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0",
     "ts-node": "^9.1.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,8 +23,8 @@
     "prepack": "yarn build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^10.0.0",
-    "@jupiterone/integration-sdk-runtime": "^10.0.0",
+    "@jupiterone/integration-sdk-core": "^10.1.0",
+    "@jupiterone/integration-sdk-runtime": "^10.1.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^10.0.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^10.1.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
- 'InMemoryGraphObjectStore' no longer stores a set amount of entities or relationships, rather it works by measuring size in bytes of graph objects by default.