### PR TITLE
Add deprecation warning when validating entities

### DIFF
--- a/packages/integration-sdk-entity-validator/src/j1Formats.ts
+++ b/packages/integration-sdk-entity-validator/src/j1Formats.ts
@@ -17,9 +17,29 @@ const j1JsonSchemaFormats = {
   asn: (x: string) => asnRegex.test(x),
 } satisfies Record<string, AjvFormat>;
 
+const additionalKeywords = [
+  {
+    keyword: 'deprecated',
+    validate: (value: boolean, data, parentSchema, context) => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Property "${context.parentDataProperty}" is deprecated. ${parentSchema.description}`,
+      );
+      // Dont want to fail validation, just alert the user
+      return true;
+    },
+  },
+];
+
 export const addJ1Formats = (ajvInstance: Ajv) => {
   for (const [name, format] of Object.entries(j1JsonSchemaFormats)) {
     ajvInstance.addFormat(name, format);
+  }
+
+  // Replace the deprecated keyword with our own implementation which will warn the user instead of ignoring
+  ajvInstance.removeKeyword('deprecated');
+  for (const keyword of additionalKeywords) {
+    ajvInstance.addKeyword(keyword);
   }
   return ajvInstance;
 };


### PR DESCRIPTION
When running validation, user should see something to this effect but the validation will not fail.

<img width="373" alt="Screenshot 2025-02-07 at 15 57 33" src="https://github.com/user-attachments/assets/12333fb6-32ce-4735-b3d6-1ff48d70e0d6" />
