### PR TITLE
Remove Windows Checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18.x]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
       - name: Check out code repository source code


### PR DESCRIPTION
# Description

This PR removes the windows checks. They are very slow and often fail on `yarn install` due to this slowness.
