### PR TITLE
Mark graph object readonly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to
 
 # Unreleased
 
+# 13.6.0 - 2024-09-19
+
+- Minor breaking change to JobState methods iterateEntities and
+  iterateRelationships function signatures. The graph object passed to the
+  iteratee is now Readonly. The intention is to prevent modification of the
+  object during iteration. This is not a breaking change since the long-standing
+  understanding is that these objects should never be modified once added to the
+  jobState.
+
+```diff
+- export type GraphObjectIteratee<T> = (obj: T) => void | Promise<void>;
++ export type GraphObjectIteratee<T> = (obj: Readonly<T>) => void | Promise<void>;
+```
+
 # 13.5.2 - 2024-09-17
 
 - Temporary logging that should be removed after investigation.

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/integration-sdk-*",
     "packages/cli"
   ],
-  "version": "13.5.2"
+  "version": "13.6.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20990,11 +20990,11 @@
     },
     "packages/cli": {
       "name": "@jupiterone/cli",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^13.5.2",
-        "@jupiterone/integration-sdk-runtime": "^13.5.2",
+        "@jupiterone/integration-sdk-core": "^13.6.0",
+        "@jupiterone/integration-sdk-runtime": "^13.6.0",
         "@lifeomic/attempt": "^3.0.3",
         "commander": "^5.0.0",
         "globby": "^11.0.1",
@@ -21027,11 +21027,11 @@
     },
     "packages/integration-sdk-benchmark": {
       "name": "@jupiterone/integration-sdk-benchmark",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^13.5.2",
-        "@jupiterone/integration-sdk-runtime": "^13.5.2",
+        "@jupiterone/integration-sdk-core": "^13.6.0",
+        "@jupiterone/integration-sdk-runtime": "^13.6.0",
         "benchmark": "^2.1.4"
       },
       "engines": {
@@ -21040,12 +21040,12 @@
     },
     "packages/integration-sdk-cli": {
       "name": "@jupiterone/integration-sdk-cli",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@jupiterone/data-model": "^0.61.11",
-        "@jupiterone/integration-sdk-core": "^13.5.2",
-        "@jupiterone/integration-sdk-runtime": "^13.5.2",
+        "@jupiterone/integration-sdk-core": "^13.6.0",
+        "@jupiterone/integration-sdk-runtime": "^13.6.0",
         "chalk": "^4",
         "commander": "^9.4.0",
         "ejs": "^3.1.9",
@@ -21066,7 +21066,7 @@
         "j1-integration": "bin/j1-integration"
       },
       "devDependencies": {
-        "@jupiterone/integration-sdk-private-test-utils": "^13.5.2",
+        "@jupiterone/integration-sdk-private-test-utils": "^13.6.0",
         "@pollyjs/adapter-node-http": "^6.0.5",
         "@pollyjs/core": "^6.0.5",
         "@pollyjs/persister-fs": "^6.0.5",
@@ -21143,11 +21143,11 @@
     },
     "packages/integration-sdk-core": {
       "name": "@jupiterone/integration-sdk-core",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@jupiterone/data-model": "^0.61.11",
-        "@jupiterone/integration-sdk-entity-validator": "^13.5.2",
+        "@jupiterone/integration-sdk-entity-validator": "^13.6.0",
         "@sinclair/typebox": "^0.32.30",
         "lodash": "^4.17.21"
       },
