### PR TITLE
Allow deletion of required properties from schema

### DIFF
--- a/packages/integration-sdk-testing/src/__tests__/jest.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jest.test.ts
@@ -358,7 +358,7 @@ describe('#toMatchGraphObjectSchema', () => {
             items: { type: 'object' },
           },
           displayName: { type: 'string' },
-          version: { delete: true },
+          version: { exclude: true },
         },
       },
     });

--- a/packages/integration-sdk-testing/src/__tests__/jest.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jest.test.ts
@@ -296,6 +296,80 @@ describe('#toMatchGraphObjectSchema', () => {
     });
   });
 
+  test('should remove properties marked for deletion from schema', () => {
+    const standardEntity = {
+      _key: 'arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0',
+      _type: 'aws_securityhub_standard',
+      _class: ['Standard'],
+      name: 'AWS Foundational Security Best Practices v1.0.0',
+      displayName: 'AWS Foundational Security Best Practices v1.0.0',
+      enabledByDefault: true,
+      managingCompany: 'AWS',
+      managingProduct: 'Security Hub',
+      region: 'us-east-1',
+      _rawData: [
+        {
+          name: 'default',
+          rawData: {
+            EnabledByDefault: true,
+            Name: 'AWS Foundational Security Best Practices v1.0.0',
+            StandardsArn:
+              'arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0',
+            StandardsManagedBy: {
+              Company: 'AWS',
+              Product: 'Security Hub',
+            },
+          },
+        },
+      ],
+    };
+
+    const failedResult = toMatchGraphObjectSchema(standardEntity, {
+      _class: ['Standard'],
+      schema: {
+        additionalProperties: true,
+        properties: {
+          _type: { const: 'aws_securityhub_standard' },
+          _rawData: {
+            type: 'array',
+            items: { type: 'object' },
+          },
+          displayName: { type: 'string' },
+        },
+      },
+    });
+
+    expect(failedResult.message()).toContain(
+      'Error validating graph object against schema',
+    );
+    expect(failedResult).toEqual({
+      message: expect.any(Function),
+      pass: false,
+    });
+
+    const succeededResult = toMatchGraphObjectSchema(standardEntity, {
+      _class: ['Standard'],
+      schema: {
+        additionalProperties: true,
+        properties: {
+          _type: { const: 'aws_securityhub_standard' },
+          _rawData: {
+            type: 'array',
+            items: { type: 'object' },
+          },
+          displayName: { type: 'string' },
+          version: { delete: true },
+        },
+      },
+    });
+
+    expect(succeededResult.message()).toContain('Success!');
+    expect(succeededResult).toEqual({
+      message: expect.any(Function),
+      pass: true,
+    });
+  });
+
   test('should match array of custom entities using schema', () => {
     const result = toMatchGraphObjectSchema(
       [

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -287,16 +287,16 @@ function dedupSchemaEnumValues(schema: GraphObjectSchema): GraphObjectSchema {
 }
 
 /**
- * Step to remove specified properties marked for deletion
+ * Step to remove specified properties marked for exclusion
  * in the schemas. This step will run after all deduplication
  * processes to ensure that the properties will be removed from
  * the final schema.
  *
- * Example: parameter: { deleted: true }
+ * Example: parameter: { exclude: true }
  *
  * @param schema
  */
-function removeSchemaDeletedValues(
+function removeSchemaExcludedValues(
   schema: GraphObjectSchema,
 ): GraphObjectSchema {
   if (!schema.properties) {
@@ -308,7 +308,7 @@ function removeSchemaDeletedValues(
   for (const propertyName in schema.properties) {
     const property = schema.properties[propertyName];
 
-    if (property.delete === true) {
+    if (property.exclude === true) {
       if (schema.required?.includes(propertyName)) {
         schema.required = schema.required.filter(
           (item) => item !== propertyName,
@@ -370,7 +370,7 @@ function generateGraphObjectSchemaFromDataModelSchemas(
   let resultSchema = dedupSchemaPropertyTypes(deepmerge.all(newSchemas));
   resultSchema = dedupSchemaRequiredPropertySchema(resultSchema);
   resultSchema = dedupSchemaEnumValues(resultSchema);
-  resultSchema = removeSchemaDeletedValues(resultSchema);
+  resultSchema = removeSchemaExcludedValues(resultSchema);
 
   return resultSchema;
 }


### PR DESCRIPTION
To avoid the use of disableClassMatch I have added in a way to remove required properties from the schema and will be applied at the end of the processing of the schema to ensure it is not re-added.

We already have the functionality to override the data-model type properties but not the required array.