### PR TITLE
add support for using hasKey from graphObjectStore

### DIFF
--- a/packages/integration-sdk-private-test-utils/src/graphObjectStore.ts
+++ b/packages/integration-sdk-private-test-utils/src/graphObjectStore.ts
@@ -66,3 +66,68 @@ export class InMemoryGraphObjectStore implements GraphObjectStore {
     return Promise.resolve();
   }
 }
+
+export class InMemoryGraphObjectStoreWithHasKeyImpl
+  implements GraphObjectStore
+{
+  private readonly entityMap = new Map<string, Entity>();
+  private readonly relationshipMap = new Map<string, Relationship>();
+
+  hasKey(_key: string | undefined) {
+    if (!_key) {
+      return false;
+    }
+    return this.entityMap.has(_key) || this.relationshipMap.has(_key);
+  }
+
+  async addEntities(stepId: string, newEntities: Entity[]): Promise<void> {
+    for (const entity of newEntities) {
+      this.entityMap.set(entity._key, entity);
+    }
+
+    return Promise.resolve();
+  }
+
+  async addRelationships(
+    stepId: string,
+    newRelationships: Relationship[],
+  ): Promise<void> {
+    for (const relationship of newRelationships) {
+      this.relationshipMap.set(relationship._key, relationship);
+    }
+
+    return Promise.resolve();
+  }
+
+  async findEntity(_key: string | undefined): Promise<Entity | undefined> {
+    const entity = _key ? this.entityMap.get(_key) : undefined;
+
+    return Promise.resolve(entity);
+  }
+
+  async iterateEntities<T extends Entity = Entity>(
+    filter: GraphObjectFilter,
+    iteratee: GraphObjectIteratee<T>,
+  ): Promise<void> {
+    for (const [_, entity] of this.entityMap) {
+      if (entity._type === filter._type) {
+        await iteratee(entity as T);
+      }
+    }
+  }
+
+  async iterateRelationships<T extends Relationship = Relationship>(
+    filter: GraphObjectFilter,
+    iteratee: GraphObjectIteratee<T>,
+  ): Promise<void> {
+    for (const [_, relationship] of this.relationshipMap) {
+      if (relationship._type === filter._type) {
+        await iteratee(relationship as T);
+      }
+    }
+  }
+
+  async flush(): Promise<void> {
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
# Description
This PR adds support for using a `hasKey` implementation from the `graphObjectStore` rather than the `DuplicateKeyTracker` if it is available.