@@ -21165,11 +21165,11 @@
     },
     "packages/integration-sdk-dev-tools": {
       "name": "@jupiterone/integration-sdk-dev-tools",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-cli": "^13.5.2",
-        "@jupiterone/integration-sdk-testing": "^13.5.2",
+        "@jupiterone/integration-sdk-cli": "^13.6.0",
+        "@jupiterone/integration-sdk-testing": "^13.6.0",
         "@types/jest": "^29.5.3",
         "@types/node": "^18",
         "@typescript-eslint/eslint-plugin": "^6.2.1",
@@ -21224,7 +21224,7 @@
     },
     "packages/integration-sdk-entities": {
       "name": "@jupiterone/integration-sdk-entities",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@jupiterone/data-model": "^0.61.11",
@@ -21239,7 +21239,7 @@
     },
     "packages/integration-sdk-entity-validator": {
       "name": "@jupiterone/integration-sdk-entity-validator",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -21257,19 +21257,19 @@
     },
     "packages/integration-sdk-http-client": {
       "name": "@jupiterone/integration-sdk-http-client",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@jupiterone/hierarchical-token-bucket": "^0.3.1",
-        "@jupiterone/integration-sdk-core": "^13.5.2",
+        "@jupiterone/integration-sdk-core": "^13.6.0",
         "@lifeomic/attempt": "^3.0.3",
         "form-data": "^4.0.0",
         "lodash": "^4.17.21",
         "node-fetch": "^2.7.0"
       },
       "devDependencies": {
-        "@jupiterone/integration-sdk-dev-tools": "^13.5.2",
-        "@jupiterone/integration-sdk-private-test-utils": "^13.5.2",
+        "@jupiterone/integration-sdk-dev-tools": "^13.6.0",
+        "@jupiterone/integration-sdk-private-test-utils": "^13.6.0",
         "@types/node-fetch": "^2.6.11"
       },
       "engines": {
@@ -21296,10 +21296,10 @@
     },
     "packages/integration-sdk-private-test-utils": {
       "name": "@jupiterone/integration-sdk-private-test-utils",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^13.5.2",
+        "@jupiterone/integration-sdk-core": "^13.6.0",
         "lodash": "^4.17.15"
       },
       "devDependencies": {
@@ -21311,10 +21311,10 @@
     },
     "packages/integration-sdk-runtime": {
       "name": "@jupiterone/integration-sdk-runtime",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^13.5.2",
+        "@jupiterone/integration-sdk-core": "^13.6.0",
         "@lifeomic/alpha": "^5.2.0",
         "@lifeomic/attempt": "^3.0.3",
         "async-sema": "^3.1.0",
@@ -21331,7 +21331,7 @@
         "rimraf": "^3.0.2"
       },
       "devDependencies": {
-        "@jupiterone/integration-sdk-private-test-utils": "^13.5.2",
+        "@jupiterone/integration-sdk-private-test-utils": "^13.6.0",
         "get-port": "^5.1.1",
         "lmdb": "^3.0.8",
         "memfs": "^3.2.0",
@@ -21378,12 +21378,12 @@
     },
     "packages/integration-sdk-testing": {
       "name": "@jupiterone/integration-sdk-testing",
-      "version": "13.5.2",
+      "version": "13.6.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^13.5.2",
-        "@jupiterone/integration-sdk-entity-validator": "^13.5.2",
-        "@jupiterone/integration-sdk-runtime": "^13.5.2",
+        "@jupiterone/integration-sdk-core": "^13.6.0",
+        "@jupiterone/integration-sdk-entity-validator": "^13.6.0",
+        "@jupiterone/integration-sdk-runtime": "^13.6.0",
         "@pollyjs/adapter-node-http": "^6.0.5",
         "@pollyjs/core": "^6.0.5",
         "@pollyjs/persister-fs": "^6.0.5",
@@ -21391,7 +21391,7 @@
         "lodash": "^4.17.15"
       },
       "devDependencies": {
-        "@jupiterone/integration-sdk-private-test-utils": "^13.5.2",
+        "@jupiterone/integration-sdk-private-test-utils": "^13.6.0",
         "@types/lodash": "^4.14.149",
         "get-port": "^5.1.1",
         "memfs": "^3.2.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^13.5.2",
-    "@jupiterone/integration-sdk-runtime": "^13.5.2",
+    "@jupiterone/integration-sdk-core": "13.5.2",
+    "@jupiterone/integration-sdk-runtime": "13.5.2",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "13.5.2",
-    "@jupiterone/integration-sdk-runtime": "13.5.2",
+    "@jupiterone/integration-sdk-core": "^13.6.0",
+    "@jupiterone/integration-sdk-runtime": "^13.6.0",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do npm run prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "13.5.2",
-    "@jupiterone/integration-sdk-runtime": "13.5.2",
+    "@jupiterone/integration-sdk-core": "^13.6.0",
+    "@jupiterone/integration-sdk-runtime": "^13.6.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do npm run prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^13.5.2",
-    "@jupiterone/integration-sdk-runtime": "^13.5.2",
+    "@jupiterone/integration-sdk-core": "13.5.2",
+    "@jupiterone/integration-sdk-runtime": "13.5.2",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.61.11",
-    "@jupiterone/integration-sdk-core": "13.5.2",
-    "@jupiterone/integration-sdk-runtime": "13.5.2",
+    "@jupiterone/integration-sdk-core": "^13.6.0",
+    "@jupiterone/integration-sdk-runtime": "^13.6.0",
     "chalk": "^4",
     "commander": "^9.4.0",
     "ejs": "^3.1.9",
@@ -45,7 +45,7 @@
     "url-exists": "^1.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "13.5.2",
+    "@jupiterone/integration-sdk-private-test-utils": "^13.6.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.61.11",
-    "@jupiterone/integration-sdk-core": "^13.5.2",
-    "@jupiterone/integration-sdk-runtime": "^13.5.2",
+    "@jupiterone/integration-sdk-core": "13.5.2",
+    "@jupiterone/integration-sdk-runtime": "13.5.2",
     "chalk": "^4",
     "commander": "^9.4.0",
     "ejs": "^3.1.9",
@@ -45,7 +45,7 @@
     "url-exists": "^1.0.3"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^13.5.2",
+    "@jupiterone/integration-sdk-private-test-utils": "13.5.2",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.61.11",
-    "@jupiterone/integration-sdk-entity-validator": "^13.5.2",
+    "@jupiterone/integration-sdk-entity-validator": "13.5.2",
     "@sinclair/typebox": "^0.32.30",
     "lodash": "^4.17.21"
   },

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@jupiterone/data-model": "^0.61.11",
-    "@jupiterone/integration-sdk-entity-validator": "13.5.2",
+    "@jupiterone/integration-sdk-entity-validator": "^13.6.0",
     "@sinclair/typebox": "^0.32.30",
     "lodash": "^4.17.21"
   },

