### PR TITLE
Allow source in IntegrationEntityData to be undefined

### DIFF
--- a/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
+++ b/packages/integration-sdk-core/src/data/createIntegrationEntity.ts
@@ -57,7 +57,7 @@ export type IntegrationEntityData = {
    * The common properties defined by data model schemas, selected by the
    * `assign._class`, will be found and transferred to the generated entity.
    */
-  source: ProviderSourceData;
+  source?: ProviderSourceData;
 
   /**
    * Literal property assignments. These values will override anything
@@ -115,7 +115,7 @@ function generateEntity({
   tagProperties,
 }: IntegrationEntityData): GeneratedEntity {
   const _rawData: EntityRawData[] = [];
-  if (Object.entries(source).length > 0) {
+  if (source && Object.entries(source).length > 0) {
     _rawData.push({ name: 'default', rawData: source });
   }
   if (assign._rawData) {
@@ -125,13 +125,13 @@ function generateEntity({
   const _class = Array.isArray(assign._class) ? assign._class : [assign._class];
 
   const entity: GeneratedEntity = {
-    ...whitelistedProviderData(source, _class),
+    ...(source ? whitelistedProviderData(source, _class) : {}),
     ...assign,
     _class,
     _rawData,
   };
 
-  if (entity.createdOn === undefined) {
+  if (entity.createdOn === undefined && source) {
     entity.createdOn =
       (source.createdAt && parseTimePropertyValue(source.createdAt)) ||
       (source.creationDate && parseTimePropertyValue(source.creationDate)) ||
@@ -140,7 +140,7 @@ function generateEntity({
         parseTimePropertyValue(source.creationTimestamp));
   }
 
-  if (entity.active === undefined && source.status) {
+  if (entity.active === undefined && source && source.status) {
     const isActive = new RegExp('(?<!in)active|enabled|online', 'i').test(
       source.status,
     );
@@ -160,7 +160,7 @@ function generateEntity({
   // `assignTags` will take care of preparing `tags` properly.
   delete entity.tags;
 
-  assignTags(entity, source.tags, tagProperties);
+  assignTags(entity, source?.tags, tagProperties);
 
   // `assignTags` may populate `displayName` from the `source.tags`. When there
   // is an `assign.displayName`, use that instead assuming that an assigned


### PR DESCRIPTION
We have some entities where we don't upload rawData in purpose because they can be huge.
The current function in the SDK doesn't allow us to use itself if the source is undefined