### PR TITLE
re-release v13.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to
 
 # 13.1.0 - 2024-07-02
 
-- Add support for multiple classes in `createIntegrationHelpers`.
+- Add support for multiple class entities in `createIntegrationHelpers`.
 
 # 13.0.0 - 2024-06-24
 


### PR DESCRIPTION
TIL that you need an annotated tag to release.

`git describe` on the release commit didn't exactly match the tag so it failed to publish

This one will work