### PR TITLE
feat(cli): aggregate step authorization into top-level config field 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/integration-sdk-*",
     "packages/cli"
   ],
-  "version": "17.3.0"
+  "version": "17.4.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20700,11 +20700,11 @@
     },
     "packages/cli": {
       "name": "@jupiterone/cli",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^17.3.0",
-        "@jupiterone/integration-sdk-runtime": "^17.3.0",
+        "@jupiterone/integration-sdk-core": "^17.4.0",
+        "@jupiterone/integration-sdk-runtime": "^17.4.0",
         "@lifeomic/attempt": "^3.0.3",
         "commander": "^5.0.0",
         "globby": "^11.0.1",
@@ -20737,11 +20737,11 @@
     },
     "packages/integration-sdk-benchmark": {
       "name": "@jupiterone/integration-sdk-benchmark",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^17.3.0",
-        "@jupiterone/integration-sdk-runtime": "^17.3.0",
+        "@jupiterone/integration-sdk-core": "^17.4.0",
+        "@jupiterone/integration-sdk-runtime": "^17.4.0",
         "benchmark": "^2.1.4"
       },
       "engines": {
@@ -20750,11 +20750,11 @@
     },
     "packages/integration-sdk-cli": {
       "name": "@jupiterone/integration-sdk-cli",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^17.3.0",
-        "@jupiterone/integration-sdk-runtime": "^17.3.0",
+        "@jupiterone/integration-sdk-core": "^17.4.0",
+        "@jupiterone/integration-sdk-runtime": "^17.4.0",
         "chalk": "^4",
         "commander": "^9.4.0",
         "ejs": "^3.1.9",
@@ -20775,7 +20775,7 @@
       },
       "devDependencies": {
         "@jupiterone/data-model": "^0.62.0",
-        "@jupiterone/integration-sdk-private-test-utils": "^17.3.0",
+        "@jupiterone/integration-sdk-private-test-utils": "^17.4.0",
         "@pollyjs/adapter-node-http": "^6.0.5",
         "@pollyjs/core": "^6.0.5",
         "@pollyjs/persister-fs": "^6.0.5",
@@ -20855,10 +20855,10 @@
     },
     "packages/integration-sdk-core": {
       "name": "@jupiterone/integration-sdk-core",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-entity-validator": "^17.3.0",
+        "@jupiterone/integration-sdk-entity-validator": "^17.4.0",
         "@sinclair/typebox": "^0.32.30",
         "lodash": "^4.17.21"
       },
