### PR TITLE
add optional hasKey function to storage interface

### DIFF
--- a/packages/integration-sdk-core/src/types/storage.ts
+++ b/packages/integration-sdk-core/src/types/storage.ts
@@ -28,6 +28,8 @@ export interface GraphObjectStore {
 
   findEntity(_key: string | undefined): Promise<Entity | undefined>;
 
+  hasKey?: (_key: string | undefined) => boolean;
+
   iterateEntities<T extends Entity = Entity>(
     filter: GraphObjectFilter,
     iteratee: GraphObjectIteratee<T>,

--- a/packages/integration-sdk-runtime/src/storage/memory.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/memory.test.ts
@@ -225,4 +225,28 @@ describe('#InMemoryGraphObjectStore', () => {
     expect(await collectRelationshipsByType(store, r2._type)).toEqual([r2]);
     expect(store.getTotalRelationshipItemCount()).toEqual(1);
   });
+
+  test('should allow testing if hasKey', async () => {
+    const store = new InMemoryGraphObjectStore();
+    const e1 = createTestEntity();
+
+    await store.addEntities('test', [e1]);
+    expect(store.hasKey(e1._key)).toBe(true);
+    expect(store.hasKey('not-real')).toBe(false);
+
+    const r1 = createTestRelationship();
+    await store.addRelationships('test', [r1]);
+
+    expect(store.hasKey(e1._key)).toBe(true);
+    expect(store.hasKey(r1._key)).toBe(true);
+    expect(store.hasKey('not-real')).toBe(false);
+
+    // after flushing then test that they are not there
+    store.flushEntities([e1], 'test');
+    store.flushRelationships([r1], 'test');
+
+    expect(store.hasKey(e1._key)).toBe(false);
+    expect(store.hasKey(r1._key)).toBe(false);
+    expect(store.hasKey('not-real')).toBe(false);
+  });
 });

--- a/packages/integration-sdk-runtime/src/storage/memory.ts
+++ b/packages/integration-sdk-runtime/src/storage/memory.ts
@@ -131,6 +131,16 @@ export class InMemoryGraphObjectStore implements GraphObjectStore {
     return Promise.resolve(entity);
   }
 
+  hasKey(_key: string | undefined): boolean {
+    if (!_key) {
+      return false;
+    }
+    return (
+      this.entityKeyToEntityMap.has(_key) ||
+      this.relationshipKeyToRelationshipMap.has(_key)
+    );
+  }
+
   /**
    * @notImplemented
    */


### PR DESCRIPTION
# Description
Adding this `hasKey` function will aid in moving entity and key lookup fully to disk to reduce memory footprint.