### PR TITLE
Improved Relationship Metadata Sorting

### DIFF
--- a/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.test.ts
+++ b/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.test.ts
@@ -6,8 +6,11 @@ import {
   StepMappedRelationshipMetadata,
   StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
-import { collectGraphObjectMetadataFromSteps } from './getSortedJupiterOneTypes';
 import { randomUUID as uuid } from 'crypto';
+import {
+  alphabetizeMetadataProperties,
+  collectGraphObjectMetadataFromSteps,
+} from './getSortedJupiterOneTypes';
 
 function createIntegrationStep({
   entities = [],
@@ -212,5 +215,65 @@ describe('collectGraphObjectMetadataFromSteps', () => {
 
       expect(metadata.mappedRelationships).toEqual([r1, r2]);
     });
+  });
+});
+
+describe('alphabetizeMetadataProperties', () => {
+  it('should correctly sort an array of StepRelationshipMetadata', () => {
+    const { relationships } = alphabetizeMetadataProperties(
+      collectGraphObjectMetadataFromSteps([
+        createIntegrationStep({
+          relationships: [
+            {
+              _type: 'aws_account_has_service',
+              sourceType: 'aws_account',
+              _class: RelationshipClass.HAS,
+              targetType: 'aws_waf',
+            },
+          ],
+        }),
+        createIntegrationStep({
+          relationships: [
+            {
+              _type: 'aws_account_owns_service',
+              sourceType: 'aws_account',
+              _class: RelationshipClass.OWNS,
+              targetType: 'aws_apigateway',
+            },
+          ],
+        }),
+        createIntegrationStep({
+          relationships: [
+            {
+              _type: 'aws_account_has_service',
+              sourceType: 'aws_account',
+              _class: RelationshipClass.HAS,
+              targetType: 'aws_apigateway',
+            },
+          ],
+        }),
+      ]),
+    );
+
+    expect(relationships).toEqual([
+      {
+        _type: 'aws_account_has_service',
+        sourceType: 'aws_account',
+        _class: 'HAS',
+        targetType: 'aws_apigateway',
+      },
+      {
+        _type: 'aws_account_owns_service',
+        sourceType: 'aws_account',
+        _class: 'OWNS',
+        targetType: 'aws_apigateway',
+      },
+      {
+        _type: 'aws_account_has_service',
+        sourceType: 'aws_account',
+        _class: 'HAS',
+        targetType: 'aws_waf',
+      },
+    ]);
   });
 });

