### PR TITLE
Automatically include _rawData in schema for entities

### DIFF
--- a/packages/integration-sdk-testing/src/__tests__/jest.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jest.test.ts
@@ -444,7 +444,7 @@ describe('#toMatchGraphObjectSchema', () => {
 
     expect(result.message()).toEqual(
       `Error validating graph object against schema (data=${JSON.stringify(
-        { ...data, _rawData: undefined },
+        data,
         null,
         2,
       )}, errors=${expectedSerialzedErrors}, index=0)
@@ -508,6 +508,50 @@ Find out more about JupiterOne schemas: https://github.com/JupiterOne/data-model
     });
 
     expect(result.message()).toEqual('Success!');
+  });
+
+  test('Should allow an entity with _rawData', () => {
+    const entity: Entity = generateCollectedEntity();
+
+    const result = toMatchGraphObjectSchema(entity, {
+      _class: ['Service'],
+      schema: generateGraphObjectSchema(),
+    });
+
+    expect(result).toEqual({
+      message: expect.any(Function),
+      pass: true,
+    });
+
+    expect(result.message()).toEqual('Success!');
+  });
+
+  test('Should not allow an entity with _rawData if excluded', () => {
+    const entity: Entity = generateCollectedEntity();
+
+    const result = toMatchGraphObjectSchema(entity, {
+      _class: ['Service'],
+      schema: generateGraphObjectSchema({
+        _rawData: { exclude: true },
+      }),
+    });
+
+    expect(result).toEqual({
+      message: expect.any(Function),
+      pass: false,
+    });
+
+    expect(result.message()).toContain(
+      `{
+    "instancePath": "",
+    "schemaPath": "#/additionalProperties",
+    "keyword": "additionalProperties",
+    "params": {
+      "additionalProperty": "_rawData"
+    },
+    "message": "must NOT have additional properties"
+  }`,
+    );
   });
 });
 

--- a/packages/integration-sdk-testing/src/__tests__/jest.test.ts
+++ b/packages/integration-sdk-testing/src/__tests__/jest.test.ts
@@ -444,7 +444,7 @@ describe('#toMatchGraphObjectSchema', () => {
 
     expect(result.message()).toEqual(
       `Error validating graph object against schema (data=${JSON.stringify(
-        data,
+        { ...data, _rawData: undefined },
         null,
         2,
       )}, errors=${expectedSerialzedErrors}, index=0)

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -608,7 +608,11 @@ function toMatchSchema<T extends Entity | ExplicitRelationship>(
   received = Array.isArray(received) ? received : [received];
 
   for (let i = 0; i < received.length; i++) {
-    const data = received[i];
+    // Removes raw data before schema validation
+    const data = {
+      ...received[i],
+    };
+    delete data._rawData;
 
     if (dataModelIntegrationSchema.validate(schema, data)) {
       continue;

--- a/packages/integration-sdk-testing/src/jest.ts
+++ b/packages/integration-sdk-testing/src/jest.ts
@@ -494,11 +494,26 @@ export function toMatchGraphObjectSchema<T extends Entity>(
     }
   }
 
+  // Adds the rawData schema which will allow you to have
+  // rawData in your entity without needing to specify it
+  // in the schema.
+  // To ensure that rawData is not present you can exclude
+  // the value in the schema by setting `exclude: true`
+  const rawDataSchema: GraphObjectSchema = {
+    properties: {
+      _rawData: {
+        type: 'array',
+        items: { type: 'object' },
+      },
+    },
+  };
+
   const newEntitySchema: GraphObjectSchema =
     generateGraphObjectSchemaFromDataModelSchemas([
       // Merging should have the highest-level schemas at the end of the array
       // so that they can override the parent classes
       ...schemas.reverse(),
+      rawDataSchema,
       schema,
     ]);
 
@@ -608,11 +623,7 @@ function toMatchSchema<T extends Entity | ExplicitRelationship>(
   received = Array.isArray(received) ? received : [received];
 
   for (let i = 0; i < received.length; i++) {
-    // Removes raw data before schema validation
-    const data = {
-      ...received[i],
-    };
-    delete data._rawData;
+    const data = received[i];
 
     if (dataModelIntegrationSchema.validate(schema, data)) {
       continue;


### PR DESCRIPTION
Currently when validating graph object's schema with `additionalProperties: false` you are required to add _rawData as a property ([As seen here](https://github.com/JupiterOne/graph-google-cloud/blob/597eb7bd798f4406d39f054fcdbff38040a040da/src/steps/service-usage/constants.ts#L28-L31))

This will remove automatically add the property to the schema to prevent this need.