### PR TITLE
Add no pretty option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## Unreleased
 
+- Add `--noPretty` option to cli to disable pretty printing of logs locally
+
 ## 10.2.0 - 2023-09-01
 
 - Allow user to override `AlphaOptions` in `createApiClient`

--- a/docs/integrations/development.md
+++ b/docs/integrations/development.md
@@ -1459,6 +1459,10 @@ ex: `j1-integration collect --step step-fetch-users --cache-path ./my-cache`
 
 Disables schema validation.
 
+###### Option `--noPretty`
+
+Disables pretty printing of logs and collected data.
+
 #### Command `j1-integration sync`
 
 Validates data collected by the `collect` command and uploads it to JupiterOne.
@@ -1557,6 +1561,10 @@ Cannot be used with the `--development` flag.
 
 ex:
 `yarn j1-integration sync --integrationInstanceId <integration instance id> --api-base-url <api base url>`
+
+###### Option `--noPretty`
+
+Disables pretty printing of logs.
 
 #### Command `j1-integration run`
 

--- a/packages/integration-sdk-cli/src/commands/collect.ts
+++ b/packages/integration-sdk-cli/src/commands/collect.ts
@@ -11,7 +11,11 @@ import {
 
 import { loadConfig } from '../config';
 import * as log from '../log';
-import { addPathOptionsToCommand, configureRuntimeFilesystem } from './options';
+import {
+  addLoggingOptions,
+  addPathOptionsToCommand,
+  configureRuntimeFilesystem,
+} from './options';
 
 // coercion function to collect multiple values for a flag
 const collector = (value: string, arr: string[]) => {
@@ -22,6 +26,7 @@ const collector = (value: string, arr: string[]) => {
 export function collect() {
   const command = createCommand('collect');
   addPathOptionsToCommand(command);
+  addLoggingOptions(command);
 
   return command
     .description('collect data and store entities and relationships to disk')
@@ -73,7 +78,7 @@ export function collect() {
       log.info('\nConfiguration loaded! Running integration...\n');
 
       const graphObjectStore = new FileSystemGraphObjectStore({
-        prettifyFiles: true,
+        prettifyFiles: !options.noPretty,
         integrationSteps: config.integrationSteps,
       });
 
@@ -89,6 +94,7 @@ export function collect() {
         {
           enableSchemaValidation,
           graphObjectStore,
+          pretty: !options.noPretty,
         },
       );
 

--- a/packages/integration-sdk-cli/src/commands/options.ts
+++ b/packages/integration-sdk-cli/src/commands/options.ts
@@ -8,6 +8,10 @@ import {
 import { Command, Option, OptionValues } from 'commander';
 import path from 'path';
 
+export function addLoggingOptions(command: Command) {
+  return command.option('--noPretty', 'disable pretty logging', false);
+}
+
 export interface PathOptions {
   projectPath: string;
 }

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -20,6 +20,7 @@ import { loadConfig } from '../config';
 import * as log from '../log';
 import {
   addApiClientOptionsToCommand,
+  addLoggingOptions,
   addPathOptionsToCommand,
   addSyncOptionsToCommand,
   configureRuntimeFilesystem,
@@ -37,6 +38,7 @@ export function run(): Command {
   addPathOptionsToCommand(command);
   addApiClientOptionsToCommand(command);
   addSyncOptionsToCommand(command);
+  addLoggingOptions(command);
 
   return command
     .description('collect and sync to upload entities and relationships')
@@ -56,7 +58,7 @@ export function run(): Command {
 
       let logger = createIntegrationLogger({
         name: 'local',
-        pretty: true,
+        pretty: !options.noPretty,
       });
 
       const synchronizationContext = await initiateSynchronization({
@@ -81,7 +83,7 @@ export function run(): Command {
       );
 
       const graphObjectStore = new FileSystemGraphObjectStore({
-        prettifyFiles: true,
+        prettifyFiles: !options.noPretty,
         integrationSteps: invocationConfig.integrationSteps,
       });
 

--- a/packages/integration-sdk-cli/src/commands/sync.ts
+++ b/packages/integration-sdk-cli/src/commands/sync.ts
@@ -9,6 +9,7 @@ import {
 import * as log from '../log';
 import {
   addApiClientOptionsToCommand,
+  addLoggingOptions,
   addPathOptionsToCommand,
   addSyncOptionsToCommand,
   configureRuntimeFilesystem,
@@ -24,6 +25,7 @@ export function sync(): Command {
   addPathOptionsToCommand(command);
   addApiClientOptionsToCommand(command);
   addSyncOptionsToCommand(command);
+  addLoggingOptions(command);
 
   return command
     .description(
@@ -42,7 +44,7 @@ export function sync(): Command {
 
       const logger = createIntegrationLogger({
         name: 'local',
-        pretty: true,
+        pretty: !options.noPretty,
       });
 
       const syncOptions = getSyncOptions(actionCommand.opts());

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -62,6 +62,7 @@ export interface ExecuteIntegrationOptions {
   enableSchemaValidation?: boolean;
   graphObjectStore?: GraphObjectStore;
   createStepGraphObjectDataUploader?: CreateStepGraphObjectDataUploaderFunction;
+  pretty?: boolean;
 }
 
 export interface ExecuteWithContextOptions {
@@ -83,7 +84,7 @@ export async function executeIntegrationLocally(
   const logger = createIntegrationLogger({
     name: 'Local',
     invocationConfig: config,
-    pretty: true,
+    pretty: options?.pretty,
   });
   const registeredEventListeners = registerIntegrationLoggerEventHandlers(
     () => logger,


### PR DESCRIPTION
# Description

Adds a `--noPretty` option to disable pretty printing of logs when running locally
