### PR TITLE
Add OnDiskDuplicateKeyTracker

### DIFF
--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -114,13 +114,6 @@ export interface InvocationConfig<
    * If not provided, the handler will run normally.
    */
   executionHandlerWrapper?: StepExecutionHandlerWrapperFunction<TStepExecutionContext>;
-  /**
-   * @expiremental
-   * Expiremental feature to enable the on-disk duplicate key tracker
-   * Requires the optional dependency `lmdb` and a valid `lmdb` build
-   * This field may be removed in future releases with no major version change!
-   */
-  useOnDiskDuplicateKeyTracker?: boolean;
 }
 
 export interface IntegrationInvocationConfig<

--- a/packages/integration-sdk-core/src/types/config.ts
+++ b/packages/integration-sdk-core/src/types/config.ts
@@ -114,6 +114,13 @@ export interface InvocationConfig<
    * If not provided, the handler will run normally.
    */
   executionHandlerWrapper?: StepExecutionHandlerWrapperFunction<TStepExecutionContext>;
+  /**
+   * @expiremental
+   * Expiremental feature to enable the on-disk duplicate key tracker
+   * Requires the optional dependency `lmdb` and a valid `lmdb` build
+   * This field may be removed in future releases with no major version change!
+   */
+  useOnDiskDuplicateKeyTracker?: boolean;
 }
 
 export interface IntegrationInvocationConfig<

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@jupiterone/integration-sdk-private-test-utils": "^12.6.0",
     "get-port": "^5.1.1",
+    "lmdb": "^3.0.8",
     "memfs": "^3.2.0",
     "ts-node": "^9.1.0",
     "wait-for-expect": "^3.0.2"

--- a/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/dependencyGraph.test.ts
@@ -31,7 +31,7 @@ import {
 } from '../dependencyGraph';
 import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
 import { MemoryDataStore } from '../jobState';