--- a/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
+++ b/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
@@ -1,14 +1,14 @@
-import { loadConfig } from '../config';
-import * as path from 'path';
-import { buildStepDependencyGraph } from '@jupiterone/integration-sdk-runtime';
 import {
   IntegrationStepExecutionContext,
   Step,
-  StepGraphObjectMetadataProperties,
   StepEntityMetadata,
-  StepRelationshipMetadata,
+  StepGraphObjectMetadataProperties,
   StepMappedRelationshipMetadata,
+  StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
+import { buildStepDependencyGraph } from '@jupiterone/integration-sdk-runtime';
+import * as path from 'path';
+import { loadConfig } from '../config';
 
 export interface TypesCommandArgs {
   projectPath: string;
@@ -60,12 +60,19 @@ function alphabetizeRelationshipMetadataPropertyByTypeCompareFn(
   a: StepRelationshipMetadata,
   b: StepRelationshipMetadata,
 ): number {
-  if (a._type > b._type) return 1;
-  if (a._type < b._type) return -1;
+  if (a.sourceType > b.sourceType) return 1;
+  if (a.sourceType < b.sourceType) return -1;
+
+  if (a.targetType > b.targetType) return 1;
+  if (a.targetType < b.targetType) return -1;
+
+  if (a._class > b._class) return 1;
+  if (a._class < b._class) return -1;
+
   return 0;
 }
 
-function alphabetizeMetadataProperties(
+export function alphabetizeMetadataProperties(
   metadata: StepGraphObjectMetadataProperties,
 ): StepGraphObjectMetadataProperties {
   return {

--- a/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
+++ b/packages/integration-sdk-cli/src/utils/getSortedJupiterOneTypes.ts
@@ -57,8 +57,8 @@ function alphabetizeEntityMetadataPropertyByTypeCompareFn(
 }
 
 function alphabetizeRelationshipMetadataPropertyByTypeCompareFn(
-  a: StepRelationshipMetadata,
-  b: StepRelationshipMetadata,
+  a: StepRelationshipMetadata | StepMappedRelationshipMetadata,
+  b: StepRelationshipMetadata | StepMappedRelationshipMetadata,
 ): number {
   if (a.sourceType > b.sourceType) return 1;
   if (a.sourceType < b.sourceType) return -1;
@@ -69,6 +69,10 @@ function alphabetizeRelationshipMetadataPropertyByTypeCompareFn(
   if (a._class > b._class) return 1;
   if (a._class < b._class) return -1;
 
+  if ('direction' in a && 'direction' in b) {
+    if (a.direction > b.direction) return 1;
+    if (a.direction < b.direction) return -1;
+  }
   return 0;
 }
 


### PR DESCRIPTION
- Modified the sorting function for StepRelationshipMetadata.
- Now sorts accurately based on `sourceType`, `targetType`, and `_class`, ensuring proper organization and retrieval of relationship metadata.

Before: `aws_account HAS aws_waf` was coming before `aws_account HAS aws_apigateway`.
After: Entries are sorted properly, ensuring `aws_account HAS aws_apigateway` is positioned before `aws_account HAS aws_waf`, respecting the alphabetical order of `targetType`.
Support is also added for mapped relationships.

Example in graph-aws

```diff
258a259
> | `aws_accessanalyzer`                        | **HAS**               | `aws_accessanalyzer_analyzer`               |
261,262d261
< | `aws_accessanalyzer`                        | **HAS**               | `aws_accessanalyzer_analyzer`               |
< | `aws_account`                               | **HAS**               | `aws_iam`                                   |
263a263
> | `aws_account`                               | **HAS**               | `aws_acm`                                   |
265c265
< | `aws_account`                               | **HAS**               | `aws_lambda`                                |
---
> | `aws_account`                               | **HAS**               | `aws_athena`                                |
267c267
< | `aws_account`                               | **HAS**               | `aws_ec2`                                   |
---
> | `aws_account`                               | **HAS**               | `aws_autoscalingplans`                      |
270d269
< | `aws_account`                               | **HAS**               | `aws_ecs`                                   |
272,275d270
< | `aws_account`                               | **HAS**               | `aws_cloudwatch_logs`                       |
< | `aws_account`                               | **HAS**               | `aws_kms`                                   |
< | `aws_account`                               | **HAS**               | `aws_cloudwatch_events`                     |
< | `aws_account`                               | **HAS**               | `aws_cloudhsm`                              |
277,279c272
< | `aws_account`                               | **HAS**               | `aws_s3`                                    |
< | `aws_account`                               | **HAS**               | `aws_elasticloadbalancing`                  |
< | `aws_account`                               | **HAS**               | `aws_cloudwatch`                            |
---
> | `aws_account`                               | **HAS**               | `aws_cloudhsm`                              |
281c274,276
< | `aws_account`                               | **HAS**               | `aws_dynamodb`                              |
---
> | `aws_account`                               | **HAS**               | `aws_cloudwatch`                            |
> | `aws_account`                               | **HAS**               | `aws_cloudwatch_events`                     |
> | `aws_account`                               | **HAS**               | `aws_cloudwatch_logs`                       |
286d280
< | `aws_account`                               | **HAS**               | `aws_rds`                                   |
289,291c283,285
< | `aws_account`                               | **HAS**               | `aws_eks`                                   |
< | `aws_account`                               | **HAS**               | `aws_es`                                    |
< | `aws_account`                               | **HAS**               | `aws_elasticache`                           |
---
> | `aws_account`                               | **HAS**               | `aws_dynamodb`                              |
> | `aws_account`                               | **HAS**               | `aws_ec2`                                   |
> | `aws_account`                               | **HAS**               | `aws_ec2_vpc`                               |
292a287
> | `aws_account`                               | **HAS**               | `aws_ecs`                                   |
294c289,291
< | `aws_account`                               | **HAS**               | `aws_acm`                                   |
---
> | `aws_account`                               | **HAS**               | `aws_eks`                                   |
> | `aws_account`                               | **HAS**               | `aws_elasticache`                           |
> | `aws_account`                               | **HAS**               | `aws_elasticloadbalancing`                  |
296c293
< | `aws_account`                               | **HAS**               | `aws_fms`                                   |
---
> | `aws_account`                               | **HAS**               | `aws_es`                                    |
298c295
< | `aws_account`                               | **HAS**               | `aws_kinesis`                               |
---
> | `aws_account`                               | **HAS**               | `aws_fms`                                   |
300d296
< | `aws_account`                               | **HAS**               | `aws_glue`                                  |
301a298
> | `aws_account`                               | **HAS**               | `aws_glue`                                  |
302a300
> | `aws_account`                               | **HAS**               | `aws_iam`                                   |
304a303,305
> | `aws_account`                               | **HAS**               | `aws_kinesis`                               |
> | `aws_account`                               | **HAS**               | `aws_kms`                                   |
> | `aws_account`                               | **HAS**               | `aws_lambda`                                |
308c309
< | `aws_account`                               | **HAS**               | `aws_secretsmanager`                        |
---
> | `aws_account`                               | **HAS**               | `aws_rds`                                   |
312,314c313,314
< | `aws_account`                               | **HAS**               | `aws_sqs`                                   |
< | `aws_account`                               | **HAS**               | `aws_sns`                                   |
< | `aws_account`                               | **HAS**               | `aws_shield`                                |
---
> | `aws_account`                               | **HAS**               | `aws_s3`                                    |
> | `aws_account`                               | **HAS**               | `aws_secretsmanager`                        |
315a316,318
> | `aws_account`                               | **HAS**               | `aws_shield`                                |
> | `aws_account`                               | **HAS**               | `aws_sns`                                   |
> | `aws_account`                               | **HAS**               | `aws_sqs`                                   |
316a320
> | `aws_account`                               | **HAS**               | `aws_states`                                |
321,324d324
< | `aws_account`                               | **HAS**               | `aws_athena`                                |
< | `aws_account`                               | **HAS**               | `aws_autoscalingplans`                      |
< | `aws_account`                               | **HAS**               | `aws_states`                                |
< | `aws_account`                               | **HAS**               | `aws_ec2_vpc`                               |
325a326,329
> | `aws_alb`                                   | **USES**              | `aws_eni`                                   |
> | `aws_alb`                                   | **HAS**               | `aws_lb_listener`                           |
> | `aws_alb`                                   | **CONNECTS**          | `aws_lb_target_group`                       |
> | `aws_alb`                                   | **HAS**               | `aws_security_group`                        |
327a332
> | `aws_api_gateway_rest_api`                  | **USES**              | `aws_api_gateway_domain_name`               |
330,331c335
< | `aws_api_gateway_rest_api`                  | **USES**              | `aws_api_gateway_domain_name`               |
< | `aws_api_gateway_v2_api`                    | **HAS**               | `aws_api_gateway_v2_route`                  |
---
> | `aws_api_gateway_rest_api`                  | **TRIGGERS**          | `aws_lambda_function`                       |
332a337
> | `aws_api_gateway_v2_api`                    | **HAS**               | `aws_api_gateway_v2_route`                  |
340,344d344
< | `aws_api_gateway_rest_api`                  | **TRIGGERS**          | `aws_lambda_function`                       |
< | `aws_autoscaling_group`                     | **HAS**               | `aws_instance`                              |
< | `aws_autoscaling_group`                     | **USES**              | `aws_autoscaling_launch_configuration`      |
< | `aws_autoscaling_group`                     | **USES**              | `aws_launch_template`                       |
< | `aws_autoscaling_group`                     | **USES**              | `aws_autoscaling_policy`                    |
346a347,350
> | `aws_autoscaling_group`                     | **USES**              | `aws_autoscaling_launch_configuration`      |
> | `aws_autoscaling_group`                     | **USES**              | `aws_autoscaling_policy`                    |
> | `aws_autoscaling_group`                     | **HAS**               | `aws_instance`                              |
> | `aws_autoscaling_group`                     | **USES**              | `aws_launch_template`                       |
349,350d352
< | `aws_iam_role`                              | **ASSIGNED**          | `aws_batch_compute_environment`             |
< | `aws_batch_compute_environment`             | **USES**              | `aws_iam_role`                              |
353d354
< | `aws_batch_job_queue`                       | **HAS**               | `aws_batch_job`                             |
354a356,358
> | `aws_batch_compute_environment`             | **USES**              | `aws_iam_role`                              |
> | `aws_batch_compute_environment`             | **HAS**               | `aws_security_group`                        |
> | `aws_batch_job_queue`                       | **HAS**               | `aws_batch_job`                             |
355a360
> | `aws_cloudfront`                            | **HAS**               | `aws_cloudfront_distribution`               |
357d361
< | `aws_cloudfront_distribution`               | **CONNECTS**          | `aws_elb`                                   |
358a363
> | `aws_cloudfront_distribution`               | **CONNECTS**          | `aws_elb`                                   |
360c365
< | `aws_cloudfront`                            | **HAS**               | `aws_cloudfront_distribution`               |
---
> | `aws_cloudhsm`                              | **HAS**               | `aws_cloudhsm_cluster`                      |
363c368,369
< | `aws_cloudhsm`                              | **HAS**               | `aws_cloudhsm_cluster`                      |
---
> | `aws_cloudhsm_cluster`                      | **HAS**               | `aws_security_group`                        |
> | `aws_cloudhsm_instance`                     | **HAS**               | `aws_security_group`                        |
366c372
< | `aws_cloudwatch_logs`                       | **HAS**               | `aws_cloudwatch_log_group`                  |
---
> | `aws_cloudwatch_log_group`                  | **USES**              | `aws_kms_key`                               |
367a374
> | `aws_cloudwatch_logs`                       | **HAS**               | `aws_cloudwatch_log_group`                  |
372d378
< | `aws_config_rule`                           | **EVALUATES**         | `aws_resource`                              |
374c380
< | `aws_rds_cluster`                           | **HAS**               | `aws_db_cluster_snapshot`                   |
---
> | `aws_config_rule`                           | **EVALUATES**         | `aws_resource`                              |
376d381
< | `aws_db_instance`                           | **HAS**               | `aws_db_snapshot`                           |
378c383,384
< | `aws_db_instance`                           | **USES**              | `aws_secret`                                |
---
> | `aws_db_instance`                           | **USES**              | `aws_db_parameter_group`                    |
> | `aws_db_instance`                           | **HAS**               | `aws_db_snapshot`                           |
379a386,388
> | `aws_db_instance`                           | **USES**              | `aws_kms_key`                               |
> | `aws_db_instance`                           | **USES**              | `aws_secret`                                |
> | `aws_db_instance`                           | **HAS**               | `aws_security_group`                        |
381,383d389
< | `aws_db_proxy_target`                       | **CONNECTS**          | `aws_db_instance`                           |
< | `aws_db_proxy_target`                       | **CONNECTS**          | `aws_rds_cluster`                           |
< | `aws_db_proxy_target_group`                 | **HAS**               | `aws_db_proxy_target`                       |
387a394,396
> | `aws_db_proxy_target`                       | **CONNECTS**          | `aws_db_instance`                           |
> | `aws_db_proxy_target`                       | **CONNECTS**          | `aws_rds_cluster`                           |
> | `aws_db_proxy_target_group`                 | **HAS**               | `aws_db_proxy_target`                       |
389a399
> | `aws_detector`                              | **IDENTIFIED**        | `aws_finding`                               |
392d401
< | `aws_directconnect`                         | **HAS**               | `aws_directconnect_virtual_interface`       |
393a403,404
> | `aws_directconnect`                         | **HAS**               | `aws_directconnect_virtual_interface`       |
> | `aws_directconnect_lag`                     | **USES**              | `aws_direct_connect_connection`             |
396d406
< | `aws_directconnect_lag`                     | **USES**              | `aws_direct_connect_connection`             |
400,401d409
< | `aws_dynamodb_global_table`                 | **IS**                | `aws_dynamodb_table`                        |
< | `aws_dynamodb`                              | **HAS**               | `aws_dynamodb_table`                        |
402a411,413
> | `aws_dynamodb`                              | **HAS**               | `aws_dynamodb_table`                        |
> | `aws_dynamodb_global_table`                 | **IS**                | `aws_dynamodb_table`                        |
> | `aws_dynamodb_table`                        | **USES**              | `aws_kms_key`                               |
404d414
< | `aws_ebs_volume`                            | **USES**              | `aws_ebs_snapshot`                          |
405a416
> | `aws_ebs_volume`                            | **USES**              | `aws_ebs_snapshot`                          |
407a419
> | `aws_ec2`                                   | **HAS**               | `aws_ec2_settings`                          |
410a423
> | `aws_ec2`                                   | **USES**              | `aws_kms_key`                               |
412a426
> | `aws_ec2`                                   | **HAS**               | `aws_prefix_list`                           |
416,418d429
< | `aws_ec2`                                   | **HAS**               | `aws_prefix_list`                           |
< | `aws_ec2`                                   | **HAS**               | `aws_ec2_settings`                          |
< | `aws_ec2`                                   | **USES**              | `aws_kms_key`                               |
419a431,432
> | `aws_ecr_image`                             | **HAS**               | `aws_ecr_image_scan_finding`                |
> | `aws_ecr_repository`                        | **HAS**               | `aws_ecr_image`                             |
421a435,439
> | `aws_ecs_cluster`                           | **HAS**               | `aws_ecs_container_instance`                |
> | `aws_ecs_cluster`                           | **HAS**               | `aws_ecs_service`                           |
> | `aws_ecs_cluster`                           | **RUNS**              | `aws_ecs_task`                              |
> | `aws_ecs_container_instance`                | **RUNS**              | `aws_ecs_task`                              |
> | `aws_ecs_service`                           | **HAS**               | `aws_security_group`                        |
422a441,442
> | `aws_ecs_task_definition`                   | **DEFINES**           | `aws_ecs_service`                           |
> | `aws_ecs_task_definition`                   | **DEFINES**           | `aws_ecs_task`                              |
424,425d443
< | `aws_iam_role`                              | **ASSIGNED**          | `aws_ecs_task_definition`                   |
< | `aws_efs_file_system`                       | **HAS**               | `aws_efs_mount_target`                      |
426a445,446
> | `aws_efs_file_system`                       | **HAS**               | `aws_efs_mount_target`                      |
> | `aws_efs_file_system`                       | **USES**              | `aws_kms_key`                               |
428c448
< | `aws_eks_cluster`                           | **HAS**               | `aws_eks_node_group`                        |
---
> | `aws_efs_mount_target`                      | **HAS**               | `aws_security_group`                        |
430c450,451
< | `aws_eks_node_group`                        | **HAS**               | `aws_instance`                              |
---
> | `aws_eks_cluster`                           | **HAS**               | `aws_eks_node_group`                        |
> | `aws_eks_cluster`                           | **HAS**               | `aws_security_group`                        |
432,433c453
< | `aws_elasticache_redis_cluster`             | **HAS**               | `aws_elasticache_cluster_node`              |
< | `aws_elasticache_memcached_cluster`         | **HAS**               | `aws_elasticache_snapshot`                  |
---
> | `aws_eks_node_group`                        | **HAS**               | `aws_instance`                              |
435a456,462
> | `aws_elasticache_cluster_node`              | **USES**              | `aws_eni`                                   |
> | `aws_elasticache_cluster_node`              | **HAS**               | `aws_security_group`                        |
> | `aws_elasticache_memcached_cluster`         | **HAS**               | `aws_elasticache_snapshot`                  |
> | `aws_elasticache_memcached_cluster`         | **USES**              | `aws_eni`                                   |
> | `aws_elasticache_memcached_cluster`         | **HAS**               | `aws_security_group`                        |
> | `aws_elasticache_redis_cluster`             | **HAS**               | `aws_elasticache_cluster_node`              |
> | `aws_elasticache_redis_cluster`             | **USES**              | `aws_kms_key`                               |
440d466
< | `aws_elasticmapreduce_cluster`              | **HAS**               | `aws_instance`                              |
441a468
> | `aws_elasticmapreduce_cluster`              | **HAS**               | `aws_instance`                              |
442a470,472
> | `aws_elasticsearch_domain`                  | **USES**              | `aws_eni`                                   |
> | `aws_elasticsearch_domain`                  | **HAS**               | `aws_security_group`                        |
> | `aws_elb`                                   | **USES**              | `aws_eni`                                   |
443a474,476
> | `aws_elb`                                   | **HAS**               | `aws_lb_listener`                           |
> | `aws_elb`                                   | **CONNECTS**          | `aws_lb_target_group`                       |
> | `aws_elb`                                   | **HAS**               | `aws_security_group`                        |
444a478
> | `aws_eni`                                   | **HAS**               | `aws_security_group`                        |
445a480
> | `aws_firehose`                              | **HAS**               | `aws_firehose_delivery_stream`              |
448d482
< | `aws_firehose`                              | **HAS**               | `aws_firehose_delivery_stream`              |
450d483
< | `aws_firewall_policy`                       | **HAS**               | `aws_firewall_rule_group`                   |
451a485
> | `aws_firewall_policy`                       | **HAS**               | `aws_firewall_rule_group`                   |
460d493
< | `aws_glue_data_catalog_encryption_settings` | **USES**              | `aws_kms_key`                               |
464a498
> | `aws_glue_data_catalog_encryption_settings` | **USES**              | `aws_kms_key`                               |
466d499
< | `aws_detector`                              | **IDENTIFIED**        | `aws_finding`                               |
468,469d500
< | `aws_iam_group`                             | **ASSIGNED**          | `aws_iam_group_policy`                      |
< | `aws_iam_group`                             | **ASSIGNED**          | `aws_iam_policy`                            |
478a510
> | `aws_iam`                                   | **HAS**               | `aws_iam_server_certificate`                |
482c514,516
< | `aws_iam`                                   | **HAS**               | `aws_iam_server_certificate`                |
---
> | `aws_iam_group`                             | **ASSIGNED**          | `aws_iam_group_policy`                      |
> | `aws_iam_group`                             | **ASSIGNED**          | `aws_iam_policy`                            |
> | `aws_iam_group`                             | **HAS**               | `aws_iam_user`                              |
484a519,520
> | `aws_iam_policy`                            | **RESTRICTS**         | `aws_iam_role`                              |
> | `aws_iam_policy`                            | **RESTRICTS**         | `aws_iam_user`                              |
487,490c523,526
< | `aws_iam_role_policy`                       | **ALLOWS**            | `aws_resource`                              |
< | `aws_iam_role_policy`                       | **DENIES**            | `aws_resource`                              |
< | `aws_iam_user_policy`                       | **ALLOWS**            | `aws_resource`                              |
< | `aws_iam_user_policy`                       | **DENIES**            | `aws_resource`                              |
---
> | `aws_iam_role`                              | **ASSIGNED**          | `aws_batch_compute_environment`             |
> | `aws_iam_role`                              | **ASSIGNED**          | `aws_ecs_task_definition`                   |
> | `aws_iam_role`                              | **ASSIGNED**          | `aws_iam_policy`                            |
> | `aws_iam_role`                              | **ASSIGNED**          | `aws_iam_role_policy`                       |
493,497c529,530
< | `aws_iam_role`                              | **ASSIGNED**          | `aws_iam_role_policy`                       |
< | `aws_iam_policy`                            | **RESTRICTS**         | `aws_iam_role`                              |
< | `aws_iam_role`                              | **ASSIGNED**          | `aws_iam_policy`                            |
< | `aws_iam_user`                              | **ASSIGNED**          | `mfa_device`                                |
< | `aws_iam_group`                             | **HAS**               | `aws_iam_user`                              |
---
> | `aws_iam_role_policy`                       | **ALLOWS**            | `aws_resource`                              |
> | `aws_iam_role_policy`                       | **DENIES**            | `aws_resource`                              |
499,500d531
< | `aws_iam_user`                              | **ASSIGNED**          | `aws_iam_user_policy`                       |
< | `aws_iam_policy`                            | **RESTRICTS**         | `aws_iam_user`                              |
502c533,536
< | `aws_inspector_assessment`                  | **IDENTIFIED**        | `aws_inspector_finding`                     |
---
> | `aws_iam_user`                              | **ASSIGNED**          | `aws_iam_user_policy`                       |
> | `aws_iam_user`                              | **ASSIGNED**          | `mfa_device`                                |
> | `aws_iam_user_policy`                       | **ALLOWS**            | `aws_resource`                              |
> | `aws_iam_user_policy`                       | **DENIES**            | `aws_resource`                              |
504,505c538
< | `aws_inspectorv2`                           | **IDENTIFIED**        | `aws_inspectorv2_finding`                   |
< | `aws_inspectorv2`                           | **SCANS**             | `aws_instance`                              |
---
> | `aws_inspector_assessment`                  | **IDENTIFIED**        | `aws_inspector_finding`                     |
508,510c541,542
< | `aws_instance`                              | **HAS**               | `aws_instance_inventory`                    |
< | `aws_instance`                              | **INSTALLED**         | `aws_instance_application`                  |
< | `aws_instance`                              | **LOGS**              | `aws_instance_patch_state`                  |
---
> | `aws_inspectorv2`                           | **IDENTIFIED**        | `aws_inspectorv2_finding`                   |
> | `aws_inspectorv2`                           | **SCANS**             | `aws_instance`                              |
511a544
> | `aws_instance`                              | **USES**              | `aws_ebs_volume`                            |
513a547,549
> | `aws_instance`                              | **INSTALLED**         | `aws_instance_application`                  |
> | `aws_instance`                              | **HAS**               | `aws_instance_inventory`                    |
> | `aws_instance`                              | **LOGS**              | `aws_instance_patch_state`                  |
515c551
< | `aws_instance`                              | **USES**              | `aws_ebs_volume`                            |
---
> | `aws_instance`                              | **HAS**               | `aws_security_group`                        |
519d554
< | `aws_lambda_function`                       | **ASSIGNED**          | `aws_iam_role`                              |
520a556,557
> | `aws_lambda_function`                       | **ASSIGNED**          | `aws_iam_role`                              |
> | `aws_lambda_function`                       | **HAS**               | `aws_security_group`                        |
523d559
< | `aws_lb_listener`                           | **HAS**               | `aws_lb_listener_rule`                      |
525a562
> | `aws_lb_listener`                           | **HAS**               | `aws_lb_listener_rule`                      |
528d564
< | `aws_lexv2_bot`                             | **HAS**               | `aws_lexv2_bot_alias`                       |
530,535c566
< | `aws_elb`                                   | **CONNECTS**          | `aws_lb_target_group`                       |
< | `aws_alb`                                   | **CONNECTS**          | `aws_lb_target_group`                       |
< | `aws_nlb`                                   | **CONNECTS**          | `aws_lb_target_group`                       |
< | `aws_alb`                                   | **HAS**               | `aws_lb_listener`                           |
< | `aws_elb`                                   | **HAS**               | `aws_lb_listener`                           |
< | `aws_nlb`                                   | **HAS**               | `aws_lb_listener`                           |
---
> | `aws_lexv2_bot`                             | **HAS**               | `aws_lexv2_bot_alias`                       |
537d567
< | `aws_network_acl`                           | **PROTECTS**          | `aws_subnet`                                |
539a570
> | `aws_network_acl`                           | **PROTECTS**          | `aws_subnet`                                |
542a574,577
> | `aws_nlb`                                   | **USES**              | `aws_eni`                                   |
> | `aws_nlb`                                   | **HAS**               | `aws_lb_listener`                           |
> | `aws_nlb`                                   | **CONNECTS**          | `aws_lb_target_group`                       |
> | `aws_organization`                          | **HAS**               | `aws_organization_root`                     |
545d579
< | `aws_organization`                          | **HAS**               | `aws_organization_root`                     |
549,550d582
< | `aws_rds_cluster`                           | **CONTAINS**          | `aws_db_instance`                           |
< | `aws_rds_cluster`                           | **USES**              | `aws_secret`                                |
552d583
< | `aws_rds`                                   | **HAS**               | `aws_rds_cluster`                           |
554a586,589
> | `aws_rds`                                   | **HAS**               | `aws_rds_cluster`                           |
> | `aws_rds_cluster`                           | **HAS**               | `aws_db_cluster_snapshot`                   |
> | `aws_rds_cluster`                           | **CONTAINS**          | `aws_db_instance`                           |
> | `aws_rds_cluster`                           | **USES**              | `aws_kms_key`                               |
556,557c591,592
< | `aws_db_instance`                           | **USES**              | `aws_db_parameter_group`                    |
< | `aws_redshift_cluster`                      | **USES**              | `aws_redshift_cluster_parameter_group`      |
---
> | `aws_rds_cluster`                           | **USES**              | `aws_secret`                                |
> | `aws_rds_cluster`                           | **HAS**               | `aws_security_group`                        |
558a594,596
> | `aws_redshift_cluster`                      | **USES**              | `aws_kms_key`                               |
> | `aws_redshift_cluster`                      | **USES**              | `aws_redshift_cluster_parameter_group`      |
> | `aws_redshift_cluster`                      | **HAS**               | `aws_security_group`                        |
560d597
< | `aws_redshift_workgroup`                    | **HAS**               | `aws_redshift_serverless_workgroup`         |
562,580c599
< | `aws_resource`                              | **HAS**               | `aws_inspectorv2_finding`                   |
< | `aws_batch_compute_environment`             | **HAS**               | `aws_security_group`                        |
< | `aws_cloudhsm_cluster`                      | **HAS**               | `aws_security_group`                        |
< | `aws_cloudhsm_instance`                     | **HAS**               | `aws_security_group`                        |
< | `aws_instance`                              | **HAS**               | `aws_security_group`                        |
< | `aws_eni`                                   | **HAS**               | `aws_security_group`                        |
< | `aws_vpc_endpoint`                          | **HAS**               | `aws_security_group`                        |
< | `aws_ecs_service`                           | **HAS**               | `aws_security_group`                        |
< | `aws_efs_mount_target`                      | **HAS**               | `aws_security_group`                        |
< | `aws_eks_cluster`                           | **HAS**               | `aws_security_group`                        |
< | `aws_elasticache_memcached_cluster`         | **HAS**               | `aws_security_group`                        |
< | `aws_elasticache_cluster_node`              | **HAS**               | `aws_security_group`                        |
< | `aws_elb`                                   | **HAS**               | `aws_security_group`                        |
< | `aws_alb`                                   | **HAS**               | `aws_security_group`                        |
< | `aws_elasticsearch_domain`                  | **HAS**               | `aws_security_group`                        |
< | `aws_lambda_function`                       | **HAS**               | `aws_security_group`                        |
< | `aws_rds_cluster`                           | **HAS**               | `aws_security_group`                        |
< | `aws_db_instance`                           | **HAS**               | `aws_security_group`                        |
< | `aws_redshift_cluster`                      | **HAS**               | `aws_security_group`                        |
---
> | `aws_redshift_workgroup`                    | **HAS**               | `aws_redshift_serverless_workgroup`         |
582,597c601,602
< | `aws_elasticache_cluster_node`              | **USES**              | `aws_eni`                                   |
< | `aws_elasticache_memcached_cluster`         | **USES**              | `aws_eni`                                   |
< | `aws_alb`                                   | **USES**              | `aws_eni`                                   |
< | `aws_elb`                                   | **USES**              | `aws_eni`                                   |
< | `aws_nlb`                                   | **USES**              | `aws_eni`                                   |
< | `aws_elasticsearch_domain`                  | **USES**              | `aws_eni`                                   |
< | `aws_cloudwatch_log_group`                  | **USES**              | `aws_kms_key`                               |
< | `aws_dynamodb_table`                        | **USES**              | `aws_kms_key`                               |
< | `aws_efs_file_system`                       | **USES**              | `aws_kms_key`                               |
< | `aws_elasticache_redis_cluster`             | **USES**              | `aws_kms_key`                               |
< | `aws_rds_cluster`                           | **USES**              | `aws_kms_key`                               |
< | `aws_db_instance`                           | **USES**              | `aws_kms_key`                               |
< | `aws_redshift_cluster`                      | **USES**              | `aws_kms_key`                               |
< | `aws_s3_bucket`                             | **USES**              | `aws_kms_key`                               |
< | `aws_sns_topic`                             | **USES**              | `aws_kms_key`                               |
< | `aws_sqs_queue`                             | **USES**              | `aws_kms_key`                               |
---
> | `aws_resource`                              | **HAS**               | `aws_inspectorv2_finding`                   |
> | `aws_resource`                              | **ALLOWS**            | `aws_security_group`                        |
601a607
> | `aws_s3`                                    | **HAS**               | `aws_s3_bucket`                             |
602a609,611
> | `aws_s3_bucket`                             | **USES**              | `aws_kms_key`                               |
> | `aws_s3_bucket`                             | **NOTIFIES**          | `aws_lambda_function`                       |
> | `aws_s3_bucket`                             | **HAS**               | `aws_macie_finding`                         |
604d612
< | `aws_transfer_user`                         | **ALLOWS**            | `aws_s3_bucket`                             |
606d613
< | `aws_s3_bucket`                             | **HAS**               | `aws_macie_finding`                         |
609,610d615
< | `aws_s3_bucket`                             | **NOTIFIES**          | `aws_lambda_function`                       |
< | `aws_s3_bucket`                             | **NOTIFIES**          | `aws_sqs_queue`                             |
612c617
< | `aws_s3`                                    | **HAS**               | `aws_s3_bucket`                             |
---
> | `aws_s3_bucket`                             | **NOTIFIES**          | `aws_sqs_queue`                             |
614a620
> | `aws_security_group`                        | **PROTECTS**          | `aws_alb`                                   |
618,620c624
< | `aws_security_group`                        | **PROTECTS**          | `aws_instance`                              |
< | `aws_security_group`                        | **PROTECTS**          | `aws_eni`                                   |
< | `aws_security_group`                        | **PROTECTS**          | `aws_vpc_endpoint`                          |
---
> | `aws_security_group`                        | **PROTECTS**          | `aws_db_instance`                           |
624d627
< | `aws_security_group`                        | **PROTECTS**          | `aws_elasticache_memcached_cluster`         |
626,627c629
< | `aws_security_group`                        | **PROTECTS**          | `aws_elb`                                   |
< | `aws_security_group`                        | **PROTECTS**          | `aws_alb`                                   |
---
> | `aws_security_group`                        | **PROTECTS**          | `aws_elasticache_memcached_cluster`         |
628a631,633
> | `aws_security_group`                        | **PROTECTS**          | `aws_elb`                                   |
> | `aws_security_group`                        | **PROTECTS**          | `aws_eni`                                   |
> | `aws_security_group`                        | **PROTECTS**          | `aws_instance`                              |
629a635
> | `aws_security_group`                        | **USES**              | `aws_prefix_list`                           |
631d636
< | `aws_security_group`                        | **PROTECTS**          | `aws_db_instance`                           |
634,635c639
< | `aws_resource`                              | **ALLOWS**            | `aws_security_group`                        |
< | `aws_security_group`                        | **USES**              | `aws_prefix_list`                           |
---
> | `aws_security_group`                        | **PROTECTS**          | `aws_vpc_endpoint`                          |
645d648
< | `aws_shield_protection_group`               | **PROTECTS**          | `aws_resource`                              |
647c650
< | `aws_vpn_gateway`                           | **CONNECTS**          | `aws_customer_gateway`                      |
---
> | `aws_shield_protection_group`               | **PROTECTS**          | `aws_resource`                              |
648a652
> | `aws_sns_topic`                             | **USES**              | `aws_kms_key`                               |
650d653
< | `aws_sqs_queue`                             | **SENDS**             | `aws_sqs_queue`                             |
651a655,657
> | `aws_sqs_queue`                             | **USES**              | `aws_kms_key`                               |
> | `aws_sqs_queue`                             | **SENDS**             | `aws_sqs_queue`                             |
> | `aws_ssm`                                   | **MANAGES**           | `aws_instance`                              |
654,655d659
< | `aws_ssm`                                   | **HAS**               | `aws_session_document`                      |
< | `aws_ssm`                                   | **MANAGES**           | `aws_instance`                              |
656a661,662
> | `aws_ssm`                                   | **HAS**               | `aws_session_document`                      |
> | `aws_subnet`                                | **HAS**               | `aws_cloudhsm_instance`                     |
659d664
< | `aws_subnet`                                | **HAS**               | `aws_cloudhsm_instance`                     |
663d667
< | `aws_subnet`                                | **HAS**               | `aws_workspace`                             |
664a669
> | `aws_subnet`                                | **HAS**               | `aws_workspace`                             |
667,668c672,674
< | `aws_vpc`                                   | **CONTAINS**          | `aws_subnet`                                |
< | `aws_vpc`                                   | **HAS**               | `aws_route_table`                           |
---
> | `aws_transfer_user`                         | **ALLOWS**            | `aws_s3_bucket`                             |
> | `aws_vpc`                                   | **HAS**               | `aws_alb`                                   |
> | `aws_vpc`                                   | **HAS**               | `aws_cloudhsm_cluster`                      |
674,676d679
< | `aws_vpc`                                   | **HAS**               | `aws_vpc_endpoint`                          |
< | `aws_vpc`                                   | **HAS**               | `aws_cloudhsm_cluster`                      |
< | `aws_vpc`                                   | **HAS**               | `aws_internet_gateway`                      |
678,679c681
< | `aws_vpc`                                   | **HAS**               | `aws_alb`                                   |
< | `aws_vpc`                                   | **HAS**               | `aws_nlb`                                   |
---
> | `aws_vpc`                                   | **HAS**               | `aws_internet_gateway`                      |
681a684
> | `aws_vpc`                                   | **HAS**               | `aws_nlb`                                   |
682a686
> | `aws_vpc`                                   | **HAS**               | `aws_route_table`                           |
684a689
> | `aws_vpc`                                   | **CONTAINS**          | `aws_subnet`                                |
685a691
> | `aws_vpc`                                   | **HAS**               | `aws_vpc_endpoint`                          |
686a693,694
> | `aws_vpc_endpoint`                          | **HAS**               | `aws_security_group`                        |
> | `aws_vpn_gateway`                           | **CONNECTS**          | `aws_customer_gateway`                      |
688,689d695
< | `aws_waf_web_acl`                           | **PROTECTS**          | `aws_cloudfront_distribution`               |
< | `aws_waf_v2_web_acl`                        | **PROTECTS**          | `aws_cloudfront_distribution`               |
690a697,698
> | `aws_waf_v2_web_acl`                        | **PROTECTS**          | `aws_cloudfront_distribution`               |
> | `aws_waf_web_acl`                           | **PROTECTS**          | `aws_cloudfront_distribution`               |
694,701d701
< | `aws_ecr_image`                             | **HAS**               | `aws_ecr_image_scan_finding`                |
< | `aws_ecr_repository`                        | **HAS**               | `aws_ecr_image`                             |
< | `aws_ecs_cluster`                           | **HAS**               | `aws_ecs_container_instance`                |
< | `aws_ecs_cluster`                           | **HAS**               | `aws_ecs_service`                           |
< | `aws_ecs_cluster`                           | **RUNS**              | `aws_ecs_task`                              |
< | `aws_ecs_container_instance`                | **RUNS**              | `aws_ecs_task`                              |
< | `aws_ecs_task_definition`                   | **DEFINES**           | `aws_ecs_service`                           |
< | `aws_ecs_task_definition`                   | **DEFINES**           | `aws_ecs_task`                              |
714d713
< | `aws_cloudtrail`                       | **LOGS**              | `*aws_s3_bucket*`                   | FORWARD   |
716,717c715
< | `aws_kms_key`                          | **USES**              | `*aws_db_cluster_snapshot*`         | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_db_snapshot*`                 | REVERSE   |
---
> | `aws_cloudtrail`                       | **SENDS**             | `*aws_dynamodb*`                    | REVERSE   |
719,720c717,721
< | `aws_kms_key`                          | **USES**              | `*aws_ebs_snapshot*`                | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_ebs_volume*`                  | REVERSE   |
---
> | `aws_cloudtrail`                       | **SENDS**             | `*aws_lambda*`                      | REVERSE   |
> | `aws_cloudtrail`                       | **SENDS**             | `*aws_lambda_function*`             | REVERSE   |
> | `aws_cloudtrail`                       | **SENDS**             | `*aws_s3*`                          | REVERSE   |
> | `aws_cloudtrail`                       | **LOGS**              | `*aws_s3_bucket*`                   | FORWARD   |
> | `aws_cloudtrail`                       | **SENDS**             | `*aws_s3_bucket*`                   | REVERSE   |
724c725
< | `aws_kms_key`                          | **USES**              | `*aws_elasticache_snapshot*`        | REVERSE   |
---
> | `aws_ecs_task`                         | **USES**              | `*aws_eni*`                         | FORWARD   |
726,727d726
< | `aws_vpc`                              | **LOGS**              | `*aws_cloudwatch_log_group*`        | FORWARD   |
< | `aws_vpc`                              | **LOGS**              | `*aws_s3_bucket*`                   | FORWARD   |
729d727
< | `aws_kms_key`                          | **USES**              | `*aws_glue_security_configuration*` | REVERSE   |
733a732,733
> | `aws_iam_role`                         | **TRUSTS**            | `*aws_resource*`                    | FORWARD   |
> | `aws_iam_role`                         | **TRUSTS**            | `*external_resource*`               | FORWARD   |
735a736
> | `aws_iam_saml_provider`                | **IS**                | `*external_resource*`               | FORWARD   |
738,740d738
< | `aws_iam_role`                         | **TRUSTS**            | `*aws_resource*`                    | FORWARD   |
< | `aws_iam_role`                         | **TRUSTS**            | `*external_resource*`               | FORWARD   |
< | `aws_iam_saml_provider`                | **IS**                | `*external_resource*`               | FORWARD   |
741a740
> | `aws_inspectorv2_finding`              | **HAS**               | `*aws_resource*`                    | REVERSE   |
743a743
> | `aws_instance_patch_state`             | **GENERATED**         | `*aws_patch_baseline*`              | REVERSE   |
746,748c746,760
< | `aws_cloudtrail`                       | **SENDS**             | `*aws_lambda*`                      | REVERSE   |
< | `aws_cloudtrail`                       | **SENDS**             | `*aws_dynamodb*`                    | REVERSE   |
< | `aws_cloudtrail`                       | **SENDS**             | `*aws_lambda_function*`             | REVERSE   |
---
> | `aws_kms_key`                          | **USES**              | `*aws_cloudwatch_log_group*`        | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_db_cluster_snapshot*`         | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_db_instance*`                 | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_db_snapshot*`                 | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_dynamodb_table*`              | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_ebs_snapshot*`                | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_ebs_volume*`                  | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_efs_file_system*`             | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_elasticache_redis_cluster*`   | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_elasticache_snapshot*`        | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_glue_security_configuration*` | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_rds_cluster*`                 | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_redshift_cluster*`            | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_s3_bucket*`                   | REVERSE   |
> | `aws_kms_key`                          | **USES**              | `*aws_sns_topic*`                   | REVERSE   |
760d771
< | `aws_instance_patch_state`             | **GENERATED**         | `*aws_patch_baseline*`              | REVERSE   |
762,772d772
< | `aws_inspectorv2_finding`              | **HAS**               | `*aws_resource*`                    | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_cloudwatch_log_group*`        | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_dynamodb_table*`              | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_efs_file_system*`             | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_elasticache_redis_cluster*`   | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_rds_cluster*`                 | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_db_instance*`                 | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_redshift_cluster*`            | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_s3_bucket*`                   | REVERSE   |
< | `aws_kms_key`                          | **USES**              | `*aws_sns_topic*`                   | REVERSE   |
< | `aws_route53_record`                   | **CONNECTS**          | `*aws_ses*`                         | FORWARD   |
773a774
> | `aws_route53_record`                   | **CONNECTS**          | `*aws_ses*`                         | FORWARD   |
777,778d777
< | `aws_s3_bucket`                        | **ALLOWS**            | `*everyone*`                        | FORWARD   |
< | `aws_s3_bucket`                        | **ALLOWS**            | `*everyone*`                        | REVERSE   |
780a780,781
> | `aws_s3_bucket`                        | **ALLOWS**            | `*aws_resource*`                    | FORWARD   |
> | `aws_s3_bucket`                        | **DENIES**            | `*aws_resource*`                    | REVERSE   |
784,787d784
< | `aws_cloudtrail`                       | **SENDS**             | `*aws_s3*`                          | REVERSE   |
< | `aws_cloudtrail`                       | **SENDS**             | `*aws_s3_bucket*`                   | REVERSE   |
< | `aws_s3_bucket`                        | **ALLOWS**            | `*aws_resource*`                    | FORWARD   |
< | `aws_s3_bucket`                        | **DENIES**            | `*aws_resource*`                    | REVERSE   |
788a786,788
> | `aws_s3_bucket`                        | **ALLOWS**            | `*everyone*`                        | FORWARD   |
> | `aws_s3_bucket`                        | **ALLOWS**            | `*everyone*`                        | REVERSE   |
> | `aws_security_group`                   | **USES**              | `*aws_prefix_list*`                 | FORWARD   |
791d790
< | `aws_security_group`                   | **USES**              | `*aws_prefix_list*`                 | FORWARD   |
793d791
< | `aws_sns_topic`                        | **NOTIFIES**          | `*aws_resource*`                    | FORWARD   |
795a794
> | `aws_sns_topic`                        | **NOTIFIES**          | `*aws_resource*`                    | FORWARD   |
797a797,800
> | `aws_vpc`                              | **LOGS**              | `*aws_cloudwatch_log_group*`        | FORWARD   |
> | `aws_vpc`                              | **LOGS**              | `*aws_s3_bucket*`                   | FORWARD   |
> | `aws_vpc`                              | **CONNECTS**          | `*aws_vpc*`                         | FORWARD   |
> | `aws_vpc`                              | **CONNECTS**          | `*aws_vpc*`                         | REVERSE   |
802,804d804
< | `aws_vpc`                              | **CONNECTS**          | `*aws_vpc*`                         | FORWARD   |
< | `aws_vpc`                              | **CONNECTS**          | `*aws_vpc*`                         | REVERSE   |
< | `aws_ecs_task`                         | **USES**              | `*aws_eni*`                         | FORWARD   |
```
