### PR TITLE
Add step concurrency to dependency graph

### DIFF
--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -81,6 +81,13 @@ export interface InvocationConfig<
    */
   dependencyGraphOrder?: string[];
   /**
+   * Optionally define the number of steps to execute in parallel.
+   *
+   * If this value is not provided the concurrency defaults to
+   * Number.POSITIVE_INFINITY
+   */
+  stepConcurrency?: number;
+  /**
    * This configuration element is used to store information about data
    * ingestion sources that can be enabled or disabled. When this element
    * is provided, it is expected that one or more steps will reference

--- a/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
+++ b/packages/integration-sdk-runtime/src/execution/dependencyGraph.ts
@@ -82,6 +82,7 @@ export function executeStepDependencyGraph<
   executionContext,
   inputGraph,
   stepStartStates,
+  stepConcurrency,
   duplicateKeyTracker,
   graphObjectStore,
   dataStore,
@@ -95,6 +96,7 @@ export function executeStepDependencyGraph<
   executionContext: TExecutionContext;
   inputGraph: DepGraph<Step<TStepExecutionContext>>;
   stepStartStates: StepStartStates;
+  stepConcurrency?: number;
   duplicateKeyTracker: DuplicateKeyTracker;
   graphObjectStore: GraphObjectStore;
   dataStore: MemoryDataStore;
@@ -114,7 +116,11 @@ export function executeStepDependencyGraph<
   const workingGraph = inputGraph.clone();
 
   // create a queue for managing promises to be executed
-  const promiseQueue = new PromiseQueue();
+  const promiseQueueOptions: { concurrency?: number } = {};
+  if (stepConcurrency !== undefined) {
+    promiseQueueOptions.concurrency = stepConcurrency;
+  }
+  const promiseQueue = new PromiseQueue(promiseQueueOptions);
 
   const typeTracker = new TypeTracker();
   const stepResultsMap = buildStepResultsMap(inputGraph, stepStartStates);

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -257,6 +257,7 @@ export async function executeWithContext<
         executionContext: context,
         integrationSteps: config.integrationSteps,
         stepStartStates,
+        stepConcurrency: config.stepConcurrency,
         duplicateKeyTracker: new DuplicateKeyTracker(
           config.normalizeGraphObjectKey,
         ),

--- a/packages/integration-sdk-runtime/src/execution/step.ts
+++ b/packages/integration-sdk-runtime/src/execution/step.ts
@@ -49,6 +49,7 @@ export async function executeSteps<
   afterAddEntity,
   afterAddRelationship,
   dependencyGraphOrder,
+  stepConcurrency,
   executionHandlerWrapper,
 }: {
   executionContext: TExecutionContext;
@@ -63,6 +64,7 @@ export async function executeSteps<
   afterAddEntity?: AfterAddEntityHookFunction<TExecutionContext>;
   afterAddRelationship?: AfterAddRelationshipHookFunction<TExecutionContext>;
   dependencyGraphOrder?: string[];
+  stepConcurrency?: number;
   executionHandlerWrapper?: StepExecutionHandlerWrapperFunction<TStepExecutionContext>;
 }): Promise<IntegrationStepResult[]> {
   const stepsByGraphId = seperateStepsByDependencyGraph(integrationSteps);
@@ -88,6 +90,7 @@ export async function executeSteps<
         executionContext,
         inputGraph: buildStepDependencyGraph(steps),
         stepStartStates: pick(stepStartStates, stepIds),
+        stepConcurrency,
         duplicateKeyTracker,
         graphObjectStore,
         dataStore,


### PR DESCRIPTION
This will give us the ability to limit the number of concurrent steps. Currently the value is the default (`POSITIVE_INFINITY`)