### PR TITLE
Remove unused batch size (count) parameters

### DIFF
--- a/packages/integration-sdk-cli/src/__tests__/options.test.ts
+++ b/packages/integration-sdk-cli/src/__tests__/options.test.ts
@@ -9,15 +9,12 @@ import {
   validateSyncOptions,
 } from '../commands/options';
 import {
-  DEFAULT_UPLOAD_BATCH_SIZE,
   JUPITERONE_DEV_API_BASE_URL,
   JUPITERONE_PROD_API_BASE_URL,
 } from '@jupiterone/integration-sdk-runtime';
 
 const syncOptions = (values?: Partial<SyncOptions>): SyncOptions => ({
   source: 'integration-managed',
-  uploadBatchSize: DEFAULT_UPLOAD_BATCH_SIZE,
-  uploadRelationshipBatchSize: DEFAULT_UPLOAD_BATCH_SIZE,
   skipFinalize: false,
   ...values,
 });

--- a/packages/integration-sdk-cli/src/commands/options.ts
+++ b/packages/integration-sdk-cli/src/commands/options.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_UPLOAD_BATCH_SIZE,
   getAccountFromEnvironment,
   getApiKeyFromEnvironment,
   JUPITERONE_DEV_API_BASE_URL,
@@ -39,8 +38,6 @@ export interface SyncOptions {
   source: 'integration-managed' | 'integration-external' | 'api';
   scope?: string | undefined;
   integrationInstanceId?: string | undefined;
-  uploadBatchSize: number;
-  uploadRelationshipBatchSize: number;
   skipFinalize: boolean;
 }
 
@@ -69,18 +66,6 @@ export function addSyncOptionsToCommand(command: Command): Command {
       'integration-managed',
     )
     .option('--scope <anystring>', 'specify synchronization job scope value')
-    .option(
-      '-u, --upload-batch-size <number>',
-      'specify number of entities and relationships per upload batch',
-      (value, _previous: Number) => Number(value),
-      DEFAULT_UPLOAD_BATCH_SIZE,
-    )
-    .option(
-      '-ur, --upload-relationship-batch-size <number>',
-      'specify number of relationships per upload batch, overrides --upload-batch-size',
-      (value, _previous: Number) => Number(value),
-      DEFAULT_UPLOAD_BATCH_SIZE,
-    )
     .option(
       '--skip-finalize',
       'skip synchronization finalization to leave job open for additional uploads',
@@ -127,8 +112,6 @@ export function getSyncOptions(options: OptionValues): SyncOptions {
     source: options.source,
     scope: options.scope,
     integrationInstanceId: options.integrationInstanceId,
-    uploadBatchSize: options.uploadBatchSize,
-    uploadRelationshipBatchSize: options.uploadRelationshipBatchSize,
     skipFinalize: options.skipFinalize,
   };
 }

--- a/packages/integration-sdk-cli/src/commands/run.ts
+++ b/packages/integration-sdk-cli/src/commands/run.ts
@@ -109,9 +109,6 @@ export function run(): Command {
                 stepId,
                 synchronizationJobContext: synchronizationContext,
                 uploadConcurrency: DEFAULT_UPLOAD_CONCURRENCY,
-                uploadBatchSize: options.uploadBatchSize,
-                uploadRelationshipsBatchSize:
-                  options.uploadRelationshipBatchSize,
               });
             },
           },

--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -133,8 +133,6 @@ export interface CreatePersisterApiStepGraphObjectDataUploaderParams {
   stepId: string;
   synchronizationJobContext: SynchronizationJobContext;
   uploadConcurrency: number;
-  uploadBatchSize?: number;
-  uploadRelationshipsBatchSize?: number;
   uploadBatchSizeInBytes?: number;
 }
 
@@ -142,8 +140,6 @@ export function createPersisterApiStepGraphObjectDataUploader({
   stepId,
   synchronizationJobContext,
   uploadConcurrency,
-  uploadBatchSize,
-  uploadRelationshipsBatchSize,
   uploadBatchSizeInBytes,
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
   if (
@@ -166,8 +162,6 @@ export function createPersisterApiStepGraphObjectDataUploader({
         await uploadGraphObjectData(
           context,
           graphObjectData,
-          uploadBatchSize,
-          uploadRelationshipsBatchSize,
           uploadBatchSizeInBytes,
         );
       } catch (err) {
@@ -175,8 +169,7 @@ export function createPersisterApiStepGraphObjectDataUploader({
           {
             err,
             uploadConcurrency,
-            uploadBatchSize,
-            uploadRelationshipsBatchSize,
+            uploadBatchSizeInBytes,
           },
           'Error uploading graph object data',
         );

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/batchSize.test.ts
@@ -57,8 +57,6 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
     await uploadGraphObjectData(
       synchronizationJobContext,
       flushedObjectData,
-      5,
-      10,
       350, //bytes
     );
 
@@ -129,8 +127,6 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
       await uploadGraphObjectData(
         synchronizationJobContext,
         flushedObjectData,
-        250,
-        250,
         bytesToBatch,
       );
 
@@ -171,8 +167,6 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
     await uploadGraphObjectData(
       synchronizationJobContext,
       bigObjectData,
-      250,
-      250,
       bytesToBatch,
     );
 
@@ -238,8 +232,6 @@ describe('#createPersisterApiStepGraphObjectDataUploader', () => {
     await uploadGraphObjectData(
       synchronizationJobContext,
       bigObjectData,
-      250,
-      250,
       bytesToBatch,
     );
 


### PR DESCRIPTION
The `uploadBatchSize` and `uploadRelationshipsBatchSize` parameters are entirely unused, because they're piped down all the way to `uploadData` where the parameter is unused and instead it uses `uploadBatchSizeInBytes` instead (the last two lines in this PR).

This will be released in a major version update due to it being a breaking change to the interfaces/CLI commands.