### PR TITLE
Set entities and relationships to be optional in step definition

### DIFF
--- a/packages/integration-sdk-cli/src/commands/document.ts
+++ b/packages/integration-sdk-cli/src/commands/document.ts
@@ -52,10 +52,7 @@ async function executeDocumentAction(
     projectPath,
   });
 
-  if (
-    !(metadata.entities || []).length &&
-    !(metadata.relationships || []).length
-  ) {
+  if (!metadata.entities?.length && !metadata.relationships?.length) {
     log.info(
       'No entities or relationships found to generate documentation for. Exiting.',
     );
@@ -163,7 +160,7 @@ function generateGraphObjectDocumentationFromStepsMetadata(
   let relationshipSection = '';
   let mappedRelationshipSection = '';
 
-  if ((metadata.entities || []).length) {
+  if (metadata.entities?.length) {
     const generatedEntityTable = generateEntityTableFromAllStepEntityMetadata(
       metadata.entities || [],
     );
@@ -177,7 +174,7 @@ The following entities are created:
 ${generatedEntityTable}`;
   }
 
-  if ((metadata.relationships || []).length) {
+  if (metadata.relationships?.length) {
     const generatedRelationshipTable =
       generateRelationshipTableFromAllStepEntityMetadata(
         metadata.relationships || [],

--- a/packages/integration-sdk-cli/src/commands/document.ts
+++ b/packages/integration-sdk-cli/src/commands/document.ts
@@ -52,7 +52,10 @@ async function executeDocumentAction(
     projectPath,
   });
 
-  if (!metadata.entities.length && !metadata.relationships.length) {
+  if (
+    !(metadata.entities || []).length &&
+    !(metadata.relationships || []).length
+  ) {
     log.info(
       'No entities or relationships found to generate documentation for. Exiting.',
     );
@@ -160,9 +163,9 @@ function generateGraphObjectDocumentationFromStepsMetadata(
   let relationshipSection = '';
   let mappedRelationshipSection = '';
 
-  if (metadata.entities.length) {
+  if ((metadata.entities || []).length) {
     const generatedEntityTable = generateEntityTableFromAllStepEntityMetadata(
-      metadata.entities,
+      metadata.entities || [],
     );
 
     entitySection += `
@@ -174,10 +177,10 @@ The following entities are created:
 ${generatedEntityTable}`;
   }
 
-  if (metadata.relationships.length) {
+  if ((metadata.relationships || []).length) {
     const generatedRelationshipTable =
       generateRelationshipTableFromAllStepEntityMetadata(
-        metadata.relationships,
+        metadata.relationships || [],
       );
 
     relationshipSection += `

--- a/packages/integration-sdk-cli/src/commands/generate-integration-graph-schema.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-integration-graph-schema.ts
@@ -98,7 +98,7 @@ export function generateIntegrationGraphSchema(
   ): IntegrationGraphSchemaEntityMetadata[] {
     const entities: IntegrationGraphSchemaEntityMetadata[] = [];
 
-    for (const entityMetadata of stepEntityMetadata) {
+    for (const entityMetadata of stepEntityMetadata || []) {
       const entitySchemaKey = getEntitySchemaKey(entityMetadata);
 
       if (uniqueEntitySchemaSet.has(entitySchemaKey)) continue;
@@ -115,7 +115,7 @@ export function generateIntegrationGraphSchema(
   ) {
     const relationships: IntegrationGraphSchemaRelationshipMetadata[] = [];
 
-    for (const relationshipMetadata of stepRelationshipMetadata) {
+    for (const relationshipMetadata of stepRelationshipMetadata || []) {
       const relationshipSchemaKey =
         getRelationshipSchemaKey(relationshipMetadata);
 
@@ -157,13 +157,13 @@ export function generateIntegrationGraphSchema(
 
   for (const step of integrationSteps) {
     integrationGraphSchema.entities = integrationGraphSchema.entities.concat(
-      getIntegrationGraphSchemaEntityMetadataForStep(step.entities),
+      getIntegrationGraphSchemaEntityMetadataForStep(step.entities || []),
     );
 
     integrationGraphSchema.relationships =
       integrationGraphSchema.relationships.concat(
         getIntegrationGraphSchemaRelationshipMetadataForStep(
-          step.relationships,
+          step.relationships || [],
         ),
       );
 

--- a/packages/integration-sdk-cli/src/commands/visualize-types.ts
+++ b/packages/integration-sdk-cli/src/commands/visualize-types.ts
@@ -82,7 +82,10 @@ async function executeVisualizeTypesAction(
     projectPath,
   });
 
-  if (!metadata.entities.length && !metadata.relationships.length) {
+  if (
+    !(metadata.entities || []).length &&
+    !(metadata.relationships || []).length
+  ) {
     log.info(
       'No entities or relationships found to generate types graph for. Exiting.',
     );
@@ -133,7 +136,7 @@ export function getNodesAndEdgesFromStepMetadata(
   },
 ): { nodes: Node[]; edges: Edge[] } {
   const relationshipEdges = getEdgesFromStepRelationshipMetadata(
-    metadata.relationships,
+    metadata.relationships || [],
     {
       types: options?.types,
     },
@@ -145,7 +148,7 @@ export function getNodesAndEdgesFromStepMetadata(
         types: options?.types,
       },
     );
-  const entityNodes = getNodesFromStepEntityMetadata(metadata.entities, {
+  const entityNodes = getNodesFromStepEntityMetadata(metadata.entities || [], {
     types: options?.types,
     edges: [...relationshipEdges, ...mappedRelationshipEdges],
   });

--- a/packages/integration-sdk-cli/src/commands/visualize-types.ts
+++ b/packages/integration-sdk-cli/src/commands/visualize-types.ts
@@ -82,10 +82,7 @@ async function executeVisualizeTypesAction(
     projectPath,
   });
 
-  if (
-    !(metadata.entities || []).length &&
-    !(metadata.relationships || []).length
-  ) {
+  if (!metadata.entities?.length && !metadata.relationships?.length) {
     log.info(
       'No entities or relationships found to generate types graph for. Exiting.',
     );

--- a/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
+++ b/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
@@ -69,10 +69,10 @@ function alphabetizeMetadataProperties(
   metadata: StepGraphObjectMetadataProperties,
 ): StepGraphObjectMetadataProperties {
   return {
-    entities: metadata.entities.sort(
+    entities: metadata.entities?.sort(
       alphabetizeEntityMetadataPropertyByTypeCompareFn,
     ),
-    relationships: metadata.relationships.sort(
+    relationships: metadata.relationships?.sort(
       alphabetizeRelationshipMetadataPropertyByTypeCompareFn,
     ),
     mappedRelationships: metadata.mappedRelationships?.sort(
@@ -102,7 +102,7 @@ export function collectGraphObjectMetadataFromSteps(
       IntegrationStepExecutionContext<object>
     >;
 
-    for (const e of step.entities) {
+    for (const e of step.entities || []) {
       if (entityTypeSet.has(e._type)) {
         continue;
       }
@@ -111,7 +111,7 @@ export function collectGraphObjectMetadataFromSteps(
       entities.push(e);
     }
 
-    for (const r of step.relationships) {
+    for (const r of step.relationships || []) {
       const relationshipSetValue = toRelationshipSetValue(r);
 
       if (relationshipTypeSet.has(relationshipSetValue)) {

--- a/packages/integration-sdk-core/src/types/step.ts
+++ b/packages/integration-sdk-core/src/types/step.ts
@@ -180,13 +180,13 @@ export interface StepGraphObjectMetadataProperties {
    * Metadata about the entities ingested in this integration step. This is
    * used to generate documentation.
    */
-  entities: StepEntityMetadata[];
+  entities?: StepEntityMetadata[];
 
   /**
    * Metadata about the relationships ingested in this integration step. This is
    * used to generate documentation.
    */
-  relationships: StepRelationshipMetadata[];
+  relationships?: StepRelationshipMetadata[];
 
   /**
    * Metadata about any mapped relationships ingested in this integration step. This is

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -603,8 +603,8 @@ export function getDeclaredTypesInStep<
   const partialTypes: string[] = [];
 
   [
-    ...step.entities,
-    ...step.relationships,
+    ...(step.entities || []),
+    ...(step.relationships || []),
     ...(step.mappedRelationships || []),
   ].map((e) => {
     declaredTypes.push(e._type);

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -91,7 +91,7 @@ function integrationStepsToGraphObjectIndexMetadataMap(
       relationships: new Map(),
     };
 
-    for (const entityMetadata of step.entities) {
+    for (const entityMetadata of step.entities || []) {
       if (entityMetadata.indexMetadata) {
         metadataMap.entities.set(
           entityMetadata._type,
@@ -100,7 +100,7 @@ function integrationStepsToGraphObjectIndexMetadataMap(
       }
     }
 
-    for (const relationshipMetadata of step.relationships) {
+    for (const relationshipMetadata of step.relationships || []) {
       if (relationshipMetadata.indexMetadata) {
         metadataMap.relationships.set(
           relationshipMetadata._type,

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -697,7 +697,7 @@ export function toMatchStepMetadata(
     restEntities = rest;
   }
   if (restEntities.length > 0) {
-    const declaredTypes = (step.entities || []).map((e) => e._type);
+    const declaredTypes = step.entities?.map((e) => e._type);
     const encounteredTypes = [
       ...new Set(results.collectedEntities.map((e) => e._type)),
     ];
@@ -739,7 +739,7 @@ export function toMatchStepMetadata(
     restDirectRelationships = rest;
   }
   if (restDirectRelationships.length > 0) {
-    const declaredTypes = (step.relationships || []).map((r) => r._type);
+    const declaredTypes = step.relationships?.map((r) => r._type);
     const encounteredTypes = [
       ...new Set(
         results.collectedRelationships

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -675,7 +675,7 @@ export function toMatchStepMetadata(
   const step = stepDependencyGraph.getNodeData(stepId);
 
   let restEntities = results.collectedEntities;
-  for (const entityMetadata of step.entities) {
+  for (const entityMetadata of step.entities || []) {
     const { targets, rest } = filterGraphObjects(
       restEntities,
       (e) => e._type === entityMetadata._type,
@@ -697,7 +697,7 @@ export function toMatchStepMetadata(
     restEntities = rest;
   }
   if (restEntities.length > 0) {
-    const declaredTypes = step.entities.map((e) => e._type);
+    const declaredTypes = (step.entities || []).map((e) => e._type);
     const encounteredTypes = [
       ...new Set(results.collectedEntities.map((e) => e._type)),
     ];
@@ -714,7 +714,7 @@ export function toMatchStepMetadata(
   } = filterGraphObjects(results.collectedRelationships, isMappedRelationship);
 
   let restDirectRelationships = collectedDirectRelationships;
-  for (const relationshipMetadata of step.relationships) {
+  for (const relationshipMetadata of step.relationships || []) {
     const { targets, rest } = filterGraphObjects(
       restDirectRelationships,
       (r) => r._type === relationshipMetadata._type,
@@ -739,7 +739,7 @@ export function toMatchStepMetadata(
     restDirectRelationships = rest;
   }
   if (restDirectRelationships.length > 0) {
-    const declaredTypes = step.relationships.map((r) => r._type);
+    const declaredTypes = (step.relationships || []).map((r) => r._type);
     const encounteredTypes = [
       ...new Set(
         results.collectedRelationships


### PR DESCRIPTION
Some steps don't generate entities or relationships, we shouldn't enforce to declare them.
We already do this with mappedRelationships.