@@ -20880,11 +20880,11 @@
     },
     "packages/integration-sdk-dev-tools": {
       "name": "@jupiterone/integration-sdk-dev-tools",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-cli": "^17.3.0",
-        "@jupiterone/integration-sdk-testing": "^17.3.0",
+        "@jupiterone/integration-sdk-cli": "^17.4.0",
+        "@jupiterone/integration-sdk-testing": "^17.4.0",
         "@types/jest": "^29.5.3",
         "@types/node": "^18",
         "@typescript-eslint/eslint-plugin": "^6.2.1",
@@ -20939,7 +20939,7 @@
     },
     "packages/integration-sdk-entities": {
       "name": "@jupiterone/integration-sdk-entities",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -20957,7 +20957,7 @@
     },
     "packages/integration-sdk-entity-validator": {
       "name": "@jupiterone/integration-sdk-entity-validator",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -20975,19 +20975,19 @@
     },
     "packages/integration-sdk-http-client": {
       "name": "@jupiterone/integration-sdk-http-client",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@jupiterone/hierarchical-token-bucket": "^0.3.1",
-        "@jupiterone/integration-sdk-core": "^17.3.0",
+        "@jupiterone/integration-sdk-core": "^17.4.0",
         "@lifeomic/attempt": "^3.0.3",
         "form-data": "^4.0.0",
         "lodash": "^4.17.21",
         "node-fetch": "^2.7.0"
       },
       "devDependencies": {
-        "@jupiterone/integration-sdk-dev-tools": "^17.3.0",
-        "@jupiterone/integration-sdk-private-test-utils": "^17.3.0",
+        "@jupiterone/integration-sdk-dev-tools": "^17.4.0",
+        "@jupiterone/integration-sdk-private-test-utils": "^17.4.0",
         "@types/node-fetch": "^2.6.11"
       },
       "engines": {
@@ -21014,10 +21014,10 @@
     },
     "packages/integration-sdk-private-test-utils": {
       "name": "@jupiterone/integration-sdk-private-test-utils",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^17.3.0",
+        "@jupiterone/integration-sdk-core": "^17.4.0",
         "lodash": "^4.17.15"
       },
       "devDependencies": {
@@ -21029,10 +21029,10 @@
     },
     "packages/integration-sdk-runtime": {
       "name": "@jupiterone/integration-sdk-runtime",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^17.3.0",
+        "@jupiterone/integration-sdk-core": "^17.4.0",
         "@lifeomic/alpha": "^5.2.0",
         "@lifeomic/attempt": "^3.0.3",
         "async-sema": "^3.1.0",
@@ -21049,7 +21049,7 @@
         "rimraf": "^3.0.2"
       },
       "devDependencies": {
-        "@jupiterone/integration-sdk-private-test-utils": "^17.3.0",
+        "@jupiterone/integration-sdk-private-test-utils": "^17.4.0",
         "get-port": "^5.1.1",
         "lmdb": "^3.0.8",
         "memfs": "^3.2.0",
@@ -21096,12 +21096,12 @@
     },
     "packages/integration-sdk-testing": {
       "name": "@jupiterone/integration-sdk-testing",
-      "version": "17.3.0",
+      "version": "17.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@jupiterone/integration-sdk-core": "^17.3.0",
-        "@jupiterone/integration-sdk-entity-validator": "^17.3.0",
-        "@jupiterone/integration-sdk-runtime": "^17.3.0",
+        "@jupiterone/integration-sdk-core": "^17.4.0",
+        "@jupiterone/integration-sdk-entity-validator": "^17.4.0",
+        "@jupiterone/integration-sdk-runtime": "^17.4.0",
         "@pollyjs/adapter-node-http": "^6.0.5",
         "@pollyjs/core": "^6.0.5",
         "@pollyjs/persister-fs": "^6.0.5",
@@ -21109,7 +21109,7 @@
         "lodash": "^4.17.15"
       },
       "devDependencies": {
-        "@jupiterone/integration-sdk-private-test-utils": "^17.3.0",
+        "@jupiterone/integration-sdk-private-test-utils": "^17.4.0",
         "@types/lodash": "^4.14.149",
         "get-port": "^5.1.1",
         "memfs": "^3.2.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/cli",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "The JupiterOne cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^17.3.0",
-    "@jupiterone/integration-sdk-runtime": "^17.3.0",
+    "@jupiterone/integration-sdk-core": "^17.4.0",
+    "@jupiterone/integration-sdk-runtime": "^17.4.0",
     "@lifeomic/attempt": "^3.0.3",
     "commander": "^5.0.0",
     "globby": "^11.0.1",

--- a/packages/integration-sdk-benchmark/package.json
+++ b/packages/integration-sdk-benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-benchmark",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "private": true,
   "description": "SDK benchmarking scripts",
   "main": "./src/index.js",
@@ -15,8 +15,8 @@
     "benchmark": "for file in ./src/benchmarks/*; do npm run prebenchmark && node $file; done"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^17.3.0",
-    "@jupiterone/integration-sdk-runtime": "^17.3.0",
+    "@jupiterone/integration-sdk-core": "^17.4.0",
+    "@jupiterone/integration-sdk-runtime": "^17.4.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/integration-sdk-cli/package.json
+++ b/packages/integration-sdk-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-cli",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -25,8 +25,8 @@
     "plop": "plop --plopfile dist/src/generator/newIntegration.js"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^17.3.0",
-    "@jupiterone/integration-sdk-runtime": "^17.3.0",
+    "@jupiterone/integration-sdk-core": "^17.4.0",
+    "@jupiterone/integration-sdk-runtime": "^17.4.0",
     "chalk": "^4",
     "commander": "^9.4.0",
     "ejs": "^3.1.9",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@jupiterone/data-model": "^0.62.0",
-    "@jupiterone/integration-sdk-private-test-utils": "^17.3.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^17.4.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.test.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.test.ts
@@ -190,4 +190,71 @@ describe('#generateIngestionSourcesConfig', () => {
       ingestionSourcesConfig[INGESTION_SOURCE_IDS.TEST_SOURCE],
     ).toBeUndefined();
   });
