### PR TITLE
feat(runtime): always expose caCertificate and disableTlsVerification…

### DIFF
--- a/packages/integration-sdk-runtime/src/execution/__tests__/config.test.ts
+++ b/packages/integration-sdk-runtime/src/execution/__tests__/config.test.ts
@@ -20,6 +20,8 @@ afterEach(() => {
   delete process.env.STRING_VARIABLE;
   delete process.env.BOOLEAN_VARIABLE;
   delete process.env.STRING_ARRAY_VARIABLE;
+  delete process.env.CA_CERTIFICATE;
+  delete process.env.DISABLE_TLS_VERIFICATION;
 
   vol.reset();
 });
@@ -106,6 +108,51 @@ test('throws error if expected environment boolean field does not match "true" o
   ).toThrow(
     'Expected boolean value for field "booleanVariable" but received "mochi".',
   );
+});
+
+test('loads CA_CERTIFICATE and DISABLE_TLS_VERIFICATION even when not declared in instanceConfigFields', () => {
+  process.env.CA_CERTIFICATE =
+    '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----';
+  process.env.DISABLE_TLS_VERIFICATION = 'true';
+
+  const config = loadConfigFromEnvironmentVariables({});
+
+  expect(config).toEqual({
+    caCertificate:
+      '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----',
+    disableTlsVerification: true,
+  });
+});
+
+test('treats CA_CERTIFICATE and DISABLE_TLS_VERIFICATION as optional when env is not set', () => {
+  const instanceConfigFields: IntegrationInstanceConfigFieldMap<
+    Record<'stringVariable', IntegrationInstanceConfigField>
+  > = {
+    stringVariable: {
+      type: 'string',
+    },
+  };
+
+  const config = loadConfigFromEnvironmentVariables(instanceConfigFields);
+
+  expect(config).toEqual({
+    stringVariable: 'string',
+  });
+});
+
+test('respects integration-declared caCertificate / disableTlsVerification over implicit defaults', () => {
+  process.env.CA_CERTIFICATE = 'cert-value';
+  const instanceConfigFields: IntegrationInstanceConfigFieldMap<
+    Record<'caCertificate', IntegrationInstanceConfigField>
+  > = {
+    caCertificate: {
+      type: 'string',
+    },
+  };
+
+  const config = loadConfigFromEnvironmentVariables(instanceConfigFields);
+
+  expect(config).toEqual({ caCertificate: 'cert-value' });
 });
 
 test('loads environment variables from .env', () => {

--- a/packages/integration-sdk-runtime/src/execution/config.ts
+++ b/packages/integration-sdk-runtime/src/execution/config.ts
@@ -12,6 +12,21 @@ import {
 const dotenvExpand = require('dotenv-expand');
 
 /**
+ * Global "agent configurations" that are exposed to every integration whose
+ * `integrationPlatformFeatures.supportsAgentConfigurations` is enabled. They
+ * are intentionally NOT required to be declared in `instanceConfigFields` so
+ * that integrations can opt in without per-integration schema changes.
+ *
+ * The values are consumed by `BaseAPIClient.getDefaultAgent()` in
+ * `@jupiterone/integration-sdk-http-client` and by the equivalent helper in
+ * `@private/http-client` inside the integrations monorepo.
+ */
+const IMPLICIT_AGENT_CONFIG_FIELDS: IntegrationInstanceConfigFieldMap = {
+  caCertificate: { type: 'string', optional: true },
+  disableTlsVerification: { type: 'boolean', optional: true },
+};
+
+/**
  * Reads integration configuration from environment variables
  */
 export function loadConfigFromEnvironmentVariables<
@@ -20,7 +35,14 @@ export function loadConfigFromEnvironmentVariables<
   // pull in environment variables from .env file if available
   dotenvExpand(dotenv.config());
 
-  return Object.entries(configMap)
+  // Merge implicit agent-configuration fields without overriding any
+  // declarations the integration may have already made for the same key.
+  const mergedConfigMap = {
+    ...IMPLICIT_AGENT_CONFIG_FIELDS,
+    ...configMap,
+  } as IntegrationInstanceConfigFieldMap<TConfig>;
+
+  return Object.entries(mergedConfigMap)
     .map(([field, config]): [string, string | object | boolean | undefined] => {
       const environmentVariableName = snakeCase(field).toUpperCase();
 

--- a/packages/integration-sdk-runtime/src/execution/instance.ts
+++ b/packages/integration-sdk-runtime/src/execution/instance.ts
@@ -52,9 +52,13 @@ export function createIntegrationInstanceForLocalExecution(
       process.env.INTEGRATION_INSTANCE_ACCOUNT_ID ||
       process.env.JUPITERONE_LOCAL_INTEGRATION_INSTANCE_ACCOUNT_ID ||
       LOCAL_INTEGRATION_INSTANCE.accountId,
-    config: config.instanceConfigFields
-      ? loadConfigFromEnvironmentVariables(config.instanceConfigFields)
-      : {},
+    // Always call `loadConfigFromEnvironmentVariables` so that the implicit
+    // agent-configuration fields (caCertificate / disableTlsVerification) are
+    // picked up from the environment even when an integration does not declare
+    // any `instanceConfigFields` of its own.
+    config: loadConfigFromEnvironmentVariables(
+      config.instanceConfigFields ?? {},
+    ),
     disabledSources: parseDisabledIngestionSourcesFromEnv(),
   };
 }


### PR DESCRIPTION
… from env

These two fields back the platform-wide "agent configurations" feature (IntegrationPlatformFeatures.supportsAgentConfigurations) and are set by the customer through the global UI form, not declared per-integration. loadConfigFromEnvironmentVariables previously only iterated entries in the integration's instanceConfigFields, so any integration that did not re-declare these fields received undefined for both at runtime — even though the platform had written CA_CERTIFICATE / DISABLE_TLS_VERIFICATION into the environment.

Merge them in as implicit optional fields. Integration-declared entries for the same keys still win, and createIntegrationInstanceForLocalExecution now always runs the loader (with an empty map if no instanceConfigFields were supplied) so the implicit fields surface even for integrations that do not declare a config schema of their own.