--- a/packages/integration-sdk-core/src/types/jobState.ts
+++ b/packages/integration-sdk-core/src/types/jobState.ts
@@ -4,7 +4,7 @@ export interface GraphObjectFilter {
   _type: string;
 }
 
-export type GraphObjectIteratee<T> = (obj: T) => void | Promise<void>;
+export type GraphObjectIteratee<T> = (obj: Readonly<T>) => void | Promise<void>;
 export type GraphObjectIterateeOptions = {
   concurrency?: number;
 };
@@ -104,6 +104,11 @@ export interface JobState {
    * have run and therefore entities collected by those other steps should not
    * be expected to exist.
    *
+   * The graph object parameter passed to the iteratee is marked as Readonly.
+   * Once created and added to the JobState, graph objects should be considered immutable.
+   * Modifying a graph object during iteration can result in undesirable behavior
+   * since objects are upload to JupiterOne at non-regular intervals.
+   *
    * If concurrency is specified (defaults to 1), the iteratee will be executed
    * concurrently for graph objects that are found in memory and for
    * graph objects found in a given graph file. No specific ordering is guaranteed.
@@ -135,6 +140,11 @@ export interface JobState {
    * previous steps it depends on. Other steps outside the dependency ancestry
    * may not have run and therefore relationships collected by those other steps
    * should not be expected to exist.
+   *
+   * The graph object parameter passed to the iteratee is marked as Readonly.
+   * Once created and added to the JobState, graph objects should be considered immutable.
+   * Modifying a graph object during iteration can result in undesirable behavior
+   * since objects are upload to JupiterOne at non-regular intervals.
    *
    * If concurrency is specified (defaults to 1), the iteratee will be executed
    * concurrently for graph objects that are found in memory and for

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "13.5.2",
-    "@jupiterone/integration-sdk-testing": "13.5.2",
+    "@jupiterone/integration-sdk-cli": "^13.6.0",
+    "@jupiterone/integration-sdk-testing": "^13.6.0",
     "@types/jest": "^29.5.3",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6.2.1",

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^13.5.2",
-    "@jupiterone/integration-sdk-testing": "^13.5.2",
+    "@jupiterone/integration-sdk-cli": "13.5.2",
+    "@jupiterone/integration-sdk-testing": "13.5.2",
     "@types/jest": "^29.5.3",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6.2.1",

--- a/packages/integration-sdk-entities/package.json
+++ b/packages/integration-sdk-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-entities",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "Generated types for the JupiterOne data-model",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-entity-validator/package.json
+++ b/packages/integration-sdk-entity-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-entity-validator",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "Validator for JupiterOne integration entities",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -24,15 +24,15 @@
   },
   "dependencies": {
     "@jupiterone/hierarchical-token-bucket": "^0.3.1",
-    "@jupiterone/integration-sdk-core": "^13.5.2",
+    "@jupiterone/integration-sdk-core": "13.5.2",
     "@lifeomic/attempt": "^3.0.3",
     "form-data": "^4.0.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^13.5.2",
-    "@jupiterone/integration-sdk-private-test-utils": "^13.5.2",
+    "@jupiterone/integration-sdk-dev-tools": "13.5.2",
+    "@jupiterone/integration-sdk-private-test-utils": "13.5.2",
     "@types/node-fetch": "^2.6.11"
   },
   "bugs": {

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,15 +24,15 @@
   },
   "dependencies": {
     "@jupiterone/hierarchical-token-bucket": "^0.3.1",
-    "@jupiterone/integration-sdk-core": "13.5.2",
+    "@jupiterone/integration-sdk-core": "^13.6.0",
     "@lifeomic/attempt": "^3.0.3",
     "form-data": "^4.0.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "13.5.2",
-    "@jupiterone/integration-sdk-private-test-utils": "13.5.2",
+    "@jupiterone/integration-sdk-dev-tools": "^13.6.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^13.6.0",
     "@types/node-fetch": "^2.6.11"
   },
   "bugs": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^13.5.2",
+    "@jupiterone/integration-sdk-core": "13.5.2",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "13.5.2",
+    "@jupiterone/integration-sdk-core": "^13.6.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -23,7 +23,7 @@
     "prepack": "npm run build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^13.5.2",
+    "@jupiterone/integration-sdk-core": "13.5.2",
     "@lifeomic/alpha": "^5.2.0",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^13.5.2",
+    "@jupiterone/integration-sdk-private-test-utils": "13.5.2",
     "get-port": "^5.1.1",
     "lmdb": "^3.0.8",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "npm run build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "13.5.2",
+    "@jupiterone/integration-sdk-core": "^13.6.0",
     "@lifeomic/alpha": "^5.2.0",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "13.5.2",
+    "@jupiterone/integration-sdk-private-test-utils": "^13.6.0",
     "get-port": "^5.1.1",
     "lmdb": "^3.0.8",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/FileSystemGraphObjectStore.ts
@@ -25,7 +25,6 @@ import { BigMap } from '../../execution/utils/bigMap';
 import { chunk, min } from 'lodash';
 import { DEFAULT_UPLOAD_BATCH_SIZE_IN_BYTES } from '../../synchronization';
 
-export const DEFAULT_GRAPH_OBJECT_BUFFER_THRESHOLD = 500;
 export const DEFAULT_GRAPH_OBJECT_FILE_SIZE = 500;
 
 // no more than 2^30 bytes (1GB)
@@ -220,7 +219,7 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
     const iteratedEntities = new Map<string, boolean>();
     await this.localGraphObjectStore.iterateEntities(
       filter,
-      (obj: T) => {
+      (obj: Readonly<T>) => {
         iteratedEntities.set(obj._key, true);
         return iteratee(obj);
       },
@@ -230,7 +229,7 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
     await iterateEntityTypeIndex({
       type: filter._type,
       options,
-      iteratee: (obj: T) => {
+      iteratee: (obj: Readonly<T>) => {
         if (iteratedEntities.has(obj._key)) {
           return;
         }
@@ -249,15 +248,18 @@ export class FileSystemGraphObjectStore implements GraphObjectStore {
     //There is a detailed description of the changes to come to avoid having to do this
     //Here: https://jupiterone.atlassian.net/wiki/spaces/INT/pages/786169857/Task+SDK+decouple+tasks
     const iteratedRelationships = new Map<string, boolean>();
-    await this.localGraphObjectStore.iterateRelationships(filter, (obj: T) => {
-      iteratedRelationships.set(obj._key, true);
-      return iteratee(obj);
-    });
+    await this.localGraphObjectStore.iterateRelationships(
+      filter,
+      (obj: Readonly<T>) => {
+        iteratedRelationships.set(obj._key, true);
+        return iteratee(obj);
+      },
+    );
 
     await iterateRelationshipTypeIndex({
       type: filter._type,
       options,
-      iteratee: (obj: T) => {
+      iteratee: (obj: Readonly<T>) => {
         if (iteratedRelationships.has(obj._key)) {
           return;
         }

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -516,7 +516,7 @@ describe('iterateEntities', () => {
     await store.addEntities(storageDirectoryPath, newEntities);
 
     await store.iterateEntities({ _type: _type }, (entity) => {
-      // @ts-ignore
+      // @ts-expect-error Modifying graph objects during iteration MUST not be done.
       entity.immutable = false;
     });
 

--- a/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/packages/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -530,7 +530,8 @@ describe('iterateEntities', () => {
       (entity) => entity.immutable === true,
     );
 
-    // Ideally the values would actually be immutable. This could be done by using Object.freeze prior to
+    // Ideally the values would actually be immutable. This could be done by using Object.freeze
+    // after integrations have adopted the new version of the SDK.
     expect(allHaveNotBeenMutated).toBe(false);
   });
 

--- a/packages/integration-sdk-runtime/src/synchronization/index.ts
+++ b/packages/integration-sdk-runtime/src/synchronization/index.ts
@@ -290,23 +290,6 @@ export async function uploadGraphObjectData(
         uploadBatchSizeInBytes,
       );
 
-      if (
-        synchronizationJobContext.job.integrationInstanceId ===
-        'b066d99d-e0d3-4463-8133-1ec583170b7b'
-      ) {
-        const s3BucketEntity = graphObjectData.entities
-          .filter((entity) => entity._type === 'aws_s3_bucket')
-          .map((entity) => ({
-            _key: entity._key,
-            public: entity.public,
-            access: entity.access,
-          }));
-        synchronizationJobContext.logger.info(
-          { s3BucketEntity },
-          'uploaded s3BucketEntity for instance',
-        );
-      }
-
       synchronizationJobContext.logger.debug(
         {
           entities: graphObjectData.entities.length,

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -23,9 +23,9 @@
     "prepack": "npm run build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^13.5.2",
-    "@jupiterone/integration-sdk-entity-validator": "^13.5.2",
-    "@jupiterone/integration-sdk-runtime": "^13.5.2",
+    "@jupiterone/integration-sdk-core": "13.5.2",
+    "@jupiterone/integration-sdk-entity-validator": "13.5.2",
+    "@jupiterone/integration-sdk-runtime": "13.5.2",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -33,7 +33,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^13.5.2",
+    "@jupiterone/integration-sdk-private-test-utils": "13.5.2",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "13.5.2",
+  "version": "13.6.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,9 +23,9 @@
     "prepack": "npm run build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "13.5.2",
-    "@jupiterone/integration-sdk-entity-validator": "13.5.2",
-    "@jupiterone/integration-sdk-runtime": "13.5.2",
+    "@jupiterone/integration-sdk-core": "^13.6.0",
+    "@jupiterone/integration-sdk-entity-validator": "^13.6.0",
+    "@jupiterone/integration-sdk-runtime": "^13.6.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -33,7 +33,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "13.5.2",
+    "@jupiterone/integration-sdk-private-test-utils": "^13.6.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
When graph objects are iterated, mark them as Readonly.

Clean up unnecessary debugging logs.