+
+  it('should aggregate authorization from all steps into a top-level field', () => {
+    const integrationSteps: IntegrationStep<IntegrationInstanceConfig>[] = [
+      {
+        id: 'fetch-account',
+        name: 'Fetch Account',
+        entities: [],
+        relationships: [],
+        dependsOn: [],
+        executionHandler: jest.fn(),
+        authorization: {
+          permissions: ['account:read'],
+          apis: ['accounts.googleapis.com'],
+        },
+      },
+      {
+        id: 'fetch-repos',
+        name: 'Fetch Repos',
+        entities: [],
+        relationships: [],
+        dependsOn: ['fetch-account'],
+        ingestionSourceId: INGESTION_SOURCE_IDS.FETCH_REPOS,
+        executionHandler: jest.fn(),
+        authorization: {
+          permissions: ['repo:read', 'account:read'],
+          apis: ['repos.googleapis.com'],
+          oauthScopes: ['repo:read'],
+        },
+      },
+      {
+        id: 'fetch-teams',
+        name: 'Fetch Teams',
+        entities: [],
+        relationships: [],
+        dependsOn: ['fetch-account'],
+        executionHandler: jest.fn(),
+      },
+    ];
+    const ingestionSourcesConfig = generateIngestionSourcesConfig(
+      ingestionConfig,
+      integrationSteps,
+    );
+    expect(ingestionSourcesConfig.authorization).toEqual({
+      permissions: ['account:read', 'repo:read'],
+      apis: ['accounts.googleapis.com', 'repos.googleapis.com'],
+      oauthScopes: ['repo:read'],
+    });
+  });
+
+  it('should not include authorization when no steps have it', () => {
+    const integrationSteps: IntegrationStep<IntegrationInstanceConfig>[] = [
+      {
+        id: 'fetch-repos',
+        name: 'Fetch Repos',
+        entities: [],
+        relationships: [],
+        dependsOn: [],
+        ingestionSourceId: INGESTION_SOURCE_IDS.FETCH_REPOS,
+        executionHandler: jest.fn(),
+      },
+    ];
+    const ingestionSourcesConfig = generateIngestionSourcesConfig(
+      ingestionConfig,
+      integrationSteps,
+    );
+    expect(ingestionSourcesConfig.authorization).toBeUndefined();
+  });
 });

--- a/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.ts
+++ b/packages/integration-sdk-cli/src/commands/generate-ingestion-sources-config.ts
@@ -3,6 +3,7 @@ import {
   IntegrationIngestionConfigFieldMap,
   IntegrationSourceId,
   Step,
+  StepAuthorization,
   StepExecutionContext,
   StepMetadata,
 } from '@jupiterone/integration-sdk-core';
@@ -70,7 +71,9 @@ export function generateIngestionSourcesConfigCommand() {
 export type EnhancedIntegrationIngestionConfigFieldMap = Record<
   IntegrationSourceId,
   IntegrationIngestionConfigField & { childIngestionSources?: StepMetadata[] }
->;
+> & {
+  authorization?: StepAuthorization;
+};
 
 /**
  * Generates an ingestionConfig with childIngestionSources taking into account
@@ -119,5 +122,47 @@ export function generateIngestionSourcesConfig<
       log.warn(`The key ${key} does not exist in the ingestionConfig`);
     }
   });
+
+  const aggregatedAuth = aggregateAuthorization(integrationSteps);
+  if (aggregatedAuth) {
+    newIngestionConfig.authorization = aggregatedAuth;
+  }
+
   return newIngestionConfig;
+}
+
+function aggregateAuthorization<
+  TStepExecutionContext extends StepExecutionContext,
+>(steps: Step<TStepExecutionContext>[]): StepAuthorization | undefined {
+  const collected: Record<keyof StepAuthorization, Set<string>> = {
+    permissions: new Set(),
+    roles: new Set(),
+    oauthScopes: new Set(),
+    apis: new Set(),
+    endpoints: new Set(),
+    licenses: new Set(),
+    documentationLinks: new Set(),
+  };
+
+  for (const step of steps) {
+    if (!step.authorization) continue;
+    for (const [key, values] of Object.entries(step.authorization)) {
+      if (Array.isArray(values)) {
+        for (const v of values) {
+          if (v) collected[key as keyof StepAuthorization].add(v);
+        }
+      }
+    }
+  }
+
+  const auth: StepAuthorization = {};
+  let hasAny = false;
+  for (const [key, set] of Object.entries(collected)) {
+    if (set.size > 0) {
+      auth[key as keyof StepAuthorization] = [...set].sort();
+      hasAny = true;
+    }
+  }
+
+  return hasAny ? auth : undefined;
 }

--- a/packages/integration-sdk-core/package.json
+++ b/packages/integration-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-core",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "npm run build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-entity-validator": "^17.3.0",
+    "@jupiterone/integration-sdk-entity-validator": "^17.4.0",
     "@sinclair/typebox": "^0.32.30",
     "lodash": "^4.17.21"
   },

--- a/packages/integration-sdk-dev-tools/package.json
+++ b/packages/integration-sdk-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-dev-tools",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "A collection of developer tools that will assist with building integrations.",
   "repository": "git@github.com:JupiterOne/sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-cli": "^17.3.0",
-    "@jupiterone/integration-sdk-testing": "^17.3.0",
+    "@jupiterone/integration-sdk-cli": "^17.4.0",
+    "@jupiterone/integration-sdk-testing": "^17.4.0",
     "@types/jest": "^29.5.3",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6.2.1",

--- a/packages/integration-sdk-entities/package.json
+++ b/packages/integration-sdk-entities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-entities",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "Generated types for the JupiterOne data-model",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-entity-validator/package.json
+++ b/packages/integration-sdk-entity-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-entity-validator",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "Validator for JupiterOne integration entities",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-sdk-http-client/package.json
+++ b/packages/integration-sdk-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-http-client",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "The HTTP client for use in JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -24,15 +24,15 @@
   },
   "dependencies": {
     "@jupiterone/hierarchical-token-bucket": "^0.3.1",
-    "@jupiterone/integration-sdk-core": "^17.3.0",
+    "@jupiterone/integration-sdk-core": "^17.4.0",
     "@lifeomic/attempt": "^3.0.3",
     "form-data": "^4.0.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^17.3.0",
-    "@jupiterone/integration-sdk-private-test-utils": "^17.3.0",
+    "@jupiterone/integration-sdk-dev-tools": "^17.4.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^17.4.0",
     "@types/node-fetch": "^2.6.11"
   },
   "bugs": {

--- a/packages/integration-sdk-private-test-utils/package.json
+++ b/packages/integration-sdk-private-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/integration-sdk-private-test-utils",
   "private": true,
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build:dist": "tsc -p tsconfig.json --declaration"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^17.3.0",
+    "@jupiterone/integration-sdk-core": "^17.4.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/integration-sdk-runtime/package.json
+++ b/packages/integration-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-runtime",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,7 +23,7 @@
     "prepack": "npm run build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^17.3.0",
+    "@jupiterone/integration-sdk-core": "^17.4.0",
     "@lifeomic/alpha": "^5.2.0",
     "@lifeomic/attempt": "^3.0.3",
     "async-sema": "^3.1.0",
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^17.3.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^17.4.0",
     "get-port": "^5.1.1",
     "lmdb": "^3.0.8",
     "memfs": "^3.2.0",

--- a/packages/integration-sdk-testing/package.json
+++ b/packages/integration-sdk-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk-testing",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "Testing utilities for JupiterOne integrations",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -23,9 +23,9 @@
     "prepack": "npm run build:dist"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^17.3.0",
-    "@jupiterone/integration-sdk-entity-validator": "^17.3.0",
-    "@jupiterone/integration-sdk-runtime": "^17.3.0",
+    "@jupiterone/integration-sdk-core": "^17.4.0",
+    "@jupiterone/integration-sdk-entity-validator": "^17.4.0",
+    "@jupiterone/integration-sdk-runtime": "^17.4.0",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",
@@ -33,7 +33,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-private-test-utils": "^17.3.0",
+    "@jupiterone/integration-sdk-private-test-utils": "^17.4.0",
     "@types/lodash": "^4.14.149",
     "get-port": "^5.1.1",
     "memfs": "^3.2.0"


### PR DESCRIPTION
Adds a top-level authorization field to the generated ingestionSourcesConfig.json that aggregates all authorization requirements from every integration step — regardless of whether the step has an ingestionSourceId or not.

Previously, authorization metadata was only available inside childIngestionSources, which excluded root steps (steps matched directly by ingestionSourceId) and steps without an ingestionSourceId (like fetch-account). This meant downstream consumers like docs-v2 could never generate complete authorization documentation.

The new field collects permissions, roles, oauthScopes, apis, endpoints, licenses, and documentationLinks from all steps, deduplicates them, and sorts them alphabetically. It is only present when at least one step declares authorization.