### PR TITLE
Remove TS-Jest deprecated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to
 
 ## Unreleased
 
-- Add `--noPretty` option to cli to disable pretty printing of logs locally
+- Update `jest.js` config to remove deprecated option.
+- Add `--noPretty` option to cli to disable pretty printing of logs locally.
 
 ## 10.2.0 - 2023-09-01
 

--- a/packages/integration-sdk-dev-tools/config/jest.js
+++ b/packages/integration-sdk-dev-tools/config/jest.js
@@ -9,10 +9,13 @@ module.exports = {
     '!**/*.bak/*',
   ],
   collectCoverage: false,
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+      },
+    ],
   },
   testEnvironment: 'node',
   setupFilesAfterEnv: [


### PR DESCRIPTION
# Description
Removes depcrated way of setting ts-jest transform options. No more warnings on every test.