-import { DuplicateKeyTracker } from '../duplicateKeyTracker';
+import { InMemoryDuplicateKeyTracker } from '../duplicateKeyTracker';
 import { getDefaultStepStartStates } from '../step';
 import {
   CreateStepGraphObjectDataUploaderFunction,
@@ -149,7 +149,7 @@ describe('executeStepDependencyGraph', () => {
       executionContext,
       inputGraph: buildStepDependencyGraph(steps),
       stepStartStates,
-      duplicateKeyTracker: new DuplicateKeyTracker(),
+      duplicateKeyTracker: new InMemoryDuplicateKeyTracker(),
       graphObjectStore,
       dataStore: new MemoryDataStore(),
       createStepGraphObjectDataUploader,

--- a/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/jobState.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../jobState';
 import {
   DuplicateEntityReport,
-  DuplicateKeyTracker,
+  InMemoryDuplicateKeyTracker,
 } from '../duplicateKeyTracker';
 import { randomUUID as uuid } from 'crypto';
 import { FileSystemGraphObjectStore } from '../../storage';
@@ -67,7 +67,7 @@ function getMockCreateStepJobStateParams(
   return {
     stepId: uuid(),
     graphObjectStore: new FileSystemGraphObjectStore(),
-    duplicateKeyTracker: new DuplicateKeyTracker(),
+    duplicateKeyTracker: new InMemoryDuplicateKeyTracker(),
     typeTracker: new TypeTracker(),
     dataStore: new MemoryDataStore(),
     onDuplicateEntityKey,
@@ -135,7 +135,7 @@ describe('#findEntity', () => {
 
   test('should find entity by _key with key normalization', async () => {
     const jobState = createTestStepJobState({
-      duplicateKeyTracker: new DuplicateKeyTracker((_key) =>
+      duplicateKeyTracker: new InMemoryDuplicateKeyTracker((_key) =>
         _key.toLowerCase(),
       ),
     });
@@ -182,7 +182,7 @@ describe('#hasKey', () => {
 
   test('key normalization', async () => {
     const jobState = createTestStepJobState({
-      duplicateKeyTracker: new DuplicateKeyTracker((_key) =>
+      duplicateKeyTracker: new InMemoryDuplicateKeyTracker((_key) =>
         _key.toLowerCase(),
       ),
     });

--- a/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.test.ts
@@ -4,7 +4,6 @@ import {
 } from './duplicateKeyTracker';
 import { InMemoryGraphObjectStore } from '../storage';
 import { Entity } from '@jupiterone/integration-sdk-core';
-
 describe('DuplicateKeyTracker', () => {
   test('has key returns true when key is present', () => {
     const duplicateKeyTracker = new DuplicateKeyTracker();

--- a/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.test.ts
@@ -1,19 +1,19 @@
 import {
-  DuplicateKeyTracker,
+  InMemoryDuplicateKeyTracker,
   createDuplicateEntityReport,
 } from './duplicateKeyTracker';
 import { InMemoryGraphObjectStore } from '../storage';
 import { Entity } from '@jupiterone/integration-sdk-core';
-describe('DuplicateKeyTracker', () => {
+describe('InMemoryDuplicateKeyTracker', () => {
   test('has key returns true when key is present', () => {
-    const duplicateKeyTracker = new DuplicateKeyTracker();
+    const duplicateKeyTracker = new InMemoryDuplicateKeyTracker();
     const _key = 'test-key-1';
     duplicateKeyTracker.registerKey(_key);
     expect(duplicateKeyTracker.hasKey(_key)).toBeTrue();
   });
 
   test('has key returns false when key is not present', () => {
-    const duplicateKeyTracker = new DuplicateKeyTracker();
+    const duplicateKeyTracker = new InMemoryDuplicateKeyTracker();
     const _key = 'test-key-1';
     duplicateKeyTracker.registerKey(_key);
     expect(duplicateKeyTracker.hasKey('not-found')).toBeFalse();

--- a/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.ts
+++ b/packages/integration-sdk-runtime/src/execution/duplicateKeyTracker.ts
@@ -7,7 +7,14 @@ import {
 import { deepStrictEqual } from 'assert';
 import { BigMap } from './utils/bigMap';
 
-const DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE = 2000000;
+const DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE = 2_000_000;
+
+export interface DuplicateKeyTracker {
+  getEncounteredKeys(): string[][];
+  registerKey(_key: string): void;
+  getGraphObjectMetadata(_key: string): string | undefined;
+  hasKey(_key: string): boolean;
+}
 
 /**
  * Contains a map of every graph object key to a specific set of metadata about
@@ -16,7 +23,7 @@ const DUPLICATE_KEY_TRACKER_DEFAULT_MAP_KEY_SPACE = 2000000;
  * or relationships. We store the `_type` inside the metadata for a fast lookup
  * table.
  */
-export class DuplicateKeyTracker {
+export class InMemoryDuplicateKeyTracker implements DuplicateKeyTracker {
   private readonly graphObjectKeyMap: BigMap<string, string>;
   private readonly normalizationFunction: KeyNormalizationFunction;
 

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -266,16 +266,23 @@ export async function executeWithContext<
 
       if (process.env.USE_ON_DISK_DKT) {
         // conditionally require so the dependency can remain optional
-        const {
-          OnDiskDuplicateKeyTracker,
-        } = require('./onDiskDuplicateKeyTracker');
-        duplicateKeyTracker = new OnDiskDuplicateKeyTracker({
-          filepath: path.join(
-            process.cwd(),
-            DEFAULT_STORAGE_DIRECTORY_NAME,
-            'key-tracker.db',
-          ),
-        });
+        try {
+          const {
+            OnDiskDuplicateKeyTracker,
+          } = require('./onDiskDuplicateKeyTracker');
+          duplicateKeyTracker = new OnDiskDuplicateKeyTracker({
+            filepath: path.join(
+              process.cwd(),
+              DEFAULT_STORAGE_DIRECTORY_NAME,
+              'key-tracker.db',
+            ),
+          });
+        } catch (err) {
+          logger.warn(
+            { err },
+            'Tried to require OnDiskDuplicateKeyTracker, but failed. Falling back to InMemoryDuplicateKeyTracker',
+          );
+        }
       }
 
       const integrationStepResults = await executeSteps({

--- a/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
+++ b/packages/integration-sdk-runtime/src/execution/executeIntegration.ts
@@ -270,7 +270,11 @@ export async function executeWithContext<
           OnDiskDuplicateKeyTracker,
         } = require('./onDiskDuplicateKeyTracker');
         duplicateKeyTracker = new OnDiskDuplicateKeyTracker({
-          filepath: path.join(process.cwd(), DEFAULT_STORAGE_DIRECTORY_NAME),
+          filepath: path.join(
+            process.cwd(),
+            DEFAULT_STORAGE_DIRECTORY_NAME,
+            'key-tracker.db',
+          ),
         });
       }
 

--- a/packages/integration-sdk-runtime/src/execution/index.ts
+++ b/packages/integration-sdk-runtime/src/execution/index.ts
@@ -6,7 +6,10 @@ export {
 export { prepareLocalStepCollection } from './step';
 export { loadConfigFromEnvironmentVariables } from './config';
 export { TypeTracker, MemoryDataStore } from './jobState';
-export { DuplicateKeyTracker } from './duplicateKeyTracker';
+export {
+  DuplicateKeyTracker,
+  InMemoryDuplicateKeyTracker,
+} from './duplicateKeyTracker';
 export { buildStepDependencyGraph } from './dependencyGraph';
 export {
   StepGraphObjectDataUploader,

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -3,7 +3,6 @@ import {
   JobState,
   Relationship,
 } from '@jupiterone/integration-sdk-core';
-
 import { GraphObjectStore } from '../storage';
 import {
   createDuplicateEntityReport,

--- a/packages/integration-sdk-runtime/src/execution/jobState.ts
+++ b/packages/integration-sdk-runtime/src/execution/jobState.ts
@@ -136,6 +136,7 @@ export interface CreateStepJobStateParams {
    */
   onDuplicateEntityKey: (duplicateEntityReport: DuplicateEntityReport) => void;
 }
+
 export function createStepJobState({
   stepId,
   duplicateKeyTracker,
@@ -194,7 +195,6 @@ export function createStepJobState({
 
   function registerRelationshipInTrackers(r: Relationship) {
     duplicateKeyTracker.registerKey(r._key);
-
     typeTracker.addStepGraphObjectType({
       stepId,
       _type: r._type,

--- a/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.test.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from 'crypto';
+import { OnDiskDuplicateKeyTracker } from './onDiskDuplicateKeyTracker';
+import { rm } from 'fs/promises';
+
+describe('ondiskduplicatekeystore', () => {
+  test('should persist to disk', async () => {
+    const filepath = randomUUID();
+    try {
+      const map = new Map<string, string>();
+      const keys = Array.from({ length: 520 }, () => Math.random().toString());
+      const dt = new OnDiskDuplicateKeyTracker({
+        filepath,
+        internalBuffer: map,
+        internalBufferSize: 500,
+      });
+      for (const key of keys) {
+        await dt.registerKey(key);
+        expect(dt.hasKey(key)).toBeTrue();
+      }
+
+      for (const key of keys) {
+        expect(dt.hasKey(key)).toBeTrue();
+      }
+
+      expect(map.size).toBeLessThan(520);
+    } finally {
+      await rm(filepath, { recursive: true });
+    }
+  });
+
+  test('should return false when does not have key', async () => {
+    const filepath = randomUUID();
+    try {
+      const map = new Map<string, string>();
+      const keys = Array.from({ length: 520 }, () => Math.random().toString());
+      const dt = new OnDiskDuplicateKeyTracker({
+        filepath,
+        internalBuffer: map,
+        internalBufferSize: 500,
+      });
+      for (const key of keys) {
+        await dt.registerKey(key);
+        expect(dt.hasKey(key)).toBeTrue();
+      }
+
+      for (const key of keys) {
+        expect(dt.hasKey(key)).toBeTrue();
+      }
+
+      expect(dt.hasKey('not-real')).toBeFalse();
+    } finally {
+      await rm(filepath, { recursive: true });
+    }
+  });
+
+  test('getEncounteredKeys returns all keys', async () => {
+    const filepath = randomUUID();
+    try {
+      const keys = Array.from({ length: 10 }, () => Math.random().toString());
+
+      // settint to lower than default to ensure we get some keys on disk
+      const dt = new OnDiskDuplicateKeyTracker({
+        filepath,
+        internalBufferSize: 500,
+      });
+
+      for (const key of keys) {
+        await dt.registerKey(key);
+      }
+
+      const keySet = new Set(keys);
+      expect(keySet.size).toEqual(keys.length);
+      const encounteredKeys = dt.getEncounteredKeys().at(0)!;
+      encounteredKeys.map((key) => {
+        expect(keySet.has(key)).toBeTrue();
+      });
+      expect(encounteredKeys.length).toEqual(keySet.size);
+    } finally {
+      await rm(filepath, { recursive: true });
+    }
+  });
+});

--- a/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.test.ts
@@ -14,7 +14,7 @@ describe('ondiskduplicatekeystore', () => {
         internalBufferSize: 500,
       });
       for (const key of keys) {
-        await dt.registerKey(key);
+        dt.registerKey(key);
         expect(dt.hasKey(key)).toBeTrue();
       }
 
@@ -39,7 +39,7 @@ describe('ondiskduplicatekeystore', () => {
         internalBufferSize: 500,
       });
       for (const key of keys) {
-        await dt.registerKey(key);
+        dt.registerKey(key);
         expect(dt.hasKey(key)).toBeTrue();
       }
 
@@ -65,7 +65,7 @@ describe('ondiskduplicatekeystore', () => {
       });
 
       for (const key of keys) {
-        await dt.registerKey(key);
+        dt.registerKey(key);
       }
 
       const keySet = new Set(keys);

--- a/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.ts
+++ b/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.ts
@@ -1,0 +1,78 @@
+import { KeyNormalizationFunction } from '@jupiterone/integration-sdk-core';
+import { open, RootDatabase } from 'lmdb';
+
+const DEFAULT_IN_MEMORY_BUFFER_SIZE = 10_000;
+
+/**
+ * WARNING: Unstable, this class may make breaking changes in the future
+ * with no warning while we work out it's usage and interface in integrations
+ */
+export class OnDiskDuplicateKeyTracker {
+  private lmdb: RootDatabase;
+  private readonly interalBuffer: Map<string, string>;
+  private readonly internalBufferSize: number;
+  private readonly normalizationFunction: KeyNormalizationFunction;
+
+  constructor(params?: {
+    filepath?: string;
+    normalizationFunction?: KeyNormalizationFunction;
+    internalBuffer?: Map<string, string>;
+    internalBufferSize?: number;
+  }) {
+    this.normalizationFunction =
+      params?.normalizationFunction || ((_key) => _key);
+    this.lmdb = open(params?.filepath ?? 'key-tracker.db', {
+      encoding: 'string',
+    });
+    this.interalBuffer = params?.internalBuffer ?? new Map<string, string>();
+    this.internalBufferSize =
+      params?.internalBufferSize ?? DEFAULT_IN_MEMORY_BUFFER_SIZE;
+  }
+
+  getGraphObjectMetadata(_key: string): string | undefined {
+    return this.interalBuffer.get(_key) ?? this.lmdb.get(_key);
+  }
+
+  getEncounteredKeys(): string[][] {
+    const keys: string[] = [];
+    for (const key of this.lmdb.getKeys()) {
+      keys.push(key as string);
+    }
+    for (const key of this.interalBuffer.keys()) {
+      keys.push(key);
+    }
+    return [keys];
+  }
+
+  registerKey(_key: string) {
+    const normalizedKey = this.normalizationFunction(_key);
+    if (this.interalBuffer.has(normalizedKey) || this.lmdb.get(normalizedKey)) {
+      throw new Error(`Duplicate _key detected (_key=${_key})`);
+    }
+
+    this.interalBuffer.set(normalizedKey, _key);
+
+    if (this.interalBuffer.size > this.internalBufferSize) {
+      const keys: string[] = [];
+      this.lmdb.transactionSync(() => {
+        for (const [key, value] of this.interalBuffer.entries()) {
+          this.lmdb.put(key, value).catch((e) => {
+            throw e;
+          });
+          keys.push(key);
+        }
+      });
+
+      for (const key of keys) {
+        this.interalBuffer.delete(key);
+      }
+    }
+  }
+
+  hasKey(_key: string) {
+    const normalizedKey = this.normalizationFunction(_key);
+    return (
+      !!this.lmdb.get(normalizedKey) || this.interalBuffer.has(normalizedKey)
+    );
+  }
+}

--- a/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.ts
+++ b/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.ts
@@ -2,6 +2,7 @@ import { KeyNormalizationFunction } from '@jupiterone/integration-sdk-core';
 import type { RootDatabase } from 'lmdb';
 
 let open: any;
+/* eslint-disable no-useless-catch */
 try {
   const lmdb = require('lmdb');
   open = lmdb.open;

--- a/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.ts
+++ b/packages/integration-sdk-runtime/src/execution/onDiskDuplicateKeyTracker.ts
@@ -1,5 +1,13 @@
 import { KeyNormalizationFunction } from '@jupiterone/integration-sdk-core';
-import { open, RootDatabase } from 'lmdb';
+import type { RootDatabase } from 'lmdb';
+
+let open: any;
+try {
+  const lmdb = require('lmdb');
+  open = lmdb.open;
+} catch (err) {
+  throw err;
+}
 
 const DEFAULT_IN_MEMORY_BUFFER_SIZE = 10_000;
 

--- a/packages/integration-sdk-testing/src/jobState.ts
+++ b/packages/integration-sdk-testing/src/jobState.ts
@@ -5,7 +5,7 @@ import {
   KeyNormalizationFunction,
 } from '@jupiterone/integration-sdk-core';
 import {
-  DuplicateKeyTracker,
+  InMemoryDuplicateKeyTracker,
   MemoryDataStore,
   TypeTracker,
 } from '@jupiterone/integration-sdk-runtime';
@@ -47,7 +47,9 @@ export function createMockJobState({
   let collectedRelationships: Relationship[] = [];
   const collectedData: { [key: string]: any } = {};
 
-  const duplicateKeyTracker = new DuplicateKeyTracker(normalizeGraphObjectKey);
+  const duplicateKeyTracker = new InMemoryDuplicateKeyTracker(
+    normalizeGraphObjectKey,
+  );
   const typeTracker = new TypeTracker();
   const dataStore = new MemoryDataStore();
   const mockStepId = `mock-step-${uuid()}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,6 +2484,66 @@
   resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.3.tgz#e742a5b85eb673e2f1746b0f39cb932cbc6145bb"
   integrity sha512-GlM2AbzrErd/TmLL3E8hAHmb5Q7VhDJp35vIbyPVA5Rz55LZuRr8pwL3qrwwkVNo05gMX1J44gURKb4MHQZo7w==
 
+"@lmdb/lmdb-darwin-arm64@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.0.8.tgz#1673e9fda6678b0fd4e4b101d971e68166e36def"
+  integrity sha512-+lFwFvU+zQ9zVIFETNtmW++syh3Ps5JS8MPQ8zOYtQZoU+dTR8ivWHTaE2QVk1JG2payGDLUAvpndLAjGMdeeA==
+
+"@lmdb/lmdb-darwin-x64@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.0.8.tgz#d97c2412e23e39a3063275cc1aa15001aacc81de"
+  integrity sha512-T98rfsgfdQMS5/mqdsPb6oHSJ+iBYNa+PQDLtXLh6rzTEBsYP9x2uXxIj6VS4qXVDWXVi8rv85NCOG+UBOsHXQ==
+
+"@lmdb/lmdb-linux-arm64@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.0.8.tgz#b3e264a4c01508d73b40cc6c6d4631e55da16869"
+  integrity sha512-uEBGCQIChsixpykL0pjCxfF64btv64vzsb1NoM5u0qvabKvKEvErhXGoqovyldDu9u1T/fswD8Kf6ih0vJEvDQ==
+
+"@lmdb/lmdb-linux-arm@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.0.8.tgz#861cdcee491c97981932771ddc3ebc6e9eef71b7"
+  integrity sha512-gVNCi3bYWatdPMeFpFjuZl6bzVL55FkeZU3sPeU+NsMRXC+Zl3qOx3M6cM4OMlJWbhHjYjf2b8q83K0mczaiWQ==
+
+"@lmdb/lmdb-linux-x64@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.0.8.tgz#5422468ed6be523c6590da914a945c1ef86ece97"
+  integrity sha512-6v0B4sa9ulNezmDZtVpLjNHmA0qZzUl3001YJ2RF0naxsuv/Jq/xEwNYpOzfcdizHfpCE0oBkWzk/r+Slr+0zw==
+
+"@lmdb/lmdb-win32-x64@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.0.8.tgz#63f7be01dac6b3613b29c05c44246740f5b7edcd"
+  integrity sha512-lDLGRIMqdwYD39vinwNqqZUxCdL2m2iIdn+0HyQgIHEiT0g5rIAlzaMKzoGWon5NQumfxXFk9y0DarttkR7C1w==
+
+"@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz#44d752c1a2dc113f15f781b7cc4f53a307e3fa38"
+  integrity sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==
+
+"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz#f954f34355712212a8e06c465bc06c40852c6bb3"
+  integrity sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz#45c63037f045c2b15c44f80f0393fa24f9655367"
+  integrity sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz#35707efeafe6d22b3f373caf9e8775e8920d1399"
+  integrity sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==
+
+"@msgpackr-extract/msgpackr-extract-linux-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz#091b1218b66c341f532611477ef89e83f25fae4f"
+  integrity sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==
+
+"@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz#0f164b726869f71da3c594171df5ebc1c4b0a407"
+  integrity sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==
+
 "@nicolo-ribaudo/semver-v6@^6.3.3":
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz#ea6d23ade78a325f7a52750aab1526b02b628c29"
@@ -4698,6 +4758,11 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
+
+detect-libc@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700"
+  integrity sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -7315,6 +7380,24 @@ listr2@^3.2.2:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
+lmdb@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-3.0.8.tgz#8e7629951b0a5dc2be7220798985d0a0f53dc1e4"
+  integrity sha512-9rp8JT4jPhCRJUL7vRARa2N06OLSYzLwQsEkhC6Qu5XbcLyM/XBLMzDlgS/K7l7c5CdURLdDk9uE+hPFIogHTQ==
+  dependencies:
+    msgpackr "^1.9.9"
+    node-addon-api "^6.1.0"
+    node-gyp-build-optional-packages "5.1.1"
+    ordered-binary "^1.4.1"
+    weak-lru-cache "^1.2.2"
+  optionalDependencies:
+    "@lmdb/lmdb-darwin-arm64" "3.0.8"
+    "@lmdb/lmdb-darwin-x64" "3.0.8"
+    "@lmdb/lmdb-linux-arm" "3.0.8"
+    "@lmdb/lmdb-linux-arm64" "3.0.8"
+    "@lmdb/lmdb-linux-x64" "3.0.8"
+    "@lmdb/lmdb-win32-x64" "3.0.8"
+
 load-json-file@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-6.2.0.tgz#5c7770b42cafa97074ca2848707c61662f4251a1"
@@ -7865,6 +7948,27 @@ ms@2.1.3, ms@^2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msgpackr-extract@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz#e05ec1bb4453ddf020551bcd5daaf0092a2c279d"
+  integrity sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==
+  dependencies:
+    node-gyp-build-optional-packages "5.0.7"
+  optionalDependencies:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-darwin-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.2"
+
+msgpackr@^1.9.9:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.10.1.tgz#51953bb4ce4f3494f0c4af3f484f01cfbb306555"
+  integrity sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==
+  optionalDependencies:
+    msgpackr-extract "^3.0.2"
+
 multimatch@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-5.0.0.tgz#932b800963cea7a31a033328fa1e0c3a1874dbe6"
@@ -8002,6 +8106,11 @@ node-addon-api@^3.2.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
+node-addon-api@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
+  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
+
 node-fetch@2.6.7, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -8015,6 +8124,18 @@ node-fetch@^2.7.0:
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-gyp-build-optional-packages@5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz#5d2632bbde0ab2f6e22f1bbac2199b07244ae0b3"
+  integrity sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==
+
+node-gyp-build-optional-packages@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz#52b143b9dd77b7669073cbfe39e3f4118bfc603c"
+  integrity sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==
+  dependencies:
+    detect-libc "^2.0.1"
 
 node-gyp-build@^4.3.0:
   version "4.6.0"
@@ -8439,6 +8560,11 @@ ora@^6.0.1:
     stdin-discarder "^0.1.0"
     strip-ansi "^7.0.1"
     wcwidth "^1.0.1"
+
+ordered-binary@^1.4.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.5.1.tgz#94ccbf14181711081ee23931db0dc3f58aaa0df6"
+  integrity sha512-5VyHfHY3cd0iza71JepYG50My+YUbrFtGoUz2ooEydPyPM7Aai/JW098juLr+RG6+rDJuzNNTsEQu2DZa1A41A==
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -9771,7 +9897,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9828,7 +9963,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10493,6 +10635,11 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+weak-lru-cache@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
+  integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -10577,7 +10724,7 @@ wordwrap@>=0.0.2, wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10590,6 +10737,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Description
Based on feedback in #1068, the `DuplicateKeyTracker` seems like the best place for an initial pass at on-disk persistence of keys. I've added an initial `OnDiskDuplicateKeyTracker` based on `lmbd`. The use of it requires installing `lmdb` in the target project so that projects that have not adopted it don't install the `lmdb` dependency.

This should eliminate one of the two largest in-memory data stores. The other being the `FileSystemGraphObjectStore`'s key to on-disk location index map.