### PR TITLE
[CORE-3497] remove hard cap on upload batch size in bytes

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/uploader.ts
+++ b/packages/integration-sdk-runtime/src/execution/uploader.ts
@@ -4,9 +4,9 @@ import { FlushedGraphObjectData } from '../storage/types';
 import {
   uploadGraphObjectData,
   SynchronizationJobContext,
+  DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES,
 } from '../synchronization';
 import { randomUUID as uuid } from 'crypto';
-import { MAX_BATCH_SIZE_IN_BYTES } from '../synchronization/shrinkBatchRawData';
 
 export interface StepGraphObjectDataUploader {
   stepId: string;
@@ -140,14 +140,8 @@ export function createPersisterApiStepGraphObjectDataUploader({
   stepId,
   synchronizationJobContext,
   uploadConcurrency,
-  uploadBatchSizeInBytes,
+  uploadBatchSizeInBytes = DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES,
 }: CreatePersisterApiStepGraphObjectDataUploaderParams) {
-  if (
-    uploadBatchSizeInBytes &&
-    uploadBatchSizeInBytes > MAX_BATCH_SIZE_IN_BYTES
-  ) {
-    uploadBatchSizeInBytes = MAX_BATCH_SIZE_IN_BYTES;
-  }
   return createQueuedStepGraphObjectDataUploader({
     stepId,
     uploadConcurrency,

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -23,13 +23,14 @@ import { FlushedEntityData } from '../types';
 import { getRootStorageAbsolutePath } from '../../fileSystem';
 import { BigMap } from '../../execution/utils/bigMap';
 import { chunk, min } from 'lodash';
+import { DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES } from '../../synchronization';
 
 export const DEFAULT_GRAPH_OBJECT_BUFFER_THRESHOLD = 500;
 export const DEFAULT_GRAPH_OBJECT_FILE_SIZE = 500;
 
-export const DEFAULT_GRAPH_OBJECT_BUFFER_THRESHOLD_IN_BYTES = 5_000_000;
-// no more than 10^9 bytes
-export const MAX_GRAPH_OBJECT_BUFFER_THRESHOLD_IN_BYTES = 1_000_000_000;
+// no more than 2^30 bytes (1GB)
+export const MAX_GRAPH_OBJECT_BUFFER_THRESHOLD_IN_BYTES =
+  1_073_741_824 as const;
 
 // it is important that this value is set to 1
 // to ensure that only one operation can be performed at a time.
@@ -153,7 +154,7 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
     this.prettifyFiles = params?.prettifyFiles || false;
     this.graphObjectBufferThresholdInBytes = min([
       params?.graphObjectBufferThresholdInBytes ||
-        DEFAULT_GRAPH_OBJECT_BUFFER_THRESHOLD_IN_BYTES,
+        DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES,
       MAX_GRAPH_OBJECT_BUFFER_THRESHOLD_IN_BYTES,
     ])!;
     if (params?.integrationSteps) {

--- a/packages/integration-sdk-runtime/src/synchronization/__tests__/shrinkBatchRawData.test.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/__tests__/shrinkBatchRawData.test.ts
@@ -5,6 +5,7 @@ import {
 import { restoreProjectStructure } from '@jupiterone/integration-sdk-private-test-utils';
 import { createIntegrationLogger } from '../../logger';
 import { shrinkBatchRawData } from '../shrinkBatchRawData';
+import { DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES } from '..';
 
 describe('shrinkBatchRawData', () => {
   const logger = createIntegrationLogger({
@@ -20,7 +21,7 @@ describe('shrinkBatchRawData', () => {
   });
 
   it('should shrink rawData until batch size is < 6 million bytes', () => {
-    const largeData = new Array(500000).join('aaaaaaaaaa');
+    const largeData = new Array(450000).join('aaaaaaaaaa');
     const data = [
       {
         _class: 'test',
@@ -123,7 +124,7 @@ describe('shrinkBatchRawData', () => {
       },
     ];
 
-    shrinkBatchRawData(data, logger);
+    shrinkBatchRawData(data, logger, DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES);
     expect(logger.info).toBeCalledTimes(2);
     expect(logger.info).toHaveBeenNthCalledWith(
       1,
@@ -191,7 +192,7 @@ describe('shrinkBatchRawData', () => {
       },
     ];
     try {
-      shrinkBatchRawData(data, logger);
+      shrinkBatchRawData(data, logger, DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES);
       throw new Error('this was not supposed to happen');
     } catch (err) {
       expect(err).toBeInstanceOf(IntegrationError);
@@ -301,7 +302,7 @@ describe('shrinkBatchRawData', () => {
       },
     ];
     try {
-      shrinkBatchRawData(data, logger);
+      shrinkBatchRawData(data, logger, DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES);
       shrinkBatchRawDataSucceeded = true;
     } catch (err) {
       expect(err).toBeInstanceOf(IntegrationError);

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -435,8 +435,7 @@ function handleUploadDataChunkError({
   );
 
   if (isRequestUploadTooLargeError(err)) {
-    // shrink rawData further to try and achieve a batch size of < 6MB
-    shrinkBatchRawData(batch, logger);
+    shrinkBatchRawData(batch, logger, DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES);
   } else if (systemErrorResponseData?.code === 'JOB_NOT_AWAITING_UPLOADS') {
     throw new IntegrationError({
       code: 'INTEGRATION_UPLOAD_AFTER_JOB_ENDED',

--- a/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/shrinkBatchRawData.ts
@@ -7,15 +7,6 @@ import {
 import { UploadDataLookup } from '.';
 import { IntegrationLogger } from '../logger';
 
-// Uploads above 6 MiB will fail.  This is technically
-// 6144000 bytes, but we need header space.  Most web
-// servers will only allow 8KB or 16KB as a max header
-// size, so 6144000 - 16384 = 6127616 bytes
-// however, we do have to consider the size of whatever aws sdk wraps
-// our payload in. In practice we have seen batches as small as 5800000
-// fail. To be completely safe, we are using 5500000 bytes as default
-export const MAX_BATCH_SIZE_IN_BYTES = 5_500_000;
-
 // TODO [INT-3707]: uncomment and use when implementing method
 // to shrink single entity's rawData until that entity is < 1MB
 
@@ -30,7 +21,7 @@ export const MAX_BATCH_SIZE_IN_BYTES = 5_500_000;
 export function shrinkBatchRawData(
   batchData: UploadDataLookup[keyof UploadDataLookup][],
   logger: IntegrationLogger,
-  maxBatchSize = MAX_BATCH_SIZE_IN_BYTES,
+  maxBatchSize: number,
 ): void {
   logger.info(`Attempting to shrink rawData`);
   const startTimeInMilliseconds = Date.now();


### PR DESCRIPTION
With this, we can send through larger batch sizes from jupiter-managed-integration. First one targeted will be AWS via numeric feature toggle - https://app.launchdarkly.com/integrations/production/features/integration-aws-upload-batch-size-bytes